### PR TITLE
docs: fix copyright year and add SIL Lab link in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Welcome to the NCore Documentation!
 NCore provides data representations, APIs, and tools to support data-driven
 neural reconstructions with a focus on robotics / AV data.
 
-The project is developed within the Nvidia SIL Lab.
+The project is developed within the `NVIDIA SIL Lab <https://research.nvidia.com/labs/sil/>`_.
 
 ================================
 


### PR DESCRIPTION
## Summary

- Fix copyright year in `docs/conf.py` from `"2022, NVIDIA"` to `"2022-2026, NVIDIA Corporation & Affiliates"` to be consistent with SPDX headers across the codebase
- Fix `"Nvidia"` capitalization to `"NVIDIA"` in `docs/index.rst`
- Add hyperlink to [NVIDIA SIL Lab](https://research.nvidia.com/labs/sil/) research page in the documentation landing page

### Context
Part of a series of PRs to prepare the repository for open-source release.