### PR TITLE
build(proto): Update to latest rules_proto

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ bazel_dep(name = "rules_multirun", version = "0.13.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "protobuf", version = "29.1")
+bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 
 ## rules_python
@@ -88,7 +88,7 @@ http_archive(
 
 # Waymo Open Dataset (http_archive for proto definitions)
 http_archive(
-    name = "waymo-open-dataset",
+    name = "waymo_open_dataset",
     patch_strip = 2,
     patches = ["//deps/waymo-open-dataset:cc-proto.patch"],
     sha256 = "5e91fea02a0cdb1edb39d9ac27fbdb1e8d890986faab545497a95b54213b973d",

--- a/deps/waymo-open-dataset/cc-proto.patch
+++ b/deps/waymo-open-dataset/cc-proto.patch
@@ -1,22 +1,43 @@
 diff --git i/src/waymo_open_dataset/protos/defs.bzl w/src/waymo_open_dataset/protos/defs.bzl
-index 2ddaf42..28f5dfc 100644
+index 2ddaf42..3fbf9ad 100644
 --- i/src/waymo_open_dataset/protos/defs.bzl
 +++ w/src/waymo_open_dataset/protos/defs.bzl
-@@ -1,11 +1,10 @@
- """Build rule to build cc and py protos."""
-
+@@ -1,11 +1,15 @@
+-"""Build rule to build cc and py protos."""
++"""Build rule to build py protos."""
+ 
 -load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library", "py_proto_library")
-+load("@protobuf//:protobuf.bzl", "py_proto_library")
-
++load("@rules_proto//proto:defs.bzl", "proto_library")
++load("@rules_python//python:proto.bzl", _py_proto_library = "py_proto_library")
++
++# Re-define py_proto_library to avoid deprecation warning from rules_proto
++def py_proto_library(**kwargs):
++    _py_proto_library(deprecation = None, **kwargs)
+ 
  _SUFFIXES = {
      "proto": "_proto",
      "py": "_proto_py_pb2",
 -    "cc": "_cc_proto",
  }
-
+ 
  def _target_name(lang, base_name):
-@@ -31,4 +30,3 @@ def all_proto_library(src, deps = None):
+@@ -21,14 +24,15 @@ def _deps(lang, deps):
+     return [_target_name(lang, _get_basename(d)) for d in deps]
+ 
+ def all_proto_library(src, deps = None):
+-    """Adds build rulles to build python and c++ proto libraries.
++    """Adds build rules to build python proto libraries.
+ 
+     Args:
+       src: proto file.
+-      deps: optional list with proto dependensies.
++      deps: optional list with proto dependencies.
+     """
+     if deps == None:
          deps = []
      base_name = src[:-len(".proto")]
-     py_proto_library(name = _target_name("py", base_name), srcs = [src], deps = _deps("py", deps))
+-    py_proto_library(name = _target_name("py", base_name), srcs = [src], deps = _deps("py", deps))
 -    cc_proto_library(name = _target_name("cc", base_name), srcs = [src], deps = _deps("cc", deps))
++    proto_name = _target_name("proto", base_name)
++    proto_library(name = proto_name, srcs = [src], deps = _deps("proto", deps))
++    py_proto_library(name = _target_name("py", base_name), deps = [":" + proto_name])

--- a/tools/data_converter/waymo/BUILD.bazel
+++ b/tools/data_converter/waymo/BUILD.bazel
@@ -23,9 +23,9 @@ py_library(
     tags = ["no-mypy"],  # syntax errors in type annotations of tensorflow / absl-py
     deps = [
         requirement("tensorflow"),
-        "@waymo-open-dataset//waymo_open_dataset:dataset_proto_py_pb2",
-        "@waymo-open-dataset//waymo_open_dataset:label_proto_py_pb2",
-        "@waymo-open-dataset//waymo_open_dataset/protos:camera_segmentation_proto_py_pb2",
+        "@waymo_open_dataset//waymo_open_dataset:dataset_proto_py_pb2",
+        "@waymo_open_dataset//waymo_open_dataset:label_proto_py_pb2",
+        "@waymo_open_dataset//waymo_open_dataset/protos:camera_segmentation_proto_py_pb2",
     ],
 )
 


### PR DESCRIPTION
This pull request updates Bazel dependencies and build rules to switch from using `protobuf` to `rules_proto`, addressing deprecation warnings and improving proto library handling. It also updates the Waymo Open Dataset dependency naming and patches to align with these changes. The most important changes are grouped below:

Dependency and build rule updates:

* Replaced the `protobuf` Bazel dependency with `rules_proto` in `MODULE.bazel`, updating the proto library management approach.
* Updated the Waymo Open Dataset proto build patch in `cc-proto.patch` to use `rules_proto` and redefined `py_proto_library` to avoid deprecation warnings, removing `cc_proto_library` and switching to `proto_library` for proto builds. [[1]](diffhunk://#diff-1b4a7b6d35c08b1a2a0e627ffce8562673e431c49403fcd71e85ab38ecce6187L2-R15) [[2]](diffhunk://#diff-1b4a7b6d35c08b1a2a0e627ffce8562673e431c49403fcd71e85ab38ecce6187L18-R43)

Waymo Open Dataset integration:

* Changed the Bazel dependency name for Waymo Open Dataset from `waymo-open-dataset` to `waymo_open_dataset` in `MODULE.bazel` and updated references in `BUILD.bazel` to match the new naming convention. [[1]](diffhunk://#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdcL91-R91) [[2]](diffhunk://#diff-7d588d5242d1b1f44eac1721eeee0385ea416d3a5520d97ff96dd2d3f40e4201L26-R28)