### PR TITLE
ci: add conventional commits check for pull requests

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validates that all commits in a pull request follow the Conventional Commits specification.
+# https://www.conventionalcommits.org/
+
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: ['**']
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-commits:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for cocogitto to access full commit history
+          ref: ${{ github.event.pull_request.head.sha }}  # Check PR HEAD, not merge commit
+
+      - name: Check conventional commits
+        uses: cocogitto/cocogitto-action@9a9fe03b31c47444290c0d7f9b1ee1b44ee13f20
+        with:
+          command: check


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce commit message standards for all pull requests. The workflow ensures that all commits follow the Conventional Commits specification, helping maintain consistency and clarity in commit history.

**CI/CD and commit standards:**

* Added a `.github/workflows/commit-lint.yml` workflow that uses the `cocogitto/cocogitto-action` to check that all commits in a pull request conform to the Conventional Commits specification.
* Included SPDX copyright and license headers at the top of the workflow file for compliance and clarity.