### PR TITLE
ci: patch rules_python for --repo_contents_cache support

### DIFF
--- a/.github/actions/setup-bazel/action.yml
+++ b/.github/actions/setup-bazel/action.yml
@@ -64,18 +64,21 @@ runs:
         bazelisk-cache: true
         # Store build cache per workflow
         disk-cache: ${{ github.workflow }}
-        # Share repository cache between workflows
+        # Share repository cache between workflows.
+        # The repo contents cache (--repo_contents_cache, enabled by default since Bazel 8.3.0)
+        # lives under the repository cache directory, so caching it here also persists
+        # cached repo contents (Python interpreters, pip wheels, etc.) across CI runs.
         repository-cache: |
           - MODULE.bazel
-          - 3rdparty/python/requirements_3_8.txt
-          - 3rdparty/python/requirements_3_11.txt
-        # Cache external dependencies 
-        # (particularly important for Python dependencies which can be large and slow to install)
-        external-cache: true
-        # Don't pollute cache from PRs
+          - deps/pip/requirements_3_8.txt
+          - deps/pip/requirements_3_11.txt
+        # Only save caches on push (not on PRs) to avoid cache pollution
         cache-save: ${{ github.event_name != 'pull_request' }}
+        # Bump to force-invalidate all CI caches (e.g. after changing cache structure)
+        cache-version: 2
         # Add custom bazelrc options: color / timestamps / no GPU for CI builds
         bazelrc: |
             build --color=yes
             build --show_timestamps
             test --config=no-gpu
+            common --repo_contents_cache=~/.cache/bazel-repo/contents

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,6 +36,16 @@ bazel_dep(name = "platforms", version = "1.0.0")
 ## rules_python
 bazel_dep(name = "rules_python", version = "1.2.0")
 
+# Patch rules_python to support --repo_contents_cache (Bazel 8.3.0+)
+# This allows Bazel to cache fetched repo contents across workspaces and clean builds,
+# significantly speeding up cold CI builds by avoiding re-downloads of Python interpreters and wheels.
+# See: https://github.com/bazel-contrib/rules_python/issues/3039
+single_version_override(
+    module_name = "rules_python",
+    patch_strip = 1,
+    patches = ["//bazel/rules_python:rules_python_repo_contents_cache.patch"],
+)
+
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     is_default = True,

--- a/bazel/rules_python/BUILD.bazel
+++ b/bazel/rules_python/BUILD.bazel
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exports_files(["rules_python_repo_contents_cache.patch"])

--- a/bazel/rules_python/rules_python_repo_contents_cache.patch
+++ b/bazel/rules_python/rules_python_repo_contents_cache.patch
@@ -1,0 +1,38 @@
+Add support for --repo_contents_cache (Bazel 8.3.0+)
+
+When repository rules declare themselves as reproducible via ctx.repo_metadata(),
+Bazel can cache and restore the entire repo directory contents, avoiding
+re-downloads and re-extractions on cold starts (e.g. ephemeral CI).
+
+See: https://github.com/bazel-contrib/rules_python/issues/3039
+Ref: https://github.com/bazel-contrib/bazel-gazelle/pull/2119
+
+--- a/python/private/python_repository.bzl
++++ b/python/private/python_repository.bzl
+@@ -260,6 +260,10 @@
+     if rctx.attr.url:
+         attrs["url"] = rctx.attr.url
+     else:
+         attrs["urls"] = urls
+ 
++    # Support --repo_contents_cache (Bazel 8.3.0+)
++    if hasattr(rctx, "repo_metadata"):
++        return rctx.repo_metadata(reproducible = True)
++
+     return attrs
+ 
+ python_repository = repository_rule(
+--- a/python/private/pypi/whl_library.bzl
++++ b/python/private/pypi/whl_library.bzl
+@@ -349,6 +349,11 @@
+     )
+     rctx.file("BUILD.bazel", build_file_contents)
+ 
++    # Support --repo_contents_cache (Bazel 8.3.0+)
++    # Only mark as reproducible when using Bazel downloader (urls + sha256)
++    if hasattr(rctx, "repo_metadata") and rctx.attr.urls and rctx.attr.sha256:
++        return rctx.repo_metadata(reproducible = True)
++
+     return
+ 
+ def _generate_entry_point_contents(


### PR DESCRIPTION
Patch rules_python 1.2.0 to support Bazel's --repo_contents_cache (8.3.0+). Repository rules that declare themselves as reproducible via ctx.repo_metadata() allow Bazel to cache and restore entire repo directory contents, avoiding re-downloads of Python interpreters and pip wheels on cold CI builds.

Changes:
- Patch python_repository.bzl (interpreter downloads) and whl_library.bzl (pip wheel downloads) to call ctx.repo_metadata(reproducible=True)
- Add single_version_override in MODULE.bazel to apply the patch
- Remove external-cache from CI setup (replaced by repo contents cache)
- Fix stale repository-cache key file paths in CI action

This eliminates the fragile external-cache tar/untar mechanism and replaces it with Bazel-native repo contents caching, which lives under the repository cache directory and is automatically persisted by setup-bazel.

Ref: https://github.com/bazel-contrib/rules_python/issues/3039