### PR TITLE
docs(readme): overhaul README.md for OSS readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 
 # NVIDIA NCore
 
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![CI](https://github.com/NVIDIA/ncore/actions/workflows/ci.yml/badge.svg)](https://github.com/NVIDIA/ncore/actions/workflows/ci.yml)
+
+NCore provides data representations, APIs, and tools to support data-driven neural reconstructions with a focus on robotics and autonomous vehicle data.
+
+## Key Features
+
+- **Data Specification** -- Standardized and extensible component-based data format for multi-sensor sequences
+- **Data Format / Storage APIs** -- Efficient reading and writing of data components
+- **Sensor Model APIs** -- Camera, lidar, and other sensor model implementations with accurate timestamp models
+
+## Installation
+
+```bash
+pip install nvidia-ncore
+```
+
+## Documentation
+
+Full documentation is available at [nvidia.github.io/ncore](https://nvidia.github.io/ncore/).
 
 ## Contributing
 
@@ -14,3 +33,7 @@ Interested in contributing to NCore? See [CONTRIBUTING.md](CONTRIBUTING.md) for 
 ## Third Party Dependencies
 
 This project will download and install additional third-party open source software as dependencies. Review the license terms of these open source projects before use. See [ATTRIBUTIONS.md](ATTRIBUTIONS.md) for a list of direct dependencies and their licenses.
+
+## License
+
+NCore is provided under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full license text.


### PR DESCRIPTION
## Summary

Overhaul the README.md to follow NVIDIA open-source repository conventions (aligned with NVIDIA/warp, NVIDIA/NeMo, NVIDIA/TensorRT patterns).

### Changes
- Add license badge (Apache 2.0) and CI status badge
- Add project description and key features section (data specification, storage APIs, sensor model APIs)
- Add installation instructions (`pip install nvidia-ncore`)
- Add link to documentation site (nvidia.github.io/ncore)
- Add license section following standard NVIDIA OSS pattern
- Keep existing contributing and third-party dependency sections

### Context
Part of a series of PRs to prepare the repository for open-source release. This PR focuses solely on the README. Other PRs will address:
- Sphinx documentation theme migration to `nvidia_sphinx_theme`
- Documentation metadata fixes
- CHANGELOG.md
- GitHub issue/PR templates