### PR TITLE
ci: support fork CI by falling back to NVIDIA_PACKAGES_TOKEN for GitHub Packages auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           install-pandoc: true
           free-disk-space: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.NVIDIA_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Check code format
         run: bazelisk run format.check
@@ -87,7 +87,7 @@ jobs:
         with:
           install-pandoc: true
           free-disk-space: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.NVIDIA_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Build documentation
         run: bazelisk build //docs:ncore
@@ -130,7 +130,7 @@ jobs:
         with:
           install-pandoc: false
           free-disk-space: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.NVIDIA_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Publish to Test PyPI
         env:


### PR DESCRIPTION
## Summary

- Allows forks to download GitHub Packages (test data, docs assets) from the upstream `NVIDIA/ncore` repo by using a `NVIDIA_PACKAGES_TOKEN` repository secret when available
- Falls back to `GITHUB_TOKEN` on the upstream repo, so no behavior change there
- Added wiki documentation: [Fork CI Setup](https://github.com/NVIDIA/ncore/wiki/Fork-CI-Setup)

## Problem

When CI runs on a fork, the `GITHUB_TOKEN` is scoped to the fork repository, not the upstream. Since `NVIDIA/ncore` is private, the fork's token cannot authenticate against the upstream's GitHub Packages, causing `http_archive` downloads to fail with HTTP 404.

## Solution

Use `secrets.NVIDIA_PACKAGES_TOKEN || secrets.GITHUB_TOKEN` in the workflow. Fork owners create a classic PAT with `read:packages` scope (with SSO authorized for the NVIDIA org) and add it as a `NVIDIA_PACKAGES_TOKEN` repository secret on their fork.

Once `NVIDIA/ncore` becomes public, the PAT is no longer needed — public packages don't require authentication, and the `GITHUB_TOKEN` fallback will work on any fork.

## Changes

- `.github/workflows/ci.yml`: Updated 3 `github-token` parameters (in `build-and-test`, `export-docs`, and `publish-testpypi` jobs) to use the fallback expression