### PR TITLE
build(wheel): add stamp-based versioning and cocogitto config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,6 +26,12 @@ build --incompatible_allow_tags_propagation
 # Check the ctime of input files of an action before uploading it to a remote cache (there may be cases where the Linux kernel delays writing of files, which could cause false positives)
 build --guard_against_concurrent_changes
 
+# Wheel version stamping: The py_wheel rule uses {BUILD_EMBED_LABEL} as its version.
+# This default ensures local builds produce a valid (but clearly non-release) version.
+# CI overrides this with the actual version:
+#   bazelisk run --stamp --embed_label=18.6.0 //ncore:ncore_wheel.publish
+build --embed_label=0.0.0.dev0
+
 # Show outputs of failing tests by default
 test --test_output=errors
 

--- a/.cog.toml
+++ b/.cog.toml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Cocogitto configuration for conventional commit-based versioning and changelog generation.
+#
+# Usage:
+#   cog --config .cog.toml check                  # Validate commit messages
+#   cog --config .cog.toml bump --auto --dry-run  # Preview next version
+#   cog --config .cog.toml changelog              # Generate changelog
+#
+# See https://docs.cocogitto.io/reference/config.html
+
+tag_prefix = "v"
+
+# "HEAD" allows usage from jj's detached HEAD mode
+branch_whitelist = ["main", "HEAD"]
+
+[changelog]
+path = "CHANGELOG.md"
+template = "remote"
+remote = "github.com"
+owner = "NVIDIA"
+repository = "ncore"
+
+# Commit types included in the changelog (user-facing changes only).
+# Types not listed here use cocogitto defaults (omitted from changelog).
+[commit_types]
+feat = { changelog_title = "➕ Added", order = 1 }
+fix = { changelog_title = "🪲 Fixed", order = 2 }
+perf = { changelog_title = "⚡ Performance", order = 3 }
+refactor = { changelog_title = "🔄 Changed", order = 4 }
+docs = { changelog_title = "📚 Documentation", order = 5 }
+ci = { changelog_title = "⚙️ CI", order = 6 }
+build = { changelog_title = "🏗️ Build", order = 7 }
+style = { changelog_title = "🎨 Style", order = 8 }
+chore = { changelog_title = "🔧 Chore", order = 9 }
+test = { changelog_title = "🧪 Tests", order = 10 }

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Check conventional commits
         uses: cocogitto/cocogitto-action@9a9fe03b31c47444290c0d7f9b1ee1b44ee13f20
         with:
-          command: check
+          command: "--config .cog.toml check"

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@ _build/
 
 .ci-keep/
 
-# Override global gitignore for .github directory
+# Override global gitignore for dotfiles that must be tracked
 !.github/
+!.cog.toml
 
 # Bazel-specific ignores
 bazel-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the NCore project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - - -
+
 ## [v18.5.0](https://github.com/NVIDIA/ncore/releases/tag/v18.5.0) - 2026-02-17
 #### ➕ Added
 - Initial open-source release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,55 @@ PRs are merged via **rebase only** (no merge commits).
 
 Before submitting your PR, ensure your branch is *rebased* on the latest `main` and is free of merge commits.
 
