### PR TITLE
perf(sensors): reduce redundant allocations and kernel launches in se…

### DIFF
--- a/ncore/impl/sensors/camera.py
+++ b/ncore/impl/sensors/camera.py
@@ -656,16 +656,21 @@ class CameraModel(BaseModel, ABC):
         # For valid image points, compute the new timestamp and project again
         image_points_rs_prev = init_image_points[valid, :]
         mean_error_px = 1e12
+
+        # Pre-compute values that are constant across iterations
+        n_valid = int(valid.sum().item())
+        s_quat_expanded = world_sensor_s_quat.expand(n_valid, -1)
+        e_quat_expanded = world_sensor_e_quat.expand(n_valid, -1)
+        trans_start = T_world_sensor_start[:3, 3]  # [3]
+        trans_end = T_world_sensor_end[:3, 3]  # [3]
+
         for _ in range(max_iterations):
             t = self.image_points_relative_frame_times(image_points_rs_prev)
 
-            rot_rs = unitquat_to_rotmat(
-                unitquat_slerp(world_sensor_s_quat.repeat(t.shape[0], 1), world_sensor_e_quat.repeat(t.shape[0], 1), t)
-            )  # [n_valid, 3, 3]
+            rot_rs = unitquat_to_rotmat(unitquat_slerp(s_quat_expanded, e_quat_expanded, t))  # [n_valid, 3, 3]
 
-            trans_rs = (1 - t)[..., None] * T_world_sensor_start[:3, 3:4].transpose(0, 1).repeat(t.shape[0], 1) + t[
-                ..., None
-            ] * T_world_sensor_end[:3, 3:4].transpose(0, 1).repeat(t.shape[0], 1)
+            # Use broadcasting for translation interpolation
+            trans_rs = (1 - t)[..., None] * trans_start + t[..., None] * trans_end
 
             cam_rays_rs = (torch.bmm(rot_rs, world_points[valid, :, None]) + trans_rs[..., None]).squeeze(-1)
             image_points_rs = self.camera_rays_to_image_points(cam_rays_rs)
@@ -939,22 +944,20 @@ class CameraModel(BaseModel, ABC):
         else:
             camera_rays = self.image_points_to_camera_rays(image_points)
 
-        world_positions = T_sensor_world[:3, 3:4].transpose(0, 1).repeat(len(camera_rays), 1)  # [n_image_points, 3]
-
         R_sensor_world = T_sensor_world[:3, :3]  # [3, 3]
 
         world_ray_directions = torch.matmul(R_sensor_world, camera_rays[:, :, None]).squeeze(-1)  # [n_image_points, 3]
 
-        # Copy the values in the output variable
+        # Use broadcasting to expand translation()
         world_rays = torch.empty((len(camera_rays), 6), dtype=self.dtype, device=self.device)
-        world_rays[:, :3] = world_positions
+        world_rays[:, :3] = T_sensor_world[:3, 3]  # broadcasts [3] -> [n_image_points, 3]
         world_rays[:, 3:] = world_ray_directions
 
         return_var = self.WorldRaysReturn(world_rays=world_rays)
 
         if return_T_sensor_worlds:
-            # Repeat constant transformation for all rays
-            return_var.T_sensor_worlds = torch.repeat_interleave(T_sensor_world.unsqueeze(0), len(world_rays), dim=0)
+            # Expand constant transformation for all rays (uses views, avoids copying memory)
+            return_var.T_sensor_worlds = T_sensor_world.unsqueeze(0).expand(len(world_rays), -1, -1).contiguous()
 
         if return_timestamps:
             assert timestamp_us is not None
@@ -1066,12 +1069,17 @@ class CameraModel(BaseModel, ABC):
 
         t = self.image_points_relative_frame_times(image_points)
 
-        world_position_rs = (1 - t)[..., None] * T_sensor_world_start[:3, 3:4].transpose(0, 1).repeat(
-            t.shape[0], 1
-        ) + t[..., None] * T_sensor_world_end[:3, 3:4].transpose(0, 1).repeat(t.shape[0], 1)  # [n_image_points, 3]
+        # Use broadcasting instead of repeat() for translation interpolation
+        trans_start = T_sensor_world_start[:3, 3]  # [3]
+        trans_end = T_sensor_world_end[:3, 3]  # [3]
+        world_position_rs = (1 - t)[..., None] * trans_start + t[..., None] * trans_end  # [n_image_points, 3]
 
         R_sensor_world_rs = unitquat_to_rotmat(
-            unitquat_slerp(R_sensor_world_s_quat.repeat(t.shape[0], 1), R_sensor_world_e_quat.repeat(t.shape[0], 1), t)
+            unitquat_slerp(
+                R_sensor_world_s_quat.expand(t.shape[0], -1),
+                R_sensor_world_e_quat.expand(t.shape[0], -1),
+                t,
+            )
         )  # [n_image_points, 3, 3]
 
         world_ray_directions_rs = torch.bmm(R_sensor_world_rs, camera_rays[:, :, None]).squeeze(

--- a/ncore/impl/sensors/common.py
+++ b/ncore/impl/sensors/common.py
@@ -141,14 +141,14 @@ def eval_poly_inverse_horner_newton(
     assert newton_iterations >= 0, "Newton-iteration number needs to be non-negative"
 
     # Buffers of intermediate results to allow differentiation
-    x_iter = [torch.zeros_like(x) for _ in range(newton_iterations + 1)]
-    x_iter[0] = x
+    # (only allocate entries as needed during iteration)
+    x_iter = [x]
 
     for i in range(newton_iterations):
         # Evaluate single Newton step
         dfdx = eval_poly_horner(poly_derivative_coefficients, x_iter[i])
         residuals = eval_poly_horner(poly_coefficients, x_iter[i]) - y
-        x_iter[i + 1] = x_iter[i] - residuals / dfdx
+        x_iter.append(x_iter[i] - residuals / dfdx)
 
     return x_iter[newton_iterations]
 
@@ -210,19 +210,25 @@ def unitquat_to_rotmat(quat: torch.Tensor) -> torch.Tensor:
     z = quat[..., 2]
     w = quat[..., 3]
 
+    # Pre-compute squared terms to avoid redundant computation (each was previously computed 3 times)
+    x2 = x * x
+    y2 = y * y
+    z2 = z * z
+    w2 = w * w
+
     R = torch.empty(quat.shape[:-1] + (3, 3), dtype=quat.dtype, device=quat.device)
 
-    R[..., 0, 0] = torch.pow(x, 2) - torch.pow(y, 2) - torch.pow(z, 2) + torch.pow(w, 2)
+    R[..., 0, 0] = x2 - y2 - z2 + w2
     R[..., 1, 0] = 2 * (x * y + z * w)
     R[..., 2, 0] = 2 * (x * z - y * w)
 
     R[..., 0, 1] = 2 * (x * y - z * w)
-    R[..., 1, 1] = -torch.pow(x, 2) + torch.pow(y, 2) - torch.pow(z, 2) + torch.pow(w, 2)
+    R[..., 1, 1] = -x2 + y2 - z2 + w2
     R[..., 2, 1] = 2 * (y * z + x * w)
 
     R[..., 0, 2] = 2 * (x * z + y * w)
     R[..., 1, 2] = 2 * (y * z - x * w)
-    R[..., 2, 2] = -torch.pow(x, 2) - torch.pow(y, 2) + torch.pow(z, 2) + torch.pow(w, 2)
+    R[..., 2, 2] = -x2 - y2 + z2 + w2
 
     return R
 

--- a/ncore/impl/sensors/lidar.py
+++ b/ncore/impl/sensors/lidar.py
@@ -517,20 +517,22 @@ class RowOffsetStructuredSpinningLidarModel(StructuredLidarModel):
         relative_time_prev = relative_time[valid].clone()
         mean_relative_time_error = 0.5  # initialize the value to a expected value of random association [0,1]
 
+        # Pre-compute values that are constant across iterations
+        n_valid = int(valid.sum().item())
+        s_quat_expanded = world_sensor_s_quat.expand(n_valid, -1)
+        e_quat_expanded = world_sensor_e_quat.expand(n_valid, -1)
+        trans_start = T_world_sensor_start[:3, 3]  # [3]
+        trans_end = T_world_sensor_end[:3, 3]  # [3]
+
         for _ in range(max_iterations):
             relative_time = self.sensor_angles_relative_frame_times(sensor_angles_rs_prev)  # [n_valid]
 
             rot_rs = unitquat_to_rotmat(
-                unitquat_slerp(
-                    world_sensor_s_quat.repeat(relative_time.shape[0], 1),
-                    world_sensor_e_quat.repeat(relative_time.shape[0], 1),
-                    relative_time,
-                )
+                unitquat_slerp(s_quat_expanded, e_quat_expanded, relative_time)
             )  # [n_valid, 3, 3]
 
-            trans_rs = (1 - relative_time)[..., None] * T_world_sensor_start[:3, 3:4].transpose(0, 1).repeat(
-                relative_time.shape[0], 1
-            ) + relative_time[..., None] * T_world_sensor_end[:3, 3:4].transpose(0, 1).repeat(relative_time.shape[0], 1)
+            # Use broadcasting for translation interpolation
+            trans_rs = (1 - relative_time)[..., None] * trans_start + relative_time[..., None] * trans_end
 
             sensor_angles = self.sensor_rays_to_sensor_angles(
                 (torch.bmm(rot_rs, world_points[valid, :, None]) + trans_rs[..., None]).squeeze(-1), normalized=False
@@ -658,12 +660,17 @@ class RowOffsetStructuredSpinningLidarModel(StructuredLidarModel):
         # (columns are measured in increasing time order irrespective of spin-direction)
         t = elements[:, 1].to(self.dtype) / (self.n_columns - 1)
 
-        world_position_rs = (1 - t)[..., None] * T_sensor_world_start[:3, 3:4].transpose(0, 1).repeat(
-            t.shape[0], 1
-        ) + t[..., None] * T_sensor_world_end[:3, 3:4].transpose(0, 1).repeat(t.shape[0], 1)  # [n_elements, 3]
+        # Use broadcasting for translation interpolation
+        trans_start = T_sensor_world_start[:3, 3]  # [3]
+        trans_end = T_sensor_world_end[:3, 3]  # [3]
+        world_position_rs = (1 - t)[..., None] * trans_start + t[..., None] * trans_end  # [n_elements, 3]
 
         R_sensor_world_rs = unitquat_to_rotmat(
-            unitquat_slerp(R_sensor_world_s_quat.repeat(t.shape[0], 1), R_sensor_world_e_quat.repeat(t.shape[0], 1), t)
+            unitquat_slerp(
+                R_sensor_world_s_quat.expand(t.shape[0], -1),
+                R_sensor_world_e_quat.expand(t.shape[0], -1),
+                t,
+            )
         )  # [n_elements, 3, 3]
 
         world_ray_directions_rs = torch.bmm(R_sensor_world_rs, sensor_rays[:, :, None]).squeeze(-1)  # [n_elements, 3]


### PR DESCRIPTION
## Summary
- Replace `repeat()` with `expand()`/broadcasting for quaternion and translation interpolation in rolling-shutter compensation loops (camera + lidar), avoiding unnecessary memory copies
- Pre-compute squared quaternion components in `unitquat_to_rotmat`, eliminating 8 redundant `torch.pow` calls
- Use lazy list append in `eval_poly_inverse_horner_newton` instead of pre-allocating zero tensors
- Replace `repeat_interleave` with `expand().contiguous()` for constant pose outputs

All existing tests pass (`pytest_camera_3_11`, `pytest_lidar_3_11` with `--config=no-gpu`).