### PR TITLE
ci(bazel): Cache external dependencies

### DIFF
--- a/.github/actions/setup-bazel/action.yml
+++ b/.github/actions/setup-bazel/action.yml
@@ -69,6 +69,9 @@ runs:
           - MODULE.bazel
           - 3rdparty/python/requirements_3_8.txt
           - 3rdparty/python/requirements_3_11.txt
+        # Cache external dependencies 
+        # (particularly important for Python dependencies which can be large and slow to install)
+        external-cache: true
         # Don't pollute cache from PRs
         cache-save: ${{ github.event_name != 'pull_request' }}
         # Add custom bazelrc options: color / timestamps / no GPU for CI builds


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change enables caching of external dependencies, which is especially helpful for speeding up Python dependency installation during CI runs.

* GitHub Actions workflow: Enabled `external-cache` to cache external dependencies, improving CI performance for Python requirements.