### PR TITLE
docs: fix duplicate data_conversions label in waymo.rst and colmap.rst

### DIFF
--- a/docs/conversions/colmap/colmap.rst
+++ b/docs/conversions/colmap/colmap.rst
@@ -39,7 +39,7 @@ Colmap datasets additionally may expose a single static point cloud of SfM
 points, which are optionally represented in NCore as a single frame of a virtual
 lidar.
 
-.. _data_conversions:
+.. _colmap_data_conversions:
 
 Conversion
 ----------

--- a/docs/conversions/waymo/waymo.rst
+++ b/docs/conversions/waymo/waymo.rst
@@ -42,7 +42,7 @@ LiDAR data includes point clouds with multi-return support (primary and secondar
 For more information, see the `Waymo Open Dataset paper <https://openaccess.thecvf.com/content_CVPR_2020/papers/Sun_Scalability_in_Perception_for_Autonomous_Driving_Waymo_Open_Dataset_CVPR_2020_paper.pdf>`_.
 
 
-.. _data_conversions:
+.. _waymo_data_conversions:
 
 Conversion
 ----------


### PR DESCRIPTION
This pull request updates the documentation to use more specific section anchors for data conversions in the COLMAP and Waymo conversion guides. This helps avoid anchor conflicts and improves documentation clarity.

Documentation improvements:

* Changed the section anchor from `.. _data_conversions:` to `.. _colmap_data_conversions:` in `docs/conversions/colmap/colmap.rst` to provide a unique reference for COLMAP data conversions.
* Changed the section anchor from `.. _data_conversions:` to `.. _waymo_data_conversions:` in `docs/conversions/waymo/waymo.rst` to provide a unique reference for Waymo data conversions.<!--
SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe what this PR does and why. Link to any related issues. -->

## Type of Change

<!-- Check the relevant option(s): -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] My commits are GPG-signed
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally (`bazel test //...`)
- [ ] Code is formatted (`bazel run //:format`)
- [ ] I have updated documentation as needed
- [ ] My changes include SPDX license headers on all new files
