### PR TITLE
refactor(waymo-converter): separate Waymo-derived and NVIDIA-original code

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -100,7 +100,10 @@ http_archive(
 http_archive(
     name = "waymo_open_dataset",
     patch_strip = 2,
-    patches = ["//deps/waymo-open-dataset:cc-proto.patch"],
+    patches = [
+        "//deps/waymo-open-dataset:cc-proto.patch",
+        "//deps/waymo-open-dataset:py-utils.patch",
+    ],
     sha256 = "5e91fea02a0cdb1edb39d9ac27fbdb1e8d890986faab545497a95b54213b973d",
     strip_prefix = "waymo-open-dataset-1.5.1/src",
     urls = ["https://github.com/waymo-research/waymo-open-dataset/archive/refs/tags/v1.5.1.tar.gz"],

--- a/deps/waymo-open-dataset/py-utils.patch
+++ b/deps/waymo-open-dataset/py-utils.patch
@@ -1,0 +1,7 @@
+diff --git i/src/waymo_open_dataset/utils/BUILD w/src/waymo_open_dataset/utils/BUILD
+index 1234567..abcdefg 100644
+--- i/src/waymo_open_dataset/utils/BUILD
++++ w/src/waymo_open_dataset/utils/BUILD
+@@ -1 +1 @@
+-load("@wod_deps//:requirements.bzl", "requirement")
++load("@ncore_pip_deps//:requirements.bzl", "requirement")

--- a/tools/data_converter/waymo/BUILD.bazel
+++ b/tools/data_converter/waymo/BUILD.bazel
@@ -26,15 +26,39 @@ py_library(
         "@waymo_open_dataset//waymo_open_dataset:dataset_proto_py_pb2",
         "@waymo_open_dataset//waymo_open_dataset:label_proto_py_pb2",
         "@waymo_open_dataset//waymo_open_dataset/protos:camera_segmentation_proto_py_pb2",
+        "@waymo_open_dataset//waymo_open_dataset/utils:range_image_utils",
+        "@waymo_open_dataset//waymo_open_dataset/utils:transform_utils",
     ],
 )
 
-# Utilities for parsing Waymo range images
+# Fast-path protobuf parser for Waymo MatrixFloat / MatrixInt32 protos (NVIDIA-original)
+py_library(
+    name = "pylib_proto_utils",
+    srcs = ["proto_utils.py"],
+    deps = [
+        requirement("numpy"),
+    ],
+)
+
+# Modified Waymo range image utilities (Waymo Apache-2.0 + NVIDIA modifications)
+py_library(
+    name = "pylib_waymo_range_image_utils",
+    srcs = ["waymo_range_image_utils.py"],
+    deps = [
+        ":pylib_deps",
+        ":pylib_proto_utils",
+        requirement("numpy"),
+    ],
+)
+
+# NCore-specific utilities: pose extrapolation, batched point cloud conversion (NVIDIA-original)
 py_library(
     name = "pylib_utils",
     srcs = ["utils.py"],
     deps = [
         ":pylib_deps",
+        ":pylib_proto_utils",
+        ":pylib_waymo_range_image_utils",
         requirement("numpy"),
         requirement("scipy"),
     ],
@@ -48,6 +72,7 @@ py_binary(
     deps = [
         ":pylib_deps",
         ":pylib_utils",
+        ":pylib_waymo_range_image_utils",
         requirement("click"),
         requirement("numpy"),
         requirement("tqdm"),

--- a/tools/data_converter/waymo/NOTICE
+++ b/tools/data_converter/waymo/NOTICE
@@ -9,9 +9,15 @@ This package includes software developed by
 
 Waymo Open Dataset (<https://github.com/waymo-research/waymo-open-dataset>)
 
-in `utils.py`.
+- `waymo_range_image_utils.py` contains functions modified from the Waymo Open
+  Dataset v1.5.1 sources (`range_image_utils.py`, `transform_utils.py`, and
+  `frame_utils.py`). Verbatim (unmodified) utility functions are imported
+  directly from the upstream `waymo_open_dataset` package at runtime rather
+  than being duplicated.
+- `proto_utils.py` and `utils.py` are original NVIDIA code and do **not**
+  contain Waymo-derived code.
 
-Original source licensed under the Apache License, Version 2.0.
+Original Waymo source licensed under the Apache License, Version 2.0.
 
 ## waymo-open-dataset - [Apache-2.0](https://github.com/waymo-research/waymo-open-dataset/blob/master/src/waymo_open_dataset/LICENSE)
 

--- a/tools/data_converter/waymo/converter.py
+++ b/tools/data_converter/waymo/converter.py
@@ -66,8 +66,8 @@ from tools.data_converter.waymo.deps import camera_segmentation_pb2, dataset_pb2
 from tools.data_converter.waymo.utils import (
     convert_range_images_to_point_clouds,
     extrapolate_pose_based_on_velocity,
-    parse_range_image_and_segmentations,
 )
+from tools.data_converter.waymo.waymo_range_image_utils import parse_range_image_and_segmentations
 
 
 @dataclass(kw_only=True, slots=True)

--- a/tools/data_converter/waymo/converter.py
+++ b/tools/data_converter/waymo/converter.py
@@ -21,7 +21,7 @@ import json
 import logging
 
 from dataclasses import asdict, dataclass
-from typing import Dict, List, Literal, Optional
+from typing import Literal
 
 import click
 import numpy as np
@@ -229,7 +229,7 @@ class WaymoConverter4(BaseDataConverter):
         """Decode and interpolate vehicle poses from frame data."""
         # Grab poses from images, as for images the pose/timestamps correspond to each other
         T_rig_worlds_array = []
-        T_rig_world_timestamps_us_array: List[int] = []
+        T_rig_world_timestamps_us_array: list[int] = []
 
         # Buffers holding extrapolated poses to cover all frame start/end timestamps fully
         T_rig_worlds_array_extrapolated = []
@@ -427,9 +427,9 @@ class WaymoConverter4(BaseDataConverter):
             )
 
             # Variables associated with intrinsics
-            lidar_model: Optional[RowOffsetStructuredSpinningLidarModel] = None
-            lidar_model_parameters: Optional[RowOffsetStructuredSpinningLidarModelParameters] = None
-            lidar_horizontal_fov: Optional[FOV] = None
+            lidar_model: RowOffsetStructuredSpinningLidarModel | None = None
+            lidar_model_parameters: RowOffsetStructuredSpinningLidarModelParameters | None = None
+            lidar_horizontal_fov: FOV | None = None
 
             # Create lidar sensor writer
             lidar_writer = self.store_writer.register_component_writer(
@@ -727,7 +727,7 @@ class WaymoConverter4(BaseDataConverter):
         self.logger.info(f"Stored {len(cuboid_track_observations)} cuboid observations")
 
     # Semantic classes labels for camera segmentation
-    CAMERA_LABEL_CLASS_ID_STRING_MAP: Dict[int, str] = {
+    CAMERA_LABEL_CLASS_ID_STRING_MAP: dict[int, str] = {
         camera_segmentation_pb2.CameraSegmentation.Type.TYPE_UNDEFINED: "UNDEFINED",
         # The Waymo vehicle.
         camera_segmentation_pb2.CameraSegmentation.Type.TYPE_EGO_VEHICLE: "EGO_VEHICLE",
@@ -845,8 +845,8 @@ class WaymoConverter4(BaseDataConverter):
                 )
 
                 # Parse panoptic segmentation, if available
-                generic_data: Dict[str, np.ndarray] = {}
-                generic_meta_data: Dict[str, JsonLike] = {}
+                generic_data: dict[str, np.ndarray] = {}
+                generic_meta_data: dict[str, JsonLike] = {}
 
                 if (
                     hasattr(image, "camera_segmentation_label")

--- a/tools/data_converter/waymo/converter.py
+++ b/tools/data_converter/waymo/converter.py
@@ -461,7 +461,7 @@ class WaymoConverter4(BaseDataConverter):
                 timestamps_us = np.array([frame_start_timestamp_us, frame_end_timestamp_us], dtype=np.uint64)
 
                 # Extract the range image and corresponding poses for all rays
-                range_image, segmentation, range_image_top_pose = parse_range_image_and_segmentations(
+                range_image, segmentation_ri, range_image_top_pose = parse_range_image_and_segmentations(
                     frame, lidar_id, ri_index=0
                 )
 
@@ -473,9 +473,14 @@ class WaymoConverter4(BaseDataConverter):
                 pc_first, pc_second = convert_range_images_to_point_clouds(
                     frame,
                     lidar_id,
-                    [range_image, range_image_second],
-                    segmentation,
-                    range_image_top_pose,
+                    [
+                        unpack_optional(range_image, msg=f"Missing range image for laser {lidar_id}"),
+                        unpack_optional(
+                            range_image_second, msg=f"Missing second-return range image for laser {lidar_id}"
+                        ),
+                    ],
+                    segmentation_ri,
+                    unpack_optional(range_image_top_pose, msg=f"Missing top-lidar pose for laser {lidar_id}"),
                     timestamps_us,
                 )
                 points_world = pc_first.points

--- a/tools/data_converter/waymo/deps.py
+++ b/tools/data_converter/waymo/deps.py
@@ -33,6 +33,8 @@ import tensorflow.compat.v1 as tf
 
 from waymo_open_dataset import dataset_pb2, label_pb2
 from waymo_open_dataset.protos import camera_segmentation_pb2
+from waymo_open_dataset.utils import range_image_utils as waymo_range_image_utils
+from waymo_open_dataset.utils import transform_utils as waymo_transform_utils
 
 
 # Pop modified paths back to original

--- a/tools/data_converter/waymo/proto_utils.py
+++ b/tools/data_converter/waymo/proto_utils.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fast-path protobuf parser for Waymo MatrixFloat / MatrixInt32 protos.
+
+This module provides a direct wire-format parser that avoids the slow Python
+protobuf repeated-field construction that dominates the cost of ParseFromString
+for large matrices (~1M+ elements).
+"""
+
+import zlib
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+
+def _decode_varint(buf: bytes, pos: int) -> tuple[int, int]:
+    """Decode a protobuf varint starting at `pos`, returning (value, new_pos)."""
+    result = 0
+    shift = 0
+    while True:
+        b = buf[pos]
+        pos += 1
+        result |= (b & 0x7F) << shift
+        if (b & 0x80) == 0:
+            return result, pos
+        shift += 7
+
+
+@dataclass
+class ParsedMatrix:
+    """Lightweight container holding the result of fast-path protobuf matrix parsing."""
+
+    data: np.ndarray
+    dims: list[int]
+
+
+def _decode_zigzag(n: int) -> int:
+    """Decode a ZigZag-encoded signed integer (used by protobuf sint32/sint64)."""
+    return (n >> 1) ^ -(n & 1)
+
+
+def _parse_packed_varints_int32(buf: bytes, start: int, end: int) -> list[int]:
+    """Decode a sequence of packed varint-encoded int32 values.
+
+    Protobuf encodes negative int32 as 10-byte sign-extended 64-bit varints,
+    so we must mask to 32 bits and reinterpret as signed.
+    """
+    values: list[int] = []
+    pos = start
+    while pos < end:
+        val, pos = _decode_varint(buf, pos)
+        val = val & 0xFFFFFFFF
+        if val > 0x7FFFFFFF:
+            val -= 0x100000000
+        values.append(val)
+    return values
+
+
+def parse_matrix_proto(raw_compressed: bytes, dtype: type) -> ParsedMatrix:
+    """Fast-path parser for Waymo's MatrixFloat / MatrixInt32 protos.
+
+    Parses the protobuf wire format directly to locate the packed data field
+    and extracts it via np.frombuffer (for floats) or varint decoding (for int32),
+    avoiding the slow Python protobuf repeated-field construction that dominates
+    the cost of ParseFromString for large matrices (~1M+ elements).
+
+    Wire layout (from waymo_open_dataset/dataset.proto):
+      MatrixFloat { repeated float data = 1 [packed=true]; optional MatrixShape shape = 2; }
+      MatrixInt32 { repeated int32 data = 1 [packed=true]; optional MatrixShape shape = 2; }
+      MatrixShape { repeated int32 dims = 1; }
+
+    Note: packed float fields are raw IEEE 754 bytes (4 bytes each), while packed
+    int32 fields use varint encoding (variable-length per element).
+    """
+    buf = zlib.decompress(raw_compressed)
+    pos = 0
+    end = len(buf)
+    data_start: Optional[int] = None
+    data_end: Optional[int] = None
+    dims: list[int] = []
+    is_float = dtype == np.float32 or dtype == np.float64
+
+    while pos < end:
+        tag, pos = _decode_varint(buf, pos)
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+
+        if wire_type == 2:  # length-delimited
+            length, pos = _decode_varint(buf, pos)
+            if field_number == 1:  # data (packed floats or varints)
+                data_start = pos
+                data_end = pos + length
+            elif field_number == 2:  # shape sub-message
+                sub_end = pos + length
+                while pos < sub_end:
+                    sub_tag, pos = _decode_varint(buf, pos)
+                    sub_field = sub_tag >> 3
+                    sub_wire = sub_tag & 0x07
+                    if sub_field == 1 and sub_wire == 0:
+                        val, pos = _decode_varint(buf, pos)
+                        dims.append(val)
+                    elif sub_field == 1 and sub_wire == 2:
+                        sub_len, pos = _decode_varint(buf, pos)
+                        sub_data_end = pos + sub_len
+                        while pos < sub_data_end:
+                            val, pos = _decode_varint(buf, pos)
+                            dims.append(val)
+                    else:
+                        if sub_wire == 0:
+                            _, pos = _decode_varint(buf, pos)
+                        elif sub_wire == 2:
+                            sl, pos = _decode_varint(buf, pos)
+                            pos += sl
+                        else:
+                            raise ValueError(f"Unexpected sub wire type {sub_wire}")
+                continue  # pos already advanced past sub-message
+            pos += length
+        elif wire_type == 0:  # varint
+            _, pos = _decode_varint(buf, pos)
+        elif wire_type == 5:  # 32-bit
+            pos += 4
+        elif wire_type == 1:  # 64-bit
+            pos += 8
+        else:
+            raise ValueError(f"Unexpected wire type {wire_type}")
+
+    if data_start is None or data_end is None:
+        return ParsedMatrix(data=np.empty(0, dtype=dtype), dims=dims)
+
+    data: np.ndarray
+    if is_float:
+        data = np.frombuffer(memoryview(buf)[data_start:data_end], dtype=dtype)
+    else:
+        data = np.array(_parse_packed_varints_int32(buf, data_start, data_end), dtype=dtype)
+
+    return ParsedMatrix(data=data, dims=dims)

--- a/tools/data_converter/waymo/proto_utils.py
+++ b/tools/data_converter/waymo/proto_utils.py
@@ -20,10 +20,11 @@ protobuf repeated-field construction that dominates the cost of ParseFromString
 for large matrices (~1M+ elements).
 """
 
+from __future__ import annotations
+
 import zlib
 
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 
@@ -90,8 +91,8 @@ def parse_matrix_proto(raw_compressed: bytes, dtype: type) -> ParsedMatrix:
     buf = zlib.decompress(raw_compressed)
     pos = 0
     end = len(buf)
-    data_start: Optional[int] = None
-    data_end: Optional[int] = None
+    data_start: int | None = None
+    data_end: int | None = None
     dims: list[int] = []
     is_float = dtype == np.float32 or dtype == np.float64
 

--- a/tools/data_converter/waymo/utils.py
+++ b/tools/data_converter/waymo/utils.py
@@ -24,7 +24,7 @@ This module contains original NVIDIA code for:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 
@@ -87,7 +87,7 @@ class _PointCloudReturn:
     """Result of converting a single range image return to a point cloud."""
 
     points: np.ndarray
-    segmentation: Optional[np.ndarray]
+    segmentation: np.ndarray | None
     timestamps: np.ndarray
     range_image_indices: np.ndarray
     inclinations: np.ndarray
@@ -98,7 +98,7 @@ def convert_range_images_to_point_clouds(
     frame: Any,
     laser_name: str,
     range_images: list[ParsedMatrix],
-    segmentation: Optional[ParsedMatrix],
+    segmentation: ParsedMatrix | None,
     range_image_top_pose: ParsedMatrix,
     start_end_timestamps: np.ndarray,
 ) -> list[_PointCloudReturn]:

--- a/tools/data_converter/waymo/utils.py
+++ b/tools/data_converter/waymo/utils.py
@@ -21,8 +21,10 @@ This module contains original NVIDIA code for:
     and azimuths
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 
@@ -93,12 +95,12 @@ class _PointCloudReturn:
 
 
 def convert_range_images_to_point_clouds(
-    frame,
+    frame: Any,
     laser_name: str,
     range_images: list[ParsedMatrix],
     segmentation: Optional[ParsedMatrix],
     range_image_top_pose: ParsedMatrix,
-    start_end_timestamps,
+    start_end_timestamps: np.ndarray,
 ) -> list[_PointCloudReturn]:
     """Convert one or more range image returns to point clouds in a single batched pass.
 

--- a/tools/data_converter/waymo/utils.py
+++ b/tools/data_converter/waymo/utils.py
@@ -1,4 +1,5 @@
-# Copyright 2019 The Waymo Open Dataset Authors.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,12 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# ========================================================================
-#
-# Modifications Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import zlib
+"""NCore-specific utilities for Waymo data conversion.
+
+This module contains original NVIDIA code for:
+  - Pose extrapolation from velocity
+  - Batched multi-return point cloud conversion with timestamps, inclinations,
+    and azimuths
+"""
 
 from dataclasses import dataclass
 from typing import Optional
@@ -26,135 +29,29 @@ import numpy as np
 from scipy.linalg import expm
 
 from tools.data_converter.waymo.deps import dataset_pb2, tf
+from tools.data_converter.waymo.proto_utils import ParsedMatrix
+from tools.data_converter.waymo.waymo_range_image_utils import (
+    compute_inclination,
+    extract_point_cloud_from_range_image,
+    get_rotation_matrix,
+    get_transform,
+)
 
 
-def _decode_varint(buf: bytes, pos: int) -> tuple[int, int]:
-    """Decode a protobuf varint starting at `pos`, returning (value, new_pos)."""
-    result = 0
-    shift = 0
-    while True:
-        b = buf[pos]
-        pos += 1
-        result |= (b & 0x7F) << shift
-        if (b & 0x80) == 0:
-            return result, pos
-        shift += 7
-
-
-@dataclass
-class _ParsedMatrix:
-    """Lightweight container holding the result of fast-path protobuf matrix parsing."""
-
-    data: np.ndarray
-    dims: list[int]
-
-
-def _decode_zigzag(n: int) -> int:
-    """Decode a ZigZag-encoded signed integer (used by protobuf sint32/sint64)."""
-    return (n >> 1) ^ -(n & 1)
-
-
-def _parse_packed_varints_int32(buf: bytes, start: int, end: int) -> list[int]:
-    """Decode a sequence of packed varint-encoded int32 values.
-
-    Protobuf encodes negative int32 as 10-byte sign-extended 64-bit varints,
-    so we must mask to 32 bits and reinterpret as signed.
-    """
-    values: list[int] = []
-    pos = start
-    while pos < end:
-        val, pos = _decode_varint(buf, pos)
-        val = val & 0xFFFFFFFF
-        if val > 0x7FFFFFFF:
-            val -= 0x100000000
-        values.append(val)
-    return values
-
-
-def _parse_matrix_proto(raw_compressed: bytes, dtype: type) -> _ParsedMatrix:
-    """Fast-path parser for Waymo's MatrixFloat / MatrixInt32 protos.
-
-    Parses the protobuf wire format directly to locate the packed data field
-    and extracts it via np.frombuffer (for floats) or varint decoding (for int32),
-    avoiding the slow Python protobuf repeated-field construction that dominates
-    the cost of ParseFromString for large matrices (~1M+ elements).
-
-    Wire layout (from waymo_open_dataset/dataset.proto):
-      MatrixFloat { repeated float data = 1 [packed=true]; optional MatrixShape shape = 2; }
-      MatrixInt32 { repeated int32 data = 1 [packed=true]; optional MatrixShape shape = 2; }
-      MatrixShape { repeated int32 dims = 1; }
-
-    Note: packed float fields are raw IEEE 754 bytes (4 bytes each), while packed
-    int32 fields use varint encoding (variable-length per element).
-    """
-    buf = zlib.decompress(raw_compressed)
-    pos = 0
-    end = len(buf)
-    data_start: Optional[int] = None
-    data_end: Optional[int] = None
-    dims: list[int] = []
-    is_float = dtype == np.float32 or dtype == np.float64
-
-    while pos < end:
-        tag, pos = _decode_varint(buf, pos)
-        field_number = tag >> 3
-        wire_type = tag & 0x07
-
-        if wire_type == 2:  # length-delimited
-            length, pos = _decode_varint(buf, pos)
-            if field_number == 1:  # data (packed floats or varints)
-                data_start = pos
-                data_end = pos + length
-            elif field_number == 2:  # shape sub-message
-                sub_end = pos + length
-                while pos < sub_end:
-                    sub_tag, pos = _decode_varint(buf, pos)
-                    sub_field = sub_tag >> 3
-                    sub_wire = sub_tag & 0x07
-                    if sub_field == 1 and sub_wire == 0:
-                        val, pos = _decode_varint(buf, pos)
-                        dims.append(val)
-                    elif sub_field == 1 and sub_wire == 2:
-                        sub_len, pos = _decode_varint(buf, pos)
-                        sub_data_end = pos + sub_len
-                        while pos < sub_data_end:
-                            val, pos = _decode_varint(buf, pos)
-                            dims.append(val)
-                    else:
-                        if sub_wire == 0:
-                            _, pos = _decode_varint(buf, pos)
-                        elif sub_wire == 2:
-                            sl, pos = _decode_varint(buf, pos)
-                            pos += sl
-                        else:
-                            raise ValueError(f"Unexpected sub wire type {sub_wire}")
-                continue  # pos already advanced past sub-message
-            pos += length
-        elif wire_type == 0:  # varint
-            _, pos = _decode_varint(buf, pos)
-        elif wire_type == 5:  # 32-bit
-            pos += 4
-        elif wire_type == 1:  # 64-bit
-            pos += 8
-        else:
-            raise ValueError(f"Unexpected wire type {wire_type}")
-
-    if data_start is None or data_end is None:
-        return _ParsedMatrix(data=np.empty(0, dtype=dtype), dims=dims)
-
-    data: np.ndarray
-    if is_float:
-        data = np.frombuffer(memoryview(buf)[data_start:data_end], dtype=dtype)
-    else:
-        data = np.array(_parse_packed_varints_int32(buf, data_start, data_end), dtype=dtype)
-
-    return _ParsedMatrix(data=data, dims=dims)
-
-
-## Functions are adapted from the official waymo open github page
 def extrapolate_pose_based_on_velocity(
     T_SDC_global: np.ndarray, v_global: np.ndarray, w_global: np.ndarray, dt_sec: float
 ) -> np.ndarray:
+    """Extrapolate a 4x4 pose matrix forward in time using linear and angular velocity.
+
+    Args:
+      T_SDC_global: [4, 4] current pose (rotation + translation).
+      v_global: [3, 1] linear velocity in global frame.
+      w_global: [3, 1] angular velocity in global frame.
+      dt_sec: time delta in seconds.
+
+    Returns:
+      [4, 4] extrapolated pose.
+    """
     T_extrapolated = np.eye(4, dtype=np.float32)
     T_extrapolated[:3, :3] = expm(get_skew_symmetric(w_global) * dt_sec) @ T_SDC_global[:3, :3]
     T_extrapolated[:3, 3:4] = T_SDC_global[:3, 3:4] + v_global * dt_sec
@@ -163,6 +60,14 @@ def extrapolate_pose_based_on_velocity(
 
 
 def get_skew_symmetric(vec: np.ndarray) -> np.ndarray:
+    """Build the 3x3 skew-symmetric matrix for a 3-vector.
+
+    Args:
+      vec: [3, 1] or [3] vector.
+
+    Returns:
+      [3, 3] skew-symmetric matrix.
+    """
     skew_sym = np.zeros((3, 3), dtype=np.float32)
 
     skew_sym[0, 1] = -vec[2]
@@ -173,44 +78,6 @@ def get_skew_symmetric(vec: np.ndarray) -> np.ndarray:
     skew_sym[2, 1] = vec[0]
 
     return skew_sym
-
-
-### From here on the function are adopted from the waymo utils
-def parse_range_image_and_segmentations(frame, laser_name, ri_index: int = 0, range_image_top_pose=None):
-    """Parse range images and segmentations given a frame.
-
-    Args:
-       frame: open dataset frame proto
-       laser_name: the name of the laser sensor to process
-       ri_index: 0 for the first return, 1 for the second return.
-       range_image_top_pose: optional pre-parsed top-lidar pose to avoid redundant decompression.
-
-    Returns:
-       range_image: parsed range image matrix.
-       segmentations: Optional parsed segmentation matrix.
-       range_image_top_pose: parsed top-lidar per-pixel pose matrix.
-    """
-
-    range_image: Optional[_ParsedMatrix] = None
-    segmentation: Optional[_ParsedMatrix] = None
-    need_top_pose = range_image_top_pose is None
-
-    for laser in frame.lasers:
-        laser_ri_return = laser.ri_return1 if ri_index == 0 else laser.ri_return2
-
-        if need_top_pose and laser.name == dataset_pb2.LaserName.TOP:
-            range_image_top_pose = _parse_matrix_proto(laser_ri_return.range_image_pose_compressed, np.float32)
-
-        if laser.name != laser_name:
-            continue
-
-        if len(laser_ri_return.range_image_compressed) > 0:  # pylint: disable=g-explicit-length-test
-            range_image = _parse_matrix_proto(laser_ri_return.range_image_compressed, np.float32)
-
-        if len(laser_ri_return.segmentation_label_compressed) > 0:
-            segmentation = _parse_matrix_proto(laser_ri_return.segmentation_label_compressed, np.int32)
-
-    return range_image, segmentation, range_image_top_pose
 
 
 @dataclass
@@ -228,9 +95,9 @@ class _PointCloudReturn:
 def convert_range_images_to_point_clouds(
     frame,
     laser_name: str,
-    range_images: list[_ParsedMatrix],
-    segmentation: Optional[_ParsedMatrix],
-    range_image_top_pose: _ParsedMatrix,
+    range_images: list[ParsedMatrix],
+    segmentation: Optional[ParsedMatrix],
+    range_image_top_pose: ParsedMatrix,
     start_end_timestamps,
 ) -> list[_PointCloudReturn]:
     """Convert one or more range image returns to point clouds in a single batched pass.
@@ -366,334 +233,3 @@ def convert_range_images_to_point_clouds(
             )
 
     return results
-
-
-def extract_point_cloud_from_range_image(
-    range_image,
-    extrinsic,
-    inclination,
-    start_end_timestamps,
-    pixel_pose=None,
-    frame_pose=None,
-    dtype=tf.float32,
-    scope=None,
-):
-    """Extracts point cloud from range image.
-
-    Args:
-      range_image: [B, H, W] tensor. Lidar range images.
-      extrinsic: [B, 4, 4] tensor. Lidar extrinsic.
-      inclination: [B, H] tensor. Inclination for each row of the range image.
-        0-th entry corresponds to the 0-th row of the range image.
-      start_end_timestamps [2]: timestamp bounds to approximate point timestamps from.
-      pixel_pose: [B, H, W, 4, 4] tensor. If not None, it sets pose for each range
-        image pixel.
-      frame_pose: [B, 4, 4] tensor. This must be set when pixel_pose is set. It
-        decides the vehicle frame at which the cartesian points are computed.
-      dtype: float type to use internally. This is needed as extrinsic and
-        inclination sometimes have higher resolution than range_image.
-      scope: the name scope.
-
-    Returns:
-      range_image_cartesian: [B, H, W, 3] with {x, y, z} as inner dims in world frame.
-    """
-    with tf.compat.v1.name_scope(
-        scope,
-        "ExtractPointCloudFromRangeImage",
-        [range_image, extrinsic, inclination, pixel_pose, frame_pose],
-    ):
-        range_image_polar, azimuths = compute_range_image_polar(range_image, extrinsic, inclination, dtype=dtype)
-        range_image_cartesian, timestamps = compute_range_image_cartesian(
-            range_image_polar,
-            extrinsic,
-            start_end_timestamps,
-            pixel_pose=pixel_pose,
-            frame_pose=frame_pose,
-            dtype=dtype,
-            return_local_coordinates=False,
-        )
-
-        return range_image_cartesian, timestamps, azimuths
-
-
-def compute_inclination(inclination_range, height, scope=None):
-    """Computes uniform inclination range based the given range and height.
-
-    Args:
-      inclination_range: [..., 2] tensor. Inner dims are [min inclination, max
-        inclination].
-      height: an integer indicates height of the range image.
-      scope: the name scope.
-
-    Returns:
-      inclination: [..., height] tensor. Inclinations computed.
-    """
-    with tf.compat.v1.name_scope(scope, "ComputeInclination", [inclination_range]):
-        diff = inclination_range[..., 1] - inclination_range[..., 0]
-        inclination = (0.5 + tf.cast(tf.range(0, height), dtype=inclination_range.dtype)) / tf.cast(
-            height, dtype=inclination_range.dtype
-        ) * tf.expand_dims(diff, axis=-1) + inclination_range[..., 0:1]
-        return inclination
-
-
-def compute_range_image_polar(range_image, extrinsic, inclination, dtype=tf.float32, scope=None):
-    """Computes range image polar coordinates.
-
-    Args:
-      range_image: [B, H, W] tensor. Lidar range images.
-      extrinsic: [B, 4, 4] tensor. Lidar extrinsic.
-      inclination: [B, H] tensor. Inclination for each row of the range image.
-        0-th entry corresponds to the 0-th row of the range image.
-      dtype: float type to use internally. This is needed as extrinsic and
-        inclination sometimes have higher resolution than range_image.
-      scope: the name scope.
-
-    Returns:
-      range_image_polar: [B, H, W, 3] polar coordinates.
-    """
-    # pylint: disable=unbalanced-tuple-unpacking
-    _, height, width = _combined_static_and_dynamic_shape(range_image)
-    range_image_dtype = range_image.dtype
-    range_image = tf.cast(range_image, dtype=dtype)
-    extrinsic = tf.cast(extrinsic, dtype=dtype)
-    inclination = tf.cast(inclination, dtype=dtype)
-
-    with tf.compat.v1.name_scope(scope, "ComputeRangeImagePolar", [range_image, extrinsic, inclination]):
-        with tf.compat.v1.name_scope("Azimuth"):
-            # [B].
-            az_correction = tf.atan2(extrinsic[..., 1, 0], extrinsic[..., 0, 0])
-            # [W].
-            ratios = (tf.cast(tf.range(width, 0, -1), dtype=dtype) - 0.5) / tf.cast(width, dtype=dtype)
-            # [B, W].
-            azimuth = (ratios * 2.0 - 1.0) * np.pi - tf.expand_dims(az_correction, -1)
-
-        # [B, H, W]
-        azimuth_tile = tf.tile(azimuth[:, tf.newaxis, :], [1, height, 1])
-        # [B, H, W]
-        inclination_tile = tf.tile(inclination[:, :, tf.newaxis], [1, 1, width])
-        range_image_polar = tf.stack([azimuth_tile, inclination_tile, range_image], axis=-1)
-        return tf.cast(range_image_polar, dtype=range_image_dtype), azimuth
-
-
-def compute_range_image_cartesian(
-    range_image_polar,
-    extrinsic,
-    start_end_timestamps,
-    pixel_pose=None,
-    frame_pose=None,
-    dtype=tf.float32,
-    scope=None,
-    return_local_coordinates=False,
-):
-    """Computes range image cartesian coordinates from polar ones.
-
-    Args:
-      range_image_polar: [B, H, W, 3] float tensor. Lidar range image in polar
-        coordinate in sensor frame.
-      extrinsic: [B, 4, 4] float tensor. Lidar extrinsic.
-      pixel_pose: [B, H, W, 4, 4] float tensor. If not None, it sets pose for each
-        range image pixel.
-      frame_pose: [B, 4, 4] float tensor. This must be set when pixel_pose is set.
-        It decides the vehicle frame at which the cartesian points are computed.
-      dtype: float type to use internally. This is needed as extrinsic and
-        inclination sometimes have higher resolution than range_image.
-      scope: the name scope.
-
-    Returns:
-      range_image_cartesian: [B, H, W, 3] cartesian coordinates.
-    """
-    range_image_polar_dtype = range_image_polar.dtype
-    range_image_polar = tf.cast(range_image_polar, dtype=dtype)
-    extrinsic = tf.cast(extrinsic, dtype=dtype)
-    if pixel_pose is not None:
-        pixel_pose = tf.cast(pixel_pose, dtype=dtype)
-    if frame_pose is not None:
-        frame_pose = tf.cast(frame_pose, dtype=dtype)
-
-    with tf.compat.v1.name_scope(
-        scope,
-        "ComputeRangeImageCartesian",
-        [range_image_polar, extrinsic, pixel_pose, frame_pose],
-    ):
-        azimuth, inclination, range_image_range = tf.unstack(range_image_polar, axis=-1)
-
-        cos_azimuth = tf.cos(azimuth)
-        sin_azimuth = tf.sin(azimuth)
-        cos_incl = tf.cos(inclination)
-        sin_incl = tf.sin(inclination)
-
-        # [B, H, W].
-        x = cos_azimuth * cos_incl * range_image_range
-        y = sin_azimuth * cos_incl * range_image_range
-        z = sin_incl * range_image_range
-
-        ## Approximate point timestamps (see https://github.com/waymo-research/waymo-open-dataset/issues/619#issuecomment-1496410092)
-        #  inferred from column index [B, H, W]
-        nRows, nCols = azimuth.shape[1:]
-        column_relative_times = tf.reshape(tf.range(nCols) / (nCols - 1), (-1, 1, nCols))
-        relative_times = tf.repeat(column_relative_times, nRows, axis=1)
-        # *clockwise* spinning lidar lidar (largest azimuth are measured first)
-        range_image_timestamps = start_end_timestamps[0] + tf.cast(
-            relative_times * (start_end_timestamps[1] - start_end_timestamps[0]),
-            dtype=start_end_timestamps[0].dtype,
-        )
-
-        # [B, H, W, 3]
-        range_image_points = tf.stack([x, y, z], -1)
-        range_image_center = tf.zeros_like(range_image_points)
-
-        # [B, 3, 3]
-        rotation = extrinsic[..., 0:3, 0:3]
-        # translation [B, 1, 3]
-        translation = tf.expand_dims(tf.expand_dims(extrinsic[..., 0:3, 3], 1), 1)
-
-        # To vehicle frame.
-        # [B, H, W, 3]
-        range_image_points = tf.einsum("bkr,bijr->bijk", rotation, range_image_points) + translation
-
-        range_image_center = tf.einsum("bkr,bijr->bijk", rotation, range_image_center) + translation
-        if pixel_pose is not None:
-            # To global frame.
-            # [B, H, W, 3, 3]
-            pixel_pose_rotation = pixel_pose[..., 0:3, 0:3]
-            # [B, H, W, 3]
-            pixel_pose_translation = pixel_pose[..., 0:3, 3]
-            # [B, H, W, 3]
-            range_image_points = (
-                tf.einsum("bhwij,bhwj->bhwi", pixel_pose_rotation, range_image_points) + pixel_pose_translation
-            )
-
-            range_image_center = (
-                tf.einsum("bhwij,bhwj->bhwi", pixel_pose_rotation, range_image_center) + pixel_pose_translation
-            )
-
-            if frame_pose is None:
-                raise ValueError("frame_pose must be set when pixel_pose is set.")
-
-            if return_local_coordinates:
-                # To vehicle frame corresponding to the given frame_pose
-                # [B, 4, 4]
-                world_to_vehicle = tf.linalg.inv(frame_pose)
-                world_to_vehicle_rotation = world_to_vehicle[:, 0:3, 0:3]
-                world_to_vehicle_translation = world_to_vehicle[:, 0:3, 3]
-                # [B, H, W, 3]
-                range_image_points = (
-                    tf.einsum("bij,bhwj->bhwi", world_to_vehicle_rotation, range_image_points)
-                    + world_to_vehicle_translation[:, tf.newaxis, tf.newaxis, :]
-                )
-                range_image_center = (
-                    tf.einsum("bij,bhwj->bhwi", world_to_vehicle_rotation, range_image_center)
-                    + world_to_vehicle_translation[:, tf.newaxis, tf.newaxis, :]
-                )
-
-        range_image_points = tf.cast(range_image_points, dtype=range_image_polar_dtype)
-        range_image_center = tf.cast(range_image_center, dtype=range_image_polar_dtype)
-
-        return (range_image_points, range_image_center), range_image_timestamps
-
-
-def get_rotation_matrix(roll, pitch, yaw, name=None):
-    """Gets a rotation matrix given roll, pitch, yaw.
-
-    roll-pitch-yaw is z-y'-x'' intrinsic rotation which means we need to apply
-    x(roll) rotation first, then y(pitch) rotation, then z(yaw) rotation.
-
-    https://en.wikipedia.org/wiki/Euler_angles
-    http://planning.cs.uiuc.edu/node102.html
-
-    Args:
-      roll : x-rotation in radians.
-      pitch: y-rotation in radians. The shape must be the same as roll.
-      yaw: z-rotation in radians. The shape must be the same as roll.
-      name: the op name.
-
-    Returns:
-      A rotation tensor with the same data type of the input. Its shape is
-        [input_shape_of_yaw, 3 ,3].
-    """
-    with tf.compat.v1.name_scope(name, "GetRotationMatrix", [yaw, pitch, roll]):
-        cos_roll = tf.cos(roll)
-        sin_roll = tf.sin(roll)
-        cos_yaw = tf.cos(yaw)
-        sin_yaw = tf.sin(yaw)
-        cos_pitch = tf.cos(pitch)
-        sin_pitch = tf.sin(pitch)
-
-        ones = tf.ones_like(yaw)
-        zeros = tf.zeros_like(yaw)
-
-        r_roll = tf.stack(
-            [
-                tf.stack([ones, zeros, zeros], axis=-1),
-                tf.stack([zeros, cos_roll, -1.0 * sin_roll], axis=-1),
-                tf.stack([zeros, sin_roll, cos_roll], axis=-1),
-            ],
-            axis=-2,
-        )
-        r_pitch = tf.stack(
-            [
-                tf.stack([cos_pitch, zeros, sin_pitch], axis=-1),
-                tf.stack([zeros, ones, zeros], axis=-1),
-                tf.stack([-1.0 * sin_pitch, zeros, cos_pitch], axis=-1),
-            ],
-            axis=-2,
-        )
-        r_yaw = tf.stack(
-            [
-                tf.stack([cos_yaw, -1.0 * sin_yaw, zeros], axis=-1),
-                tf.stack([sin_yaw, cos_yaw, zeros], axis=-1),
-                tf.stack([zeros, zeros, ones], axis=-1),
-            ],
-            axis=-2,
-        )
-
-        return tf.matmul(r_yaw, tf.matmul(r_pitch, r_roll))
-
-
-def get_transform(rotation, translation):
-    """Combines NxN rotation and Nx1 translation to (N+1)x(N+1) transform.
-
-    Args:
-      rotation: [..., N, N] rotation tensor.
-      translation: [..., N] translation tensor. This must have the same type as
-        rotation.
-
-    Returns:
-      transform: [..., (N+1), (N+1)] transform tensor. This has the same type as
-        rotation.
-    """
-    with tf.name_scope("GetTransform"):
-        # [..., N, 1]
-        translation_n_1 = translation[..., tf.newaxis]
-        # [..., N, N+1]
-        transform = tf.concat([rotation, translation_n_1], axis=-1)
-        # [..., N]
-        last_row = tf.zeros_like(translation)
-        # [..., N+1]
-        last_row = tf.concat([last_row, tf.ones_like(last_row[..., 0:1])], axis=-1)
-        # [..., N+1, N+1]
-        transform = tf.concat([transform, last_row[..., tf.newaxis, :]], axis=-2)
-        return transform
-
-
-def _combined_static_and_dynamic_shape(tensor):
-    """Returns a list containing static and dynamic values for the dimensions.
-
-    Returns a list of static and dynamic values for shape dimensions. This is
-    useful to preserve static shapes when available in reshape operation.
-
-    Args:
-      tensor: A tensor of any type.
-
-    Returns:
-      A list of size tensor.shape.ndims containing integers or a scalar tensor.
-    """
-    static_tensor_shape = tensor.shape.as_list()
-    dynamic_tensor_shape = tf.shape(input=tensor)
-    combined_shape = []
-    for index, dim in enumerate(static_tensor_shape):
-        if dim is not None:
-            combined_shape.append(dim)
-        else:
-            combined_shape.append(dynamic_tensor_shape[index])
-    return combined_shape

--- a/tools/data_converter/waymo/waymo_range_image_utils.py
+++ b/tools/data_converter/waymo/waymo_range_image_utils.py
@@ -1,0 +1,337 @@
+# Copyright 2019 The Waymo Open Dataset Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ========================================================================
+#
+# Modifications Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# This file contains functions derived from the Waymo Open Dataset
+# (https://github.com/waymo-research/waymo-open-dataset, tag v1.5.1).
+# The original functions have been modified to support additional outputs
+# (timestamps, azimuths, ray origins) and use a fast protobuf parser.
+#
+# Verbatim (unmodified) utility functions are imported directly from the
+# upstream waymo_open_dataset package rather than being duplicated here.
+# See:
+#   - waymo_open_dataset.utils.range_image_utils: compute_inclination,
+#     _combined_static_and_dynamic_shape
+#   - waymo_open_dataset.utils.transform_utils: get_rotation_matrix,
+#     get_transform
+
+"""Modified Waymo range image utilities for NCore data conversion.
+
+Functions in this module are derived from the following upstream sources:
+  - waymo_open_dataset/utils/range_image_utils.py
+  - waymo_open_dataset/utils/frame_utils.py
+
+Key modifications from upstream:
+  - compute_range_image_polar: also returns azimuth tensor
+  - compute_range_image_cartesian: adds timestamp computation, ray origin
+    (range_image_center), and return_local_coordinates flag
+  - extract_point_cloud_from_range_image: adds start_end_timestamps parameter,
+    returns timestamps and azimuths
+  - parse_range_image_and_segmentations: uses fast protobuf parser, processes
+    a single laser at a time, drops camera projections
+"""
+
+from typing import Optional
+
+import numpy as np
+
+from tools.data_converter.waymo.deps import (
+    dataset_pb2,
+    tf,
+    waymo_range_image_utils,
+    waymo_transform_utils,
+)
+from tools.data_converter.waymo.proto_utils import ParsedMatrix, parse_matrix_proto
+
+
+# Re-export verbatim upstream functions used by other modules in this package.
+# These are NOT duplicated — they come directly from the Waymo Open Dataset.
+compute_inclination = waymo_range_image_utils.compute_inclination
+get_rotation_matrix = waymo_transform_utils.get_rotation_matrix
+get_transform = waymo_transform_utils.get_transform
+_combined_static_and_dynamic_shape = waymo_range_image_utils._combined_static_and_dynamic_shape
+
+
+def parse_range_image_and_segmentations(frame, laser_name, ri_index: int = 0, range_image_top_pose=None):
+    """Parse range images and segmentations given a frame.
+
+    Derived from waymo_open_dataset.utils.frame_utils.parse_range_image_and_camera_projection
+    with the following modifications:
+      - Uses fast protobuf wire-format parser instead of ParseFromString
+      - Processes a single laser at a time (caller specifies laser_name)
+      - Drops camera projection parsing (not needed for NCore conversion)
+      - Accepts pre-parsed range_image_top_pose to avoid redundant decompression
+
+    Args:
+       frame: open dataset frame proto
+       laser_name: the name of the laser sensor to process
+       ri_index: 0 for the first return, 1 for the second return.
+       range_image_top_pose: optional pre-parsed top-lidar pose to avoid redundant decompression.
+
+    Returns:
+       range_image: parsed range image matrix.
+       segmentations: Optional parsed segmentation matrix.
+       range_image_top_pose: parsed top-lidar per-pixel pose matrix.
+    """
+
+    range_image: Optional[ParsedMatrix] = None
+    segmentation: Optional[ParsedMatrix] = None
+    need_top_pose = range_image_top_pose is None
+
+    for laser in frame.lasers:
+        laser_ri_return = laser.ri_return1 if ri_index == 0 else laser.ri_return2
+
+        if need_top_pose and laser.name == dataset_pb2.LaserName.TOP:
+            range_image_top_pose = parse_matrix_proto(laser_ri_return.range_image_pose_compressed, np.float32)
+
+        if laser.name != laser_name:
+            continue
+
+        if len(laser_ri_return.range_image_compressed) > 0:  # pylint: disable=g-explicit-length-test
+            range_image = parse_matrix_proto(laser_ri_return.range_image_compressed, np.float32)
+
+        if len(laser_ri_return.segmentation_label_compressed) > 0:
+            segmentation = parse_matrix_proto(laser_ri_return.segmentation_label_compressed, np.int32)
+
+    return range_image, segmentation, range_image_top_pose
+
+
+def extract_point_cloud_from_range_image(
+    range_image,
+    extrinsic,
+    inclination,
+    start_end_timestamps,
+    pixel_pose=None,
+    frame_pose=None,
+    dtype=tf.float32,
+    scope=None,
+):
+    """Extracts point cloud from range image.
+
+    Derived from waymo_open_dataset.utils.range_image_utils.extract_point_cloud_from_range_image
+    with the following modifications:
+      - Accepts start_end_timestamps for per-point timestamp approximation
+      - Returns (range_image_cartesian, timestamps, azimuths) instead of just cartesian
+      - Uses modified compute_range_image_polar that also returns azimuths
+      - Uses modified compute_range_image_cartesian that computes timestamps
+
+    Args:
+      range_image: [B, H, W] tensor. Lidar range images.
+      extrinsic: [B, 4, 4] tensor. Lidar extrinsic.
+      inclination: [B, H] tensor. Inclination for each row of the range image.
+        0-th entry corresponds to the 0-th row of the range image.
+      start_end_timestamps [2]: timestamp bounds to approximate point timestamps from.
+      pixel_pose: [B, H, W, 4, 4] tensor. If not None, it sets pose for each range
+        image pixel.
+      frame_pose: [B, 4, 4] tensor. This must be set when pixel_pose is set. It
+        decides the vehicle frame at which the cartesian points are computed.
+      dtype: float type to use internally. This is needed as extrinsic and
+        inclination sometimes have higher resolution than range_image.
+      scope: the name scope.
+
+    Returns:
+      range_image_cartesian: [B, H, W, 3] with {x, y, z} as inner dims in world frame.
+    """
+    with tf.compat.v1.name_scope(
+        scope,
+        "ExtractPointCloudFromRangeImage",
+        [range_image, extrinsic, inclination, pixel_pose, frame_pose],
+    ):
+        range_image_polar, azimuths = compute_range_image_polar(range_image, extrinsic, inclination, dtype=dtype)
+        range_image_cartesian, timestamps = compute_range_image_cartesian(
+            range_image_polar,
+            extrinsic,
+            start_end_timestamps,
+            pixel_pose=pixel_pose,
+            frame_pose=frame_pose,
+            dtype=dtype,
+            return_local_coordinates=False,
+        )
+
+        return range_image_cartesian, timestamps, azimuths
+
+
+def compute_range_image_polar(range_image, extrinsic, inclination, dtype=tf.float32, scope=None):
+    """Computes range image polar coordinates.
+
+    Derived from waymo_open_dataset.utils.range_image_utils.compute_range_image_polar
+    with the following modification:
+      - Also returns the azimuth tensor as a second output
+
+    Args:
+      range_image: [B, H, W] tensor. Lidar range images.
+      extrinsic: [B, 4, 4] tensor. Lidar extrinsic.
+      inclination: [B, H] tensor. Inclination for each row of the range image.
+        0-th entry corresponds to the 0-th row of the range image.
+      dtype: float type to use internally. This is needed as extrinsic and
+        inclination sometimes have higher resolution than range_image.
+      scope: the name scope.
+
+    Returns:
+      range_image_polar: [B, H, W, 3] polar coordinates.
+      azimuth: [B, W] azimuth angles.
+    """
+    # pylint: disable=unbalanced-tuple-unpacking
+    _, height, width = _combined_static_and_dynamic_shape(range_image)
+    range_image_dtype = range_image.dtype
+    range_image = tf.cast(range_image, dtype=dtype)
+    extrinsic = tf.cast(extrinsic, dtype=dtype)
+    inclination = tf.cast(inclination, dtype=dtype)
+
+    with tf.compat.v1.name_scope(scope, "ComputeRangeImagePolar", [range_image, extrinsic, inclination]):
+        with tf.compat.v1.name_scope("Azimuth"):
+            # [B].
+            az_correction = tf.atan2(extrinsic[..., 1, 0], extrinsic[..., 0, 0])
+            # [W].
+            ratios = (tf.cast(tf.range(width, 0, -1), dtype=dtype) - 0.5) / tf.cast(width, dtype=dtype)
+            # [B, W].
+            azimuth = (ratios * 2.0 - 1.0) * np.pi - tf.expand_dims(az_correction, -1)
+
+        # [B, H, W]
+        azimuth_tile = tf.tile(azimuth[:, tf.newaxis, :], [1, height, 1])
+        # [B, H, W]
+        inclination_tile = tf.tile(inclination[:, :, tf.newaxis], [1, 1, width])
+        range_image_polar = tf.stack([azimuth_tile, inclination_tile, range_image], axis=-1)
+        return tf.cast(range_image_polar, dtype=range_image_dtype), azimuth
+
+
+def compute_range_image_cartesian(
+    range_image_polar,
+    extrinsic,
+    start_end_timestamps,
+    pixel_pose=None,
+    frame_pose=None,
+    dtype=tf.float32,
+    scope=None,
+    return_local_coordinates=False,
+):
+    """Computes range image cartesian coordinates from polar ones.
+
+    Derived from waymo_open_dataset.utils.range_image_utils.compute_range_image_cartesian
+    with the following modifications:
+      - Accepts start_end_timestamps and computes per-pixel timestamps
+      - Computes ray origin (range_image_center) alongside hit points
+      - Adds return_local_coordinates flag (upstream always returns vehicle frame;
+        this defaults to world frame)
+      - Returns ((range_image_points, range_image_center), timestamps) instead
+        of just range_image_points
+
+    Args:
+      range_image_polar: [B, H, W, 3] float tensor. Lidar range image in polar
+        coordinate in sensor frame.
+      extrinsic: [B, 4, 4] float tensor. Lidar extrinsic.
+      start_end_timestamps [2]: timestamp bounds to approximate point timestamps from.
+      pixel_pose: [B, H, W, 4, 4] float tensor. If not None, it sets pose for each
+        range image pixel.
+      frame_pose: [B, 4, 4] float tensor. This must be set when pixel_pose is set.
+        It decides the vehicle frame at which the cartesian points are computed.
+      dtype: float type to use internally. This is needed as extrinsic and
+        inclination sometimes have higher resolution than range_image.
+      scope: the name scope.
+      return_local_coordinates: if True, transform back to vehicle frame.
+
+    Returns:
+      range_image_cartesian: ((points [B,H,W,3], center [B,H,W,3]), timestamps [B,H,W]).
+    """
+    range_image_polar_dtype = range_image_polar.dtype
+    range_image_polar = tf.cast(range_image_polar, dtype=dtype)
+    extrinsic = tf.cast(extrinsic, dtype=dtype)
+    if pixel_pose is not None:
+        pixel_pose = tf.cast(pixel_pose, dtype=dtype)
+    if frame_pose is not None:
+        frame_pose = tf.cast(frame_pose, dtype=dtype)
+
+    with tf.compat.v1.name_scope(
+        scope,
+        "ComputeRangeImageCartesian",
+        [range_image_polar, extrinsic, pixel_pose, frame_pose],
+    ):
+        azimuth, inclination, range_image_range = tf.unstack(range_image_polar, axis=-1)
+
+        cos_azimuth = tf.cos(azimuth)
+        sin_azimuth = tf.sin(azimuth)
+        cos_incl = tf.cos(inclination)
+        sin_incl = tf.sin(inclination)
+
+        # [B, H, W].
+        x = cos_azimuth * cos_incl * range_image_range
+        y = sin_azimuth * cos_incl * range_image_range
+        z = sin_incl * range_image_range
+
+        ## Approximate point timestamps (see https://github.com/waymo-research/waymo-open-dataset/issues/619#issuecomment-1496410092)
+        #  inferred from column index [B, H, W]
+        nRows, nCols = azimuth.shape[1:]
+        column_relative_times = tf.reshape(tf.range(nCols) / (nCols - 1), (-1, 1, nCols))
+        relative_times = tf.repeat(column_relative_times, nRows, axis=1)
+        # *clockwise* spinning lidar lidar (largest azimuth are measured first)
+        range_image_timestamps = start_end_timestamps[0] + tf.cast(
+            relative_times * (start_end_timestamps[1] - start_end_timestamps[0]),
+            dtype=start_end_timestamps[0].dtype,
+        )
+
+        # [B, H, W, 3]
+        range_image_points = tf.stack([x, y, z], -1)
+        range_image_center = tf.zeros_like(range_image_points)
+
+        # [B, 3, 3]
+        rotation = extrinsic[..., 0:3, 0:3]
+        # translation [B, 1, 3]
+        translation = tf.expand_dims(tf.expand_dims(extrinsic[..., 0:3, 3], 1), 1)
+
+        # To vehicle frame.
+        # [B, H, W, 3]
+        range_image_points = tf.einsum("bkr,bijr->bijk", rotation, range_image_points) + translation
+
+        range_image_center = tf.einsum("bkr,bijr->bijk", rotation, range_image_center) + translation
+        if pixel_pose is not None:
+            # To global frame.
+            # [B, H, W, 3, 3]
+            pixel_pose_rotation = pixel_pose[..., 0:3, 0:3]
+            # [B, H, W, 3]
+            pixel_pose_translation = pixel_pose[..., 0:3, 3]
+            # [B, H, W, 3]
+            range_image_points = (
+                tf.einsum("bhwij,bhwj->bhwi", pixel_pose_rotation, range_image_points) + pixel_pose_translation
+            )
+
+            range_image_center = (
+                tf.einsum("bhwij,bhwj->bhwi", pixel_pose_rotation, range_image_center) + pixel_pose_translation
+            )
+
+            if frame_pose is None:
+                raise ValueError("frame_pose must be set when pixel_pose is set.")
+
+            if return_local_coordinates:
+                # To vehicle frame corresponding to the given frame_pose
+                # [B, 4, 4]
+                world_to_vehicle = tf.linalg.inv(frame_pose)
+                world_to_vehicle_rotation = world_to_vehicle[:, 0:3, 0:3]
+                world_to_vehicle_translation = world_to_vehicle[:, 0:3, 3]
+                # [B, H, W, 3]
+                range_image_points = (
+                    tf.einsum("bij,bhwj->bhwi", world_to_vehicle_rotation, range_image_points)
+                    + world_to_vehicle_translation[:, tf.newaxis, tf.newaxis, :]
+                )
+                range_image_center = (
+                    tf.einsum("bij,bhwj->bhwi", world_to_vehicle_rotation, range_image_center)
+                    + world_to_vehicle_translation[:, tf.newaxis, tf.newaxis, :]
+                )
+
+        range_image_points = tf.cast(range_image_points, dtype=range_image_polar_dtype)
+        range_image_center = tf.cast(range_image_center, dtype=range_image_polar_dtype)
+
+        return (range_image_points, range_image_center), range_image_timestamps

--- a/tools/data_converter/waymo/waymo_range_image_utils.py
+++ b/tools/data_converter/waymo/waymo_range_image_utils.py
@@ -47,7 +47,7 @@ Key modifications from upstream:
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 
@@ -78,8 +78,8 @@ def parse_range_image_and_segmentations(
     frame: Any,
     laser_name: int,
     ri_index: int = 0,
-    range_image_top_pose: Optional[ParsedMatrix] = None,
-) -> tuple[Optional[ParsedMatrix], Optional[ParsedMatrix], Optional[ParsedMatrix]]:
+    range_image_top_pose: ParsedMatrix | None = None,
+) -> tuple[ParsedMatrix | None, ParsedMatrix | None, ParsedMatrix | None]:
     """Parse range images and segmentations given a frame.
 
     Derived from waymo_open_dataset.utils.frame_utils.parse_range_image_and_camera_projection
@@ -101,8 +101,8 @@ def parse_range_image_and_segmentations(
        range_image_top_pose: parsed top-lidar per-pixel pose matrix.
     """
 
-    range_image: Optional[ParsedMatrix] = None
-    segmentation: Optional[ParsedMatrix] = None
+    range_image: ParsedMatrix | None = None
+    segmentation: ParsedMatrix | None = None
     need_top_pose = range_image_top_pose is None
 
     for laser in frame.lasers:
@@ -128,10 +128,10 @@ def extract_point_cloud_from_range_image(
     extrinsic: TfTensor,
     inclination: TfTensor,
     start_end_timestamps: np.ndarray,
-    pixel_pose: Optional[TfTensor] = None,
-    frame_pose: Optional[TfTensor] = None,
+    pixel_pose: TfTensor | None = None,
+    frame_pose: TfTensor | None = None,
     dtype: TfDType = tf.float32,
-    scope: Optional[str] = None,
+    scope: str | None = None,
 ) -> tuple[tuple[TfTensor, TfTensor], TfTensor, TfTensor]:
     """Extracts point cloud from range image.
 
@@ -183,7 +183,7 @@ def compute_range_image_polar(
     extrinsic: TfTensor,
     inclination: TfTensor,
     dtype: TfDType = tf.float32,
-    scope: Optional[str] = None,
+    scope: str | None = None,
 ) -> tuple[TfTensor, TfTensor]:
     """Computes range image polar coordinates.
 
@@ -232,10 +232,10 @@ def compute_range_image_cartesian(
     range_image_polar: TfTensor,
     extrinsic: TfTensor,
     start_end_timestamps: np.ndarray,
-    pixel_pose: Optional[TfTensor] = None,
-    frame_pose: Optional[TfTensor] = None,
+    pixel_pose: TfTensor | None = None,
+    frame_pose: TfTensor | None = None,
     dtype: TfDType = tf.float32,
-    scope: Optional[str] = None,
+    scope: str | None = None,
     return_local_coordinates: bool = False,
 ) -> tuple[tuple[TfTensor, TfTensor], TfTensor]:
     """Computes range image cartesian coordinates from polar ones.

--- a/tools/data_converter/waymo/waymo_range_image_utils.py
+++ b/tools/data_converter/waymo/waymo_range_image_utils.py
@@ -45,7 +45,9 @@ Key modifications from upstream:
     a single laser at a time, drops camera projections
 """
 
-from typing import Optional
+from __future__ import annotations
+
+from typing import Any, Optional
 
 import numpy as np
 
@@ -58,6 +60,12 @@ from tools.data_converter.waymo.deps import (
 from tools.data_converter.waymo.proto_utils import ParsedMatrix, parse_matrix_proto
 
 
+# TensorFlow tensor type alias — tf types are unavailable to mypy (follow_imports = silent),
+# so we use Any as a transparent stand-in.
+TfTensor = Any
+TfDType = Any
+
+
 # Re-export verbatim upstream functions used by other modules in this package.
 # These are NOT duplicated — they come directly from the Waymo Open Dataset.
 compute_inclination = waymo_range_image_utils.compute_inclination
@@ -66,7 +74,12 @@ get_transform = waymo_transform_utils.get_transform
 _combined_static_and_dynamic_shape = waymo_range_image_utils._combined_static_and_dynamic_shape
 
 
-def parse_range_image_and_segmentations(frame, laser_name, ri_index: int = 0, range_image_top_pose=None):
+def parse_range_image_and_segmentations(
+    frame: Any,
+    laser_name: int,
+    ri_index: int = 0,
+    range_image_top_pose: Optional[ParsedMatrix] = None,
+) -> tuple[Optional[ParsedMatrix], Optional[ParsedMatrix], Optional[ParsedMatrix]]:
     """Parse range images and segmentations given a frame.
 
     Derived from waymo_open_dataset.utils.frame_utils.parse_range_image_and_camera_projection
@@ -111,15 +124,15 @@ def parse_range_image_and_segmentations(frame, laser_name, ri_index: int = 0, ra
 
 
 def extract_point_cloud_from_range_image(
-    range_image,
-    extrinsic,
-    inclination,
-    start_end_timestamps,
-    pixel_pose=None,
-    frame_pose=None,
-    dtype=tf.float32,
-    scope=None,
-):
+    range_image: TfTensor,
+    extrinsic: TfTensor,
+    inclination: TfTensor,
+    start_end_timestamps: np.ndarray,
+    pixel_pose: Optional[TfTensor] = None,
+    frame_pose: Optional[TfTensor] = None,
+    dtype: TfDType = tf.float32,
+    scope: Optional[str] = None,
+) -> tuple[tuple[TfTensor, TfTensor], TfTensor, TfTensor]:
     """Extracts point cloud from range image.
 
     Derived from waymo_open_dataset.utils.range_image_utils.extract_point_cloud_from_range_image
@@ -165,7 +178,13 @@ def extract_point_cloud_from_range_image(
         return range_image_cartesian, timestamps, azimuths
 
 
-def compute_range_image_polar(range_image, extrinsic, inclination, dtype=tf.float32, scope=None):
+def compute_range_image_polar(
+    range_image: TfTensor,
+    extrinsic: TfTensor,
+    inclination: TfTensor,
+    dtype: TfDType = tf.float32,
+    scope: Optional[str] = None,
+) -> tuple[TfTensor, TfTensor]:
     """Computes range image polar coordinates.
 
     Derived from waymo_open_dataset.utils.range_image_utils.compute_range_image_polar
@@ -210,15 +229,15 @@ def compute_range_image_polar(range_image, extrinsic, inclination, dtype=tf.floa
 
 
 def compute_range_image_cartesian(
-    range_image_polar,
-    extrinsic,
-    start_end_timestamps,
-    pixel_pose=None,
-    frame_pose=None,
-    dtype=tf.float32,
-    scope=None,
-    return_local_coordinates=False,
-):
+    range_image_polar: TfTensor,
+    extrinsic: TfTensor,
+    start_end_timestamps: np.ndarray,
+    pixel_pose: Optional[TfTensor] = None,
+    frame_pose: Optional[TfTensor] = None,
+    dtype: TfDType = tf.float32,
+    scope: Optional[str] = None,
+    return_local_coordinates: bool = False,
+) -> tuple[tuple[TfTensor, TfTensor], TfTensor]:
     """Computes range image cartesian coordinates from polar ones.
 
     Derived from waymo_open_dataset.utils.range_image_utils.compute_range_image_cartesian


### PR DESCRIPTION


Split utils.py into three files with clear license boundaries:

- proto_utils.py (NVIDIA-only): fast protobuf wire-format parser for MatrixFloat/MatrixInt32 protos, replacing slow ParseFromString
- waymo_range_image_utils.py (Waymo Apache-2.0 + NVIDIA modifications): modified range image functions (polar, cartesian, point cloud extraction with timestamps/azimuths/ray origins) derived from upstream v1.5.1
- utils.py (NVIDIA-only): pose extrapolation and batched multi-return point cloud conversion with no Waymo-derived code

Verbatim Waymo functions (compute_inclination, get_rotation_matrix, get_transform, _combined_static_and_dynamic_shape) are now imported directly from the upstream waymo_open_dataset package instead of being vendored, enabled by a new Bazel patch that remaps @wod_deps to @ncore_pip_deps in the upstream utils/BUILD.