### PR TITLE
fix(ci): Free up disc space also for export docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         uses: ./.github/actions/setup-bazel
         with:
           install-pandoc: true
-          free-disk-space: false
+          free-disk-space: true
           github-token: ${{ secrets.NVIDIA_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Build documentation


### PR DESCRIPTION
This pull request makes a small configuration change to the CI workflow. The `free-disk-space` option is now enabled during the Bazel setup step, which will help free up additional disk space during CI runs.<!--
SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe what this PR does and why. Link to any related issues. -->

## Type of Change

<!-- Check the relevant option(s): -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] My commits are GPG-signed
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally (`bazel test //...`)
- [ ] Code is formatted (`bazel run //:format`)
- [ ] I have updated documentation as needed
- [ ] My changes include SPDX license headers on all new files