+## Releases & Versioning
+
+NCore uses [Semantic Versioning](https://semver.org/) with versions determined automatically from [Conventional Commits](https://www.conventionalcommits.org/) via [cocogitto](https://docs.cocogitto.io/).
+
+### Version Source of Truth
+
+The package version is **not hardcoded** in any source file. Instead, it is injected at build time via Bazel's `--embed_label` flag:
+
+```bash
+# Local development (uses default 0.0.0.dev0 from .bazelrc):
+bazelisk build //ncore:ncore_wheel
+
+# Explicit version:
+bazelisk build --embed_label=18.6.0 //ncore:ncore_wheel
+
+# Build + publish (CI):
+bazelisk run --stamp --embed_label=18.6.0 //ncore:ncore_wheel.publish
+```
+
+Git tags (e.g., `v18.5.0`) are the single source of truth for released versions.
+
+### Release Process
+
+Releases are managed by GitHub Actions workflows:
+
+1. An admin triggers the **Prepare Release** workflow (`release.yml`) via `workflow_dispatch`
+2. The workflow computes the next version from conventional commits since the last tag
+3. A release PR is created with an updated `CHANGELOG.md`
+4. The admin reviews and merges the PR
+5. CI detects the release commit, creates a git tag, publishes the wheel, and creates a GitHub Release
+
+### Dev Builds
+
+On-demand development builds can be created via the **Dev Build** workflow (`dev-build.yml`):
+
+1. An admin triggers the workflow via `workflow_dispatch`
+2. The version is computed from `git describe` (e.g., `18.5.0.dev7` for 7 commits after `v18.5.0`)
+3. The wheel is published to Test PyPI with the dev version
+
+### Cocogitto Configuration
+
+Cocogitto is configured via `.cog.toml` in the repository root. All `cog` commands must reference this config:
+
+```bash
+cog --config .cog.toml check                  # Validate commit messages
+cog --config .cog.toml bump --auto --dry-run   # Preview next version
+cog --config .cog.toml changelog               # Generate changelog
+```
+
 ## Commit Signatures
 
 We require that all commits are GPG-signed. This ensures commit authenticity and certifies your agreement with the Developer Certificate of Origin (DCO) below.

--- a/ncore/BUILD.bazel
+++ b/ncore/BUILD.bazel
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 load("@rules_python//python:defs.bzl", "py_library")
-load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
+load("@rules_python//python:packaging.bzl", "py_package", "py_wheel", "py_wheel_dist")
 
 # Proxy library to include PEP 561 type-marker
 py_library(
@@ -66,9 +66,32 @@ py_wheel(
         "typing_extensions",
         "universal_pathlib",
     ],
+    # Version is injected at build time via Bazel's --embed_label flag.
+    # The {BUILD_EMBED_LABEL} placeholder is resolved from --embed_label when
+    # --stamp is enabled. A default of 0.0.0.dev0 is set in .bazelrc for local builds
+    # (see below).
+    #
+    # Examples:
+    #   bazelisk run --stamp --embed_label=v18.6.0 //ncore:ncore_wheel.publish  # publish a release of 18.6.0
+    stamp = 1,
     summary = "A unified data format and library for AV / robotics",
-    version = "18.5.0",
+    version = "{BUILD_EMBED_LABEL}",
     deps = [
         ":ncore_pkg",
     ],
+)
+
+# Produces a dist/ directory containing the wheel with the stamped version in
+# its filename (e.g., bazel-bin/ncore/ncore_wheel_dist/nvidia_ncore-18.6.0-py3-none-any.whl).
+# The base py_wheel target cannot include stamp info in its output filename because Bazel requires
+# deterministic names at analysis time. Use this target when you need the
+# correctly-named wheel file, e.g., for uploading as a GitHub Release artifact.
+#
+# Example:
+#   bazelisk build //ncore:ncore_wheel_dist                                # → 0.0.0.dev0 (default)
+#   bazelisk build --stamp --embed_label=v18.6.0 //ncore:ncore_wheel_dist  # → 18.6.0
+py_wheel_dist(
+    name = "ncore_wheel_dist",
+    out = "dist",
+    wheel = ":ncore_wheel",
 )


### PR DESCRIPTION
## Summary

- Replace hardcoded wheel version (`18.5.0`) with Bazel stamp-based versioning using `{BUILD_EMBED_LABEL}`
- Add `py_wheel_dist` target for correctly-named wheel artifacts (for GitHub Release uploads)
- Add `.cog.toml` cocogitto configuration for automated changelog generation and version computation
- Add default `--embed_label=0.0.0.dev0` in `.bazelrc` for safe local builds
- Update `commit-lint.yml` to use `.cog.toml` config
- Document release process in `CONTRIBUTING.md`

## How Versioning Works

The wheel version is no longer hardcoded. Instead:

```bash
# Local dev build (uses .bazelrc default):
bazelisk build //ncore:ncore_wheel  # → version 0.0.0.dev0

# Explicit version:
bazelisk build --embed_label=18.6.0 //ncore:ncore_wheel  # → version 18.6.0

# CI release publish:
bazelisk run --stamp --embed_label=18.6.0 //ncore:ncore_wheel.publish
```

Git tags are the single source of truth. After merging, a bootstrap tag `v18.5.0` needs to be created.

## Depends On

None (base PR). PR B (release workflows) will depend on this.

## Testing

Validated locally:
- [x] `bazelisk build //ncore:ncore_wheel` → metadata shows `Version: 0.0.0.dev0`
- [x] `bazelisk build --embed_label=18.5.0 //ncore:ncore_wheel` → metadata shows `Version: 18.5.0`
- [x] `bazelisk build --stamp --embed_label=18.5.0 //ncore:ncore_wheel_dist` → produces `dist/nvidia_ncore-18.5.0-py3-none-any.whl`
- [x] `bazelisk build --stamp --embed_label=18.5.0.dev7 //ncore:ncore_wheel_dist` → produces `dist/nvidia_ncore-18.5.0.dev7-py3-none-any.whl`
- [x] `cog --config .cog.toml check` → passes