### PR TITLE
chore(waymo): update Waymo Open Dataset to version 1.6.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -104,7 +104,7 @@ http_archive(
         "//deps/waymo-open-dataset:cc-proto.patch",
         "//deps/waymo-open-dataset:py-utils.patch",
     ],
-    sha256 = "5e91fea02a0cdb1edb39d9ac27fbdb1e8d890986faab545497a95b54213b973d",
-    strip_prefix = "waymo-open-dataset-1.5.1/src",
-    urls = ["https://github.com/waymo-research/waymo-open-dataset/archive/refs/tags/v1.5.1.tar.gz"],
+    sha256 = "7b08fce2b94d45ed26590dcb7d552e2f7d5b3080ad5c59abf2b5a4207f7553d2",
+    strip_prefix = "waymo-open-dataset-1.6.1/src",
+    urls = ["https://github.com/waymo-research/waymo-open-dataset/archive/refs/tags/v1.6.1.tar.gz"],
 )

--- a/tools/data_converter/waymo/NOTICE
+++ b/tools/data_converter/waymo/NOTICE
@@ -10,7 +10,7 @@ This package includes software developed by
 Waymo Open Dataset (<https://github.com/waymo-research/waymo-open-dataset>)
 
 - `waymo_range_image_utils.py` contains functions modified from the Waymo Open
-  Dataset v1.5.1 sources (`range_image_utils.py`, `transform_utils.py`, and
+  Dataset v1.6.1 sources (`range_image_utils.py`, `transform_utils.py`, and
   `frame_utils.py`). Verbatim (unmodified) utility functions are imported
   directly from the upstream `waymo_open_dataset` package at runtime rather
   than being duplicated.

--- a/tools/data_converter/waymo/waymo_range_image_utils.py
+++ b/tools/data_converter/waymo/waymo_range_image_utils.py
@@ -17,7 +17,7 @@
 # Modifications Copyright 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This file contains functions derived from the Waymo Open Dataset
-# (https://github.com/waymo-research/waymo-open-dataset, tag v1.5.1).
+# (https://github.com/waymo-research/waymo-open-dataset, tag v1.6.1).
 # The original functions have been modified to support additional outputs
 # (timestamps, azimuths, ray origins) and use a fast protobuf parser.
 #


### PR DESCRIPTION
This pull request updates the Waymo Open Dataset dependency from version 1.5.1 to 1.6.1 throughout the project. The update ensures that all references, code comments, and notices reflect the new version, which will allow the project to benefit from the latest features and bug fixes in the Waymo Open Dataset.

Dependency update:

* Updated the Waymo Open Dataset Bazel dependency in `MODULE.bazel` to use version 1.6.1, including the new `sha256`, `strip_prefix`, and download URL.

Documentation and metadata updates:

* Updated the version reference in the `NOTICE` file to indicate that code is derived from Waymo Open Dataset v1.6.1.
* Updated the version tag in the header comment of `waymo_range_image_utils.py` to reflect the use of v1.6.1 as the source.