### PR TITLE
refactor(data_converter): make --root-dir optional by introducing FileBasedDataConverter

### DIFF
--- a/docs/conversions/pai/pai.rst
+++ b/docs/conversions/pai/pai.rst
@@ -192,8 +192,9 @@ The output for each clip is written to::
    * - Argument
      - Description
    * - ``--root-dir PATH``
-     - Directory containing clip subdirectories (local mode). Ignored in
-       streaming mode
+     - Directory containing clip subdirectories. Required for file-based
+       converters (e.g. ``pai-v4``); not needed for streaming converters
+       (e.g. ``pai-stream-v4``)
    * - ``--output-dir PATH``
      - Path where converted NCore V4 sequences will be written
 
@@ -283,9 +284,13 @@ API Reference
 **Data Converter** (:mod:`ncore.data_converter`):
 
 - :class:`~ncore.data_converter.BaseDataConverter` - Abstract base class for
-  converters
+  all converters
 - :class:`~ncore.data_converter.BaseDataConverterConfig` - Base configuration
   dataclass
+- :class:`~ncore.data_converter.FileBasedDataConverter` - Abstract base class
+  for converters that read from a local root directory (``--root-dir``)
+- :class:`~ncore.data_converter.FileBasedDataConverterConfig` - Configuration
+  base for file-based converters (validates ``--root-dir``)
 
 **Sensor Models** (:mod:`ncore.data`):
 

--- a/ncore/data_converter/__init__.py
+++ b/ncore/data_converter/__init__.py
@@ -15,10 +15,17 @@
 
 """Package containing common and abstract functionality to implement NCore data-converters"""
 
-from ncore.impl.data_converter.base import BaseDataConverter, BaseDataConverterConfig
+from ncore.impl.data_converter.base import (
+    BaseDataConverter,
+    BaseDataConverterConfig,
+    FileBasedDataConverter,
+    FileBasedDataConverterConfig,
+)
 
 
 __all__ = [
     "BaseDataConverter",
     "BaseDataConverterConfig",
+    "FileBasedDataConverter",
+    "FileBasedDataConverterConfig",
 ]

--- a/ncore/impl/data_converter/base.py
+++ b/ncore/impl/data_converter/base.py
@@ -30,7 +30,6 @@ class BaseDataConverterConfig:
     """Generic data converter parameters"""
 
     ## IO
-    root_dir: str  # Path to the raw data sequences
     output_dir: str  # Path where the converted data will be saved
 
     ## Sensor selection
@@ -61,7 +60,6 @@ class BaseDataConverter(ABC):
     def __init__(self, config: BaseDataConverterConfig) -> None:
         self.logger = logging.getLogger(__name__)
 
-        self.root_dir = UPath(config.root_dir)
         self.output_dir = UPath(config.output_dir)
 
         # External sensor selection overwrites
@@ -155,3 +153,35 @@ class BaseDataConverter(ABC):
         Runs dataset-specific conversion for a sequence referenced by a directory/file path
         """
         pass
+
+
+@dataclass(**({"slots": True, "kw_only": True} if sys.version_info >= (3, 10) else {}))
+class FileBasedDataConverterConfig(BaseDataConverterConfig):
+    """Config for converters that read from a local root directory.
+
+    Subclass this instead of :class:`BaseDataConverterConfig` when the
+    converter discovers its input sequences from ``--root-dir``.
+    """
+
+    ## IO
+    root_dir: str  # Path to the raw data sequences
+
+    def __post_init__(self) -> None:
+        if not self.root_dir:
+            raise ValueError(
+                "--root-dir is required for this converter but was not provided. "
+                "Please supply a path to the raw data sequences."
+            )
+
+
+class FileBasedDataConverter(BaseDataConverter):
+    """Base class for converters that read source data from a local root directory.
+
+    Subclass this instead of :class:`BaseDataConverter` when the converter needs
+    ``self.root_dir``.  Pair with :class:`FileBasedDataConverterConfig` (or a
+    subclass of it) to get early validation of ``root_dir``.
+    """
+
+    def __init__(self, config: FileBasedDataConverterConfig) -> None:
+        super().__init__(config)
+        self.root_dir = UPath(config.root_dir)

--- a/ncore/impl/data_converter/base.py
+++ b/ncore/impl/data_converter/base.py
@@ -120,22 +120,22 @@ class BaseDataConverter(ABC):
 
         logger = logging.getLogger(__name__)
 
-        sequence_dirs = cls.get_sequence_paths(config)
+        sequence_ids = cls.get_sequence_ids(config)
 
-        logger.info(f"Start converting {sequence_dirs} ...")
+        logger.info(f"Start converting {sequence_ids} ...")
 
         # create new instance of converter for each task and execute synchronously
-        for sequence_dir in sequence_dirs:
+        for sequence_id in sequence_ids:
             converter = cls.from_config(config)
-            converter.convert_sequence(sequence_dir)
+            converter.convert_sequence(sequence_id)
 
-        logger.info(f"Finished converting {sequence_dirs} in {config.output_dir} ...")
+        logger.info(f"Finished converting {sequence_ids} in {config.output_dir} ...")
 
     @staticmethod
     @abstractmethod
-    def get_sequence_paths(config) -> list[UPath]:
+    def get_sequence_ids(config) -> list[str]:
         """
-        Return sequence pathnames to process
+        Return dataset-specific sequence IDs (e.g., path names) to process
         """
         pass
 
@@ -148,9 +148,9 @@ class BaseDataConverter(ABC):
         pass
 
     @abstractmethod
-    def convert_sequence(self, sequence_path: UPath) -> None:
+    def convert_sequence(self, sequence_id: str) -> None:
         """
-        Runs dataset-specific conversion for a sequence referenced by a directory/file path
+        Runs dataset-specific conversion for a sequence referenced by a sequence ID
         """
         pass
 

--- a/tools/data_converter/BUILD.bazel
+++ b/tools/data_converter/BUILD.bazel
@@ -27,7 +27,6 @@ py_library(
         "cli.py",
     ],
     deps = [
-        "//ncore/impl/data_converter:pylib_base",
         "//tools:pylib_debug",
         requirement("click"),
     ],

--- a/tools/data_converter/cli.py
+++ b/tools/data_converter/cli.py
@@ -15,9 +15,9 @@
 
 import logging
 
-import click
+from types import SimpleNamespace
 
-from ncore.impl.data_converter.base import BaseDataConverterConfig
+import click
 
 
 try:
@@ -32,7 +32,12 @@ except ImportError:
 
 
 @click.group()
-@click.option("--root-dir", type=str, help="Path to the raw data sequences", required=True)
+@click.option(
+    "--root-dir",
+    type=str,
+    default=None,
+    help="Path to the raw data sequences (required for file-based converters only)",
+)
 @click.option("--output-dir", type=str, help="Path where the converted data will be saved", required=True)
 @click.option("--verbose", is_flag=True, default=False, help="Enables debug logging outputs")
 @click.option("--debug", is_flag=True, default=False, help="Start a debugpy remote debugging sessions to listen on")
@@ -80,10 +85,11 @@ def cli(ctx, *_, **kwargs):
       --output-dir <FOLDER DATA WILL BE PRODUCED>
       <your-data-variant>
     """
-    # Create a config object and remember it as the context object. From
+
+    # Create a config dict-like object and remember it as the context object. From
     # this point onwards other commands can refer to it by using the
     # @click.pass_context decorator.
-    ctx.obj = BaseDataConverterConfig(**kwargs)
+    ctx.obj = SimpleNamespace(**kwargs)
 
     # Initialize basic top-level logger configuration
     logging.basicConfig(

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 import logging
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from typing import Literal
 
 import click
@@ -39,7 +39,7 @@ from ncore.data.v4 import (
     SequenceComponentGroupsReader,
     SequenceComponentGroupsWriter,
 )
-from ncore.data_converter import BaseDataConverter, BaseDataConverterConfig
+from ncore.data_converter import FileBasedDataConverter, FileBasedDataConverterConfig
 from ncore.impl.common.transformations import HalfClosedInterval
 from ncore.impl.data.types import JsonLike, OpenCVPinholeCameraModelParameters, ShutterType
 from ncore.impl.data.v4.types import ComponentGroupAssignments
@@ -47,7 +47,7 @@ from tools.data_converter.cli import cli
 
 
 @dataclass(kw_only=True, slots=True)
-class ColmapConverter4Config(BaseDataConverterConfig):
+class ColmapConverter4Config(FileBasedDataConverterConfig):
     """Configuration for COLMAP to NCore V4 conversion."""
 
     store_type: Literal["itar", "directory"] = "itar"
@@ -141,7 +141,7 @@ class ColmapCamera:
         )
 
 
-class ColmapDataConverter(BaseDataConverter):
+class ColmapDataConverter(FileBasedDataConverter):
     """
     NVIDIA-specific data conversion from COLMAP reconstructions to NCore V4 using the V4 components/writer APIs.
     """
@@ -176,7 +176,7 @@ class ColmapDataConverter(BaseDataConverter):
             return [UPath(config.root_dir)]
 
     @staticmethod
-    def from_config(config) -> ColmapDataConverter:
+    def from_config(config: ColmapConverter4Config) -> ColmapDataConverter:
         """Create a ColmapDataConverter instance from a configuration object."""
         return ColmapDataConverter(config)
 
@@ -500,7 +500,7 @@ def colmap_v4(ctx, *_, **kwargs):
     """Colmap-specific data conversion (V4 format)"""
 
     # Extend base config with command-specific options
-    config = ColmapConverter4Config(**{**asdict(ctx.obj), **kwargs})
+    config = ColmapConverter4Config(**{**vars(ctx.obj), **kwargs})
 
     ColmapDataConverter.convert(config)
 

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -165,25 +165,27 @@ class ColmapDataConverter(FileBasedDataConverter):
         self.logger = logging.getLogger(__name__)
 
     @staticmethod
-    def get_sequence_paths(config) -> list[UPath]:
+    def get_sequence_ids(config: ColmapConverter4Config) -> list[str]:
         """Get sequence paths from config.
 
         If root_dir is a directory, return all subdirectories as sequences. If root_dir is a single sequence, return it as the only sequence."""
 
         if str(config.root_dir).endswith("/"):
-            return [p for p in UPath(config.root_dir).iterdir() if p.is_dir()]
+            return [str(p) for p in UPath(config.root_dir).iterdir() if p.is_dir()]
         else:
-            return [UPath(config.root_dir)]
+            return [str(UPath(config.root_dir))]
 
     @staticmethod
     def from_config(config: ColmapConverter4Config) -> ColmapDataConverter:
         """Create a ColmapDataConverter instance from a configuration object."""
         return ColmapDataConverter(config)
 
-    def convert_sequence(self, sequence_path: UPath) -> None:
+    def convert_sequence(self, sequence_id: str) -> None:
         """
         Runs the conversion of a single sequence
         """
+
+        sequence_path = UPath(sequence_id)
 
         self.logger.info(f"Processing sequence: {sequence_path}")
 

--- a/tools/data_converter/pai/README.md
+++ b/tools/data_converter/pai/README.md
@@ -14,7 +14,7 @@ Convert clip data from the [NVIDIA PhysicalAI-Autonomous-Vehicles](https://huggi
 
   ```bash
   export HF_TOKEN=hf_...
-  # or pass --token hf_... / --hf-token hf_... to individual commands
+  # or pass --hf-token hf_... to individual commands
   ```
 
 ## Dataset Overview

--- a/tools/data_converter/pai/README.md
+++ b/tools/data_converter/pai/README.md
@@ -143,12 +143,11 @@ bazel run //tools/data_converter/pai:convert -- \
 
 ### Streaming mode (`pai-stream-v4`)
 
-Convert clips directly from HuggingFace without a prior download. `--root-dir` is required by
-the base CLI but ignored in this mode. `--clip-id` is required.
+Convert clips directly from HuggingFace without a prior download. `--root-dir` is **not**
+required for this mode. `--clip-id` is required.
 
 ```bash
 bazel run //tools/data_converter/pai:convert -- \
-    --root-dir /tmp/unused \
     --output-dir /path/to/output \
     pai-stream-v4 \
     --clip-id <clip-id> \

--- a/tools/data_converter/pai/converter.py
+++ b/tools/data_converter/pai/converter.py
@@ -58,7 +58,12 @@ from ncore.data.v4 import (
     SequenceComponentGroupsReader,
     SequenceComponentGroupsWriter,
 )
-from ncore.data_converter import BaseDataConverter, BaseDataConverterConfig, FileBasedDataConverter
+from ncore.data_converter import (
+    BaseDataConverter,
+    BaseDataConverterConfig,
+    FileBasedDataConverter,
+    FileBasedDataConverterConfig,
+)
 from ncore.impl.common.transformations import HalfClosedInterval, se3_inverse, time_bounds
 from ncore.impl.data.types import (
     BBox3,
@@ -92,19 +97,36 @@ CONVERTER_VERSION = "1.0.0"
 
 
 @dataclass(kw_only=True, slots=True)
-class PaiConverter4Config(BaseDataConverterConfig):
-    """Shared Configuration for PAI to NCore V4 conversion."""
+class PaiLocalConverterConfig(FileBasedDataConverterConfig):
+    """Configuration for local PAI conversion (``pai-v4``).
 
-    root_dir: Optional[str] = None  # not used in streaming converter, but kept for CLI compatibility
+    Inherits :class:`FileBasedDataConverterConfig` so ``root_dir`` is required
+    and validated at construction time.
+    """
+
     seek_sec: float | None = None
     duration_sec: float | None = None
     clip_id: list[str] = field(default_factory=list)
     store_type: Literal["itar", "directory"] = "itar"
     component_group_profile: Literal["default", "separate-sensors", "separate-all"] = "separate-sensors"
     store_sequence_meta: bool = True
-    make_provider: Optional[Callable[[str], ClipDataProvider]] = (
-        None  # to be set by caller with appropriate provider factory
-    )
+
+
+@dataclass(kw_only=True, slots=True)
+class PaiStreamConverterConfig(BaseDataConverterConfig):
+    """Configuration for streaming PAI conversion (``pai-stream-v4``).
+
+    Does **not** require ``root_dir``.  The ``make_provider`` callable is used
+    to create a :class:`ClipDataProvider` for each clip at conversion time.
+    """
+
+    seek_sec: float | None = None
+    duration_sec: float | None = None
+    clip_id: list[str] = field(default_factory=list)
+    store_type: Literal["itar", "directory"] = "itar"
+    component_group_profile: Literal["default", "separate-sensors", "separate-all"] = "separate-sensors"
+    store_sequence_meta: bool = True
+    make_provider: Callable[[str], ClipDataProvider]  # factory: clip_id -> provider
 
 
 class _PaiConversionMixin:
@@ -649,7 +671,7 @@ class PaiConverter(_PaiConversionMixin, FileBasedDataConverter):
     containing clip subdirectories.
     """
 
-    def __init__(self, config) -> None:
+    def __init__(self, config: PaiLocalConverterConfig) -> None:
         super().__init__(config)
         self._init_pai_fields(config)
 
@@ -691,7 +713,7 @@ class PaiStreamConverter(_PaiConversionMixin, BaseDataConverter):
     Does **not** require ``--root-dir``.
     """
 
-    def __init__(self, config) -> None:
+    def __init__(self, config: PaiStreamConverterConfig) -> None:
         super().__init__(config)
         self._init_pai_fields(config)
         self._make_provider = config.make_provider
@@ -786,9 +808,7 @@ def pai_v4(ctx, *_, **kwargs):
     config = vars(ctx.obj)
     config.update(kwargs)
 
-    assert config["root_dir"] is not None, "--root-dir is required for pai-v4"
-
-    PaiConverter.convert(PaiConverter4Config(**config))
+    PaiConverter.convert(PaiLocalConverterConfig(**config))
 
 
 @cli.command("pai-stream-v4")
@@ -819,7 +839,7 @@ def pai_stream_v4(ctx, *_, **kwargs):
     revision = kwargs.pop("revision")
 
     config = vars(ctx.obj)
-    config.pop("root_dir", None)  # not used in streaming converter
+    config.pop("root_dir", None)  # not a field on PaiStreamConverterConfig
     config.update(kwargs)
 
     clip_ids = config.get("clip_id", ())
@@ -847,7 +867,7 @@ def pai_stream_v4(ctx, *_, **kwargs):
 
         config["make_provider"] = make_provider
 
-        PaiStreamConverter.convert(PaiConverter4Config(**config))
+        PaiStreamConverter.convert(PaiStreamConverterConfig(**config))
 
 
 if __name__ == "__main__":

--- a/tools/data_converter/pai/converter.py
+++ b/tools/data_converter/pai/converter.py
@@ -29,14 +29,15 @@ LIMITATIONS:
   - Cameras are in MP4 format (frames extracted to JPEG)
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import tempfile
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
-from types import SimpleNamespace
-from typing import Dict, Literal, cast
+from typing import Callable, Dict, Literal, Optional, cast
 
 import click
 import DracoPy
@@ -57,7 +58,7 @@ from ncore.data.v4 import (
     SequenceComponentGroupsReader,
     SequenceComponentGroupsWriter,
 )
-from ncore.data_converter import BaseDataConverter, BaseDataConverterConfig
+from ncore.data_converter import BaseDataConverter, BaseDataConverterConfig, FileBasedDataConverter
 from ncore.impl.common.transformations import HalfClosedInterval, se3_inverse, time_bounds
 from ncore.impl.data.types import (
     BBox3,
@@ -94,85 +95,39 @@ CONVERTER_VERSION = "1.0.0"
 class PaiConverter4Config(BaseDataConverterConfig):
     """Shared Configuration for PAI to NCore V4 conversion."""
 
+    root_dir: Optional[str] = None  # not used in streaming converter, but kept for CLI compatibility
     seek_sec: float | None = None
     duration_sec: float | None = None
     clip_id: list[str] = field(default_factory=list)
     store_type: Literal["itar", "directory"] = "itar"
     component_group_profile: Literal["default", "separate-sensors", "separate-all"] = "separate-sensors"
     store_sequence_meta: bool = True
+    make_provider: Optional[Callable[[str], ClipDataProvider]] = (
+        None  # to be set by caller with appropriate provider factory
+    )
 
 
-pai_shared_options = [
-    click.option(
-        "--seek-sec",
-        default=None,
-        type=click.FloatRange(min=0.0, max_open=True),
-        help="Time to skip for the dataset conversion (in seconds)",
-    ),
-    click.option(
-        "--duration-sec",
-        default=None,
-        type=click.FloatRange(min=0.0, max_open=True),
-        help="Restrict total duration of the dataset conversion (in seconds)",
-    ),
-    click.option(
-        "--clip-id",
-        multiple=True,
-        type=str,
-        default=[],
-        help="Specific clip ID(s) to convert. If not specified, converts all clip directories found under root-dir.",
-    ),
-    click.option(
-        "--store-type",
-        type=click.Choice(["itar", "directory"], case_sensitive=False),
-        default="itar",
-        show_default=True,
-        help="Output store type",
-    ),
-    click.option(
-        "component_group_profile",
-        "--profile",
-        type=click.Choice(["default", "separate-sensors", "separate-all"], case_sensitive=False),
-        default="separate-sensors",
-        show_default=True,
-        help="""Output profile, one of:
-        - "default": All components defaults or overrides
-        - "separate-sensors": Each sensor gets its own group named "<sensor_id>", remaining components use overrides
-        - "separate-all": Each component type gets its own group named after the component type, e.g. "poses", "intrinsics", respecting overwrites if provided""",
-    ),
-    click.option(
-        "store_sequence_meta", "--sequence-meta/--no-sequence-meta", default=True, help="Generate sequence meta-data?"
-    ),
-]
+class _PaiConversionMixin:
+    """Shared conversion logic for PAI data converters.
 
+    This mixin contains all the sensor decoding, metadata loading, and data
+    writing logic shared between :class:`PaiConverter` (local file-based) and
+    :class:`PaiStreamConverter` (HuggingFace streaming).
 
-def apply_options(options):
-    """Decorator that applies a list of click options to a command."""
-
-    def decorator(func):
-        for option in reversed(options):
-            func = option(func)
-        return func
-
-    return decorator
-
-
-class PaiConverter(BaseDataConverter):
+    Subclasses must set ``self.provider`` (a :class:`ClipDataProvider`) before
+    the body of :meth:`_convert_clip` runs.
     """
-    Dataset preprocessing class for converting Physical AI data to NCore canonical format.
 
-    Handles:
-    - 7 cameras: camera_cross_left/right_120fov, camera_front_tele_30fov/wide_120fov,
-                 camera_rear_left/right_70fov, camera_rear_tele_30fov
-    - 1 lidar: lidar_top_360fov
-    - Egomotion trajectory
-    - Vehicle dimensions
-    - Cuboid obstacle labels
+    # -- Type stubs for attributes provided by concrete subclasses / base classes --
+    # These are not set here; they exist on the concrete classes via their
+    # BaseDataConverter (or FileBasedDataConverter) parent.
+    logger: logging.Logger
+    output_dir: UPath
+    provider: ClipDataProvider
 
-    The converter uses a :class:`ClipDataProvider` abstraction for data access,
-    allowing the same conversion logic to work with local files (``pai-v4``)
-    or streaming from HuggingFace (``pai-stream-v4``).
-    """
+    # Methods from BaseDataConverter that the mixin calls
+    get_active_camera_ids: Callable[..., list[str]]
+    get_active_lidar_ids: Callable[..., list[str]]
 
     # Camera sensor mapping
     CAMERA_SENSORS = [
@@ -190,9 +145,8 @@ class PaiConverter(BaseDataConverter):
         "lidar_top_360fov",
     ]
 
-    def __init__(self, config: PaiConverter4Config):
-        super().__init__(config)
-        self.logger = logging.getLogger(__name__)
+    def _init_pai_fields(self, config) -> None:
+        """Initialise PAI-specific fields from *config* (a namespace or dataclass)."""
         self.seek_sec: float | None = config.seek_sec
         self.duration_sec: float | None = config.duration_sec
         self.store_type: Literal["itar", "directory"] = config.store_type
@@ -201,65 +155,14 @@ class PaiConverter(BaseDataConverter):
         )
         self.store_sequence_meta = config.store_sequence_meta
 
-        # Optional provider factory: callable(clip_id) -> ClipDataProvider.
-        # When set (e.g. by pai-stream-v4), the converter uses this instead of
-        # constructing a LocalClipDataProvider from self.root_dir.
-        self._make_provider = getattr(config, "make_provider", None)
+    def _convert_clip(self, clip_id: str) -> None:
+        """Run the full conversion pipeline for a single clip.
 
-    @staticmethod
-    def get_sequence_paths(config) -> list[UPath]:
-        """Return list of clips to process.
-
-        For local mode (``pai-v4``): lists subdirectories under ``root_dir``.
-        For streaming mode (``pai-stream-v4``): returns the clip IDs from config directly.
+        ``self.provider`` must already be set to the appropriate
+        :class:`ClipDataProvider` before calling this method.
         """
-        # Streaming mode: clip IDs are provided directly via config
-        if hasattr(config, "make_provider") and config.make_provider is not None:
-            clip_ids = list(config.clip_id)
-            if not clip_ids:
-                raise ValueError("--clip-id is required for streaming mode")
-            return [UPath(cid) for cid in clip_ids]
-
-        # Local mode: discover clips by listing subdirectories
-        data_root = UPath(config.root_dir)
-        clip_ids = sorted(d.name for d in data_root.iterdir() if d.is_dir())
-
-        if not clip_ids:
-            raise FileNotFoundError(f"No clip directories found under {data_root}")
-
-        # Filter by specific clip IDs if provided
-        if hasattr(config, "clip_id") and config.clip_id:
-            requested_ids = set(config.clip_id)
-            found_ids = set(clip_ids)
-            missing_ids = requested_ids - found_ids
-            if missing_ids:
-                logger.warning(f"Clip IDs not found under {data_root}: {missing_ids}")
-            clip_ids = [c for c in clip_ids if c in requested_ids]
-
-        return [UPath(clip_id) for clip_id in clip_ids]
-
-    @staticmethod
-    def from_config(config) -> "PaiConverter":
-        """Return an instance of the data converter"""
-        return PaiConverter(config)
-
-    def convert_sequence(self, sequence_path: UPath) -> None:
-        """
-        Runs the conversion of a single clip (sequence in NCore terminology)
-        """
-
-        # Decode clip_id from the path (directory name)
-        clip_id = str(sequence_path)
         self.clip_id = clip_id
-
         self.logger.info(f"Converting clip {clip_id}")
-
-        # Create data provider for this clip
-        if self._make_provider is not None:
-            self.provider: ClipDataProvider = self._make_provider(clip_id)
-        else:
-            clip_dir = self.root_dir / clip_id
-            self.provider = LocalClipDataProvider(clip_dir, clip_id)
 
         # Load calibration and metadata
         try:
@@ -734,6 +637,84 @@ class PaiConverter(BaseDataConverter):
 
 
 # ---------------------------------------------------------------------------
+# Concrete converter classes
+# ---------------------------------------------------------------------------
+
+
+class PaiConverter(_PaiConversionMixin, FileBasedDataConverter):
+    """PAI data converter for local files (``pai-v4``).
+
+    Reads clip data from a local root directory previously downloaded with
+    the ``pai-clip-dl`` tool.  ``--root-dir`` must point to the directory
+    containing clip subdirectories.
+    """
+
+    def __init__(self, config) -> None:
+        super().__init__(config)
+        self._init_pai_fields(config)
+
+    @staticmethod
+    def get_sequence_paths(config) -> list[UPath]:
+        """Discover clips by listing subdirectories under ``root_dir``."""
+        data_root = UPath(config.root_dir)
+        clip_ids = sorted(d.name for d in data_root.iterdir() if d.is_dir())
+
+        if not clip_ids:
+            raise FileNotFoundError(f"No clip directories found under {data_root}")
+
+        # Filter by specific clip IDs if provided
+        if hasattr(config, "clip_id") and config.clip_id:
+            requested_ids = set(config.clip_id)
+            found_ids = set(clip_ids)
+            missing_ids = requested_ids - found_ids
+            if missing_ids:
+                logger.warning(f"Clip IDs not found under {data_root}: {missing_ids}")
+            clip_ids = [c for c in clip_ids if c in requested_ids]
+
+        return [UPath(clip_id) for clip_id in clip_ids]
+
+    @staticmethod
+    def from_config(config) -> PaiConverter:
+        return PaiConverter(config)
+
+    def convert_sequence(self, sequence_path: UPath) -> None:
+        clip_id = str(sequence_path)
+        clip_dir = self.root_dir / clip_id
+        self.provider: ClipDataProvider = LocalClipDataProvider(clip_dir, clip_id)
+        self._convert_clip(clip_id)
+
+
+class PaiStreamConverter(_PaiConversionMixin, BaseDataConverter):
+    """PAI data converter for HuggingFace streaming (``pai-stream-v4``).
+
+    Converts PAI clips directly from HuggingFace without prior download.
+    Does **not** require ``--root-dir``.
+    """
+
+    def __init__(self, config) -> None:
+        super().__init__(config)
+        self._init_pai_fields(config)
+        self._make_provider = config.make_provider
+
+    @staticmethod
+    def get_sequence_paths(config) -> list[UPath]:
+        """Return clip IDs provided via ``--clip-id``."""
+        clip_ids = list(config.clip_id)
+        if not clip_ids:
+            raise ValueError("--clip-id is required for streaming mode")
+        return [UPath(cid) for cid in clip_ids]
+
+    @staticmethod
+    def from_config(config) -> PaiStreamConverter:
+        return PaiStreamConverter(config)
+
+    def convert_sequence(self, sequence_path: UPath) -> None:
+        clip_id = str(sequence_path)
+        self.provider: ClipDataProvider = self._make_provider(clip_id)
+        self._convert_clip(clip_id)
+
+
+# ---------------------------------------------------------------------------
 # Shared PAI options (used by both pai-v4 and pai-stream-v4)
 # ---------------------------------------------------------------------------
 
@@ -799,13 +780,15 @@ def pai_v4(ctx, *_, **kwargs):
     """Physical AI data conversion (local pai-clip-dl output)
 
     Converts PAI clips previously downloaded with the pai-clip-dl tool.
-    --root-dir should point to the directory containing clip subdirectories.
+    --root-dir must point to the directory containing clip subdirectories.
     """
 
-    config = asdict(ctx.obj)
+    config = vars(ctx.obj)
     config.update(kwargs)
 
-    PaiConverter.convert(SimpleNamespace(**config))
+    assert config["root_dir"] is not None, "--root-dir is required for pai-v4"
+
+    PaiConverter.convert(PaiConverter4Config(**config))
 
 
 @cli.command("pai-stream-v4")
@@ -829,13 +812,14 @@ def pai_stream_v4(ctx, *_, **kwargs):
     """Physical AI data conversion (streaming from HuggingFace)
 
     Converts PAI clips directly from HuggingFace without prior download.
-    --clip-id is required.  --root-dir is ignored (set to any placeholder).
+    --clip-id is required.  --root-dir is not needed.
     """
 
     hf_token = kwargs.pop("hf_token")
     revision = kwargs.pop("revision")
 
-    config = asdict(ctx.obj)
+    config = vars(ctx.obj)
+    config.pop("root_dir", None)  # not used in streaming converter
     config.update(kwargs)
 
     clip_ids = config.get("clip_id", ())
@@ -863,7 +847,7 @@ def pai_stream_v4(ctx, *_, **kwargs):
 
         config["make_provider"] = make_provider
 
-        PaiConverter.convert(SimpleNamespace(**config))
+        PaiStreamConverter.convert(PaiConverter4Config(**config))
 
 
 if __name__ == "__main__":

--- a/tools/data_converter/pai/converter.py
+++ b/tools/data_converter/pai/converter.py
@@ -654,7 +654,7 @@ class PaiConverter(_PaiConversionMixin, FileBasedDataConverter):
         self._init_pai_fields(config)
 
     @staticmethod
-    def get_sequence_paths(config) -> list[UPath]:
+    def get_sequence_ids(config) -> list[str]:
         """Discover clips by listing subdirectories under ``root_dir``."""
         data_root = UPath(config.root_dir)
         clip_ids = sorted(d.name for d in data_root.iterdir() if d.is_dir())
@@ -671,14 +671,14 @@ class PaiConverter(_PaiConversionMixin, FileBasedDataConverter):
                 logger.warning(f"Clip IDs not found under {data_root}: {missing_ids}")
             clip_ids = [c for c in clip_ids if c in requested_ids]
 
-        return [UPath(clip_id) for clip_id in clip_ids]
+        return clip_ids
 
     @staticmethod
     def from_config(config) -> PaiConverter:
         return PaiConverter(config)
 
-    def convert_sequence(self, sequence_path: UPath) -> None:
-        clip_id = str(sequence_path)
+    def convert_sequence(self, sequence_id: str) -> None:
+        clip_id = sequence_id
         clip_dir = self.root_dir / clip_id
         self.provider: ClipDataProvider = LocalClipDataProvider(clip_dir, clip_id)
         self._convert_clip(clip_id)
@@ -697,19 +697,19 @@ class PaiStreamConverter(_PaiConversionMixin, BaseDataConverter):
         self._make_provider = config.make_provider
 
     @staticmethod
-    def get_sequence_paths(config) -> list[UPath]:
+    def get_sequence_ids(config) -> list[str]:
         """Return clip IDs provided via ``--clip-id``."""
-        clip_ids = list(config.clip_id)
+        clip_ids: list[str] = list(config.clip_id)
         if not clip_ids:
             raise ValueError("--clip-id is required for streaming mode")
-        return [UPath(cid) for cid in clip_ids]
+        return clip_ids
 
     @staticmethod
     def from_config(config) -> PaiStreamConverter:
         return PaiStreamConverter(config)
 
-    def convert_sequence(self, sequence_path: UPath) -> None:
-        clip_id = str(sequence_path)
+    def convert_sequence(self, sequence_id: str) -> None:
+        clip_id = sequence_id
         self.provider: ClipDataProvider = self._make_provider(clip_id)
         self._convert_clip(clip_id)
 

--- a/tools/data_converter/pai/pai_remote/cli.py
+++ b/tools/data_converter/pai/pai_remote/cli.py
@@ -80,7 +80,7 @@ def main() -> None:
     help="Root output directory. Files are written to OUTPUT_DIR/CLIP_ID/.",
 )
 @click.option("--features", "-f", multiple=True, help="Feature names to download. Repeat for multiple. Default: all.")
-@click.option("--token", envvar="HF_TOKEN", help="HuggingFace API token.")
+@click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
 @click.option("--revision", default="main", help="Git branch/revision of the dataset.")
 @click.option("--no-skip-missing", is_flag=True, default=False, help="Don't skip features where the sensor is absent.")
 @click.option("--no-metadata", is_flag=True, default=False, help="Skip downloading metadata parquets.")
@@ -89,7 +89,7 @@ def download(
     clip_ids: tuple[str, ...],
     output_dir: Path,
     features: tuple[str, ...],
-    token: str | None,
+    hf_token: str | None,
     revision: str,
     no_skip_missing: bool,
     no_metadata: bool,
@@ -101,7 +101,7 @@ def download(
     same chunk are batched so each remote zip is opened only once.
     """
     _setup_logging(verbose)
-    config, remote, index = _make_components(token, revision)
+    _, remote, index = _make_components(hf_token, revision)
 
     valid = _validate_clip_ids(index, list(clip_ids))
     if not valid:
@@ -120,13 +120,13 @@ def download(
 
 @main.command()
 @click.argument("clip_ids", nargs=-1, required=True)
-@click.option("--token", envvar="HF_TOKEN", help="HuggingFace API token.")
+@click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
 @click.option("--revision", default="main", help="Git branch/revision of the dataset.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
-def info(clip_ids: tuple[str, ...], token: str | None, revision: str, verbose: bool) -> None:
+def info(clip_ids: tuple[str, ...], hf_token: str | None, revision: str, verbose: bool) -> None:
     """Show information about one or more clips (chunk, split, sensors)."""
     _setup_logging(verbose)
-    config, remote, index = _make_components(token, revision)
+    _, _, index = _make_components(hf_token, revision)
 
     valid = _validate_clip_ids(index, list(clip_ids))
     if not valid:
@@ -155,13 +155,13 @@ def info(clip_ids: tuple[str, ...], token: str | None, revision: str, verbose: b
 
 
 @main.command("list-features")
-@click.option("--token", envvar="HF_TOKEN", help="HuggingFace API token.")
+@click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
 @click.option("--revision", default="main", help="Git branch/revision of the dataset.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
-def list_features(token: str | None, revision: str, verbose: bool) -> None:
+def list_features(hf_token: str | None, revision: str, verbose: bool) -> None:
     """List all available features in the dataset."""
     _setup_logging(verbose)
-    config, remote, index = _make_components(token, revision)
+    _, _, index = _make_components(hf_token, revision)
 
     table = Table(title="Available Features")
     table.add_column("Feature", style="cyan")
@@ -186,7 +186,7 @@ def list_features(token: str | None, revision: str, verbose: bool) -> None:
 @click.option(
     "--output", "-o", type=click.Path(path_type=Path), default=None, help="Save output to file instead of stdout."
 )
-@click.option("--token", envvar="HF_TOKEN", help="HuggingFace API token.")
+@click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
 @click.option("--revision", default="main", help="Git branch/revision of the dataset.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
 def stream(
@@ -194,7 +194,7 @@ def stream(
     feature: str,
     filename: str | None,
     output: Path | None,
-    token: str | None,
+    hf_token: str | None,
     revision: str,
     verbose: bool,
 ) -> None:
@@ -203,7 +203,7 @@ def stream(
     If --file is not given, lists the clip's files in the zip archive.
     """
     _setup_logging(verbose)
-    config, remote, index = _make_components(token, revision)
+    _, remote, index = _make_components(hf_token, revision)
 
     if not index.clip_exists(clip_id):
         console.print(f"[red]Error:[/red] clip_id {clip_id!r} not found in index.")

--- a/tools/data_converter/waymo/converter.py
+++ b/tools/data_converter/waymo/converter.py
@@ -119,16 +119,19 @@ class WaymoConverter4(FileBasedDataConverter):
         self.logger = logging.getLogger(__name__)
 
     @staticmethod
-    def get_sequence_paths(config) -> list[UPath]:
-        return [p for p in sorted(UPath(config.root_dir).glob("*.tfrecord"))]
+    def get_sequence_ids(config) -> list[str]:
+        return [str(p) for p in sorted(UPath(config.root_dir).glob("*.tfrecord"))]
 
     @staticmethod
     def from_config(config: WaymoConverter4Config) -> WaymoConverter4:
         return WaymoConverter4(config)
 
-    def convert_sequence(self, sequence_path: UPath) -> None:
+    def convert_sequence(self, sequence_id: str) -> None:
         """Runs dataset-specific conversion for a sequence."""
-        self.logger.info(sequence_path)
+
+        sequence_path = UPath(sequence_id)
+
+        self.logger.info(sequence_id)
 
         dataset = tf.data.TFRecordDataset(sequence_path, compression_type="")
 

--- a/tools/data_converter/waymo/converter.py
+++ b/tools/data_converter/waymo/converter.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 import logging
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Literal
 
 import click
@@ -59,7 +59,7 @@ from ncore.impl.data.v4.components import (
     SequenceComponentGroupsWriter,
 )
 from ncore.impl.data.v4.types import ComponentGroupAssignments
-from ncore.impl.data_converter.base import BaseDataConverter, BaseDataConverterConfig
+from ncore.impl.data_converter.base import FileBasedDataConverter, FileBasedDataConverterConfig
 from ncore.impl.sensors.lidar import RowOffsetStructuredSpinningLidarModel
 from tools.data_converter.cli import cli
 from tools.data_converter.waymo.deps import camera_segmentation_pb2, dataset_pb2, label_pb2, tf
@@ -71,7 +71,7 @@ from tools.data_converter.waymo.waymo_range_image_utils import parse_range_image
 
 
 @dataclass(kw_only=True, slots=True)
-class WaymoConverter4Config(BaseDataConverterConfig):
+class WaymoConverter4Config(FileBasedDataConverterConfig):
     """Configuration for Waymo to NCore V4 conversion."""
 
     store_type: Literal["itar", "directory"] = "itar"
@@ -79,7 +79,7 @@ class WaymoConverter4Config(BaseDataConverterConfig):
     store_sequence_meta: bool = True
 
 
-class WaymoConverter4(BaseDataConverter):
+class WaymoConverter4(FileBasedDataConverter):
     """
     Dataset preprocessing class for converting Waymo Open Dataset to NCore V4 format.
 
@@ -123,7 +123,7 @@ class WaymoConverter4(BaseDataConverter):
         return [p for p in sorted(UPath(config.root_dir).glob("*.tfrecord"))]
 
     @staticmethod
-    def from_config(config) -> BaseDataConverter:
+    def from_config(config: WaymoConverter4Config) -> WaymoConverter4:
         return WaymoConverter4(config)
 
     def convert_sequence(self, sequence_path: UPath) -> None:
@@ -949,7 +949,7 @@ def waymo_v4(ctx, *_, **kwargs):
     """Waymo-specific data conversion (V4 format)"""
 
     # Extend base config with command-specific options
-    config = WaymoConverter4Config(**{**asdict(ctx.obj), **kwargs})
+    config = WaymoConverter4Config(**{**vars(ctx.obj), **kwargs})
 
     WaymoConverter4.convert(config)
 


### PR DESCRIPTION
This pull request refactors the data converter framework to distinguish between file-based and streaming converters, improving clarity and robustness across the codebase. The changes introduce a new `FileBasedDataConverter` base class, update documentation and CLI options to clarify `--root-dir` requirements, and refactor converter implementations for PAI, Waymo, and Colmap to use the appropriate base classes. The PAI converter logic is split into separate classes for local and streaming modes, making the code easier to maintain and extend.

### Framework and API changes

* Added `FileBasedDataConverter` as a new base class for converters that require a local root directory, with validation for the `--root-dir` argument. Updated imports and `__all__` in `ncore/data_converter/__init__.py` and `ncore/impl/data_converter/base.py`. [[1]](diffhunk://#diff-caa6511cebbfbf6e23b70eb5c41c26fc9631e524fc2e854aa2c3b084a7212d18L18-R28) [[2]](diffhunk://#diff-37adb652f7eb29ae86f5cf7e53ddbf5391efc0db8c64cee58cb60d60612ab760R159-R185)
* Refactored `BaseDataConverterConfig` to make `root_dir` optional and only required for file-based converters. [[1]](diffhunk://#diff-37adb652f7eb29ae86f5cf7e53ddbf5391efc0db8c64cee58cb60d60612ab760L33) [[2]](diffhunk://#diff-37adb652f7eb29ae86f5cf7e53ddbf5391efc0db8c64cee58cb60d60612ab760R48-R50)
* Updated documentation to clarify the distinction between file-based and streaming converters and the requirements for `--root-dir`. [[1]](diffhunk://#diff-8680e4005f677a122e669f219163f76767be34b591384b16119f94245da32d70L195-R197) [[2]](diffhunk://#diff-8680e4005f677a122e669f219163f76767be34b591384b16119f94245da32d70L286-R289) [[3]](diffhunk://#diff-bfc97aca793fa776180dc1b19eabbf2e6f1c8b7ba0064f6cfc9d9deba6d4040eL146-L151)

### Converter implementation changes

* Refactored Colmap and Waymo converters to subclass `FileBasedDataConverter` instead of `BaseDataConverter`, ensuring proper handling of local data sources. [[1]](diffhunk://#diff-5906fa03d0ccd479ab829602209fa02387b0db56598c06ead3b1289129ab64f5L42-R42) [[2]](diffhunk://#diff-5906fa03d0ccd479ab829602209fa02387b0db56598c06ead3b1289129ab64f5L144-R144) [[3]](diffhunk://#diff-3317a1ed86eb0b857d766a1d8483d66c14e3181c05322b985c56f027f5a6e5e7L62-R62) [[4]](diffhunk://#diff-3317a1ed86eb0b857d766a1d8483d66c14e3181c05322b985c56f027f5a6e5e7L82-R82)
* Split the PAI converter logic into `_PaiConversionMixin`, `PaiConverter` (local file-based), and `PaiStreamConverter` (streaming), improving separation of concerns and simplifying mode-specific logic. Updated CLI and conversion functions to use the correct classes. [[1]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fL60-R60) [[2]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fL105-R125) [[3]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fL193-R144) [[4]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fR634-R711) [[5]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fL802-R778) [[6]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fL832-R808) [[7]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fL866-R842)

### CLI and usability improvements

* Modified CLI options to make `--root-dir` optional and clarified help text to indicate when it is required, improving user experience and reducing confusion.

These changes collectively improve the structure, clarity, and maintainability of the data converter framework, making it easier to implement and use both file-based and streaming data converters.…eBasedDataConverter

The --root-dir CLI option was required for all converters, forcing streaming converters (e.g. pai-stream-v4) to supply a meaningless placeholder value.

Introduce FileBasedDataConverter as an intermediate base class that validates and stores root_dir, while BaseDataConverter no longer requires it. Split PaiConverter into a file-based PaiConverter and a new PaiStreamConverter that inherits BaseDataConverter directly.

- BaseDataConverterConfig.root_dir is now Optional[str] = None
- FileBasedDataConverter validates root_dir presence in __init__
- WaymoConverter4 and ColmapDataConverter inherit FileBasedDataConverter
- PaiConverter (pai-v4) inherits FileBasedDataConverter
- PaiStreamConverter (pai-stream-v4) inherits BaseDataConverter
- Shared PAI conversion logic extracted into _PaiConversionMixin
- CLI --root-dir changed from required=True to default=None
- Updated docs and README to reflect the new behavior

refactor(data_converter): make --root-dir optional by introducing FileBasedDataConverter

The --root-dir CLI option was required for all converters, forcing streaming converters (e.g. pai-stream-v4) to supply a meaningless placeholder value.

Introduce FileBasedDataConverter as an intermediate base class that validates and stores root_dir, while BaseDataConverter no longer requires it. Split PaiConverter into a file-based PaiConverter and a new PaiStreamConverter that inherits BaseDataConverter directly.

- BaseDataConverterConfig.root_dir is now Optional[str] = None
- FileBasedDataConverter validates root_dir in both convert() and __init__
- WaymoConverter4 and ColmapDataConverter inherit FileBasedDataConverter
- PaiConverter (pai-v4) inherits FileBasedDataConverter
- PaiStreamConverter (pai-stream-v4) inherits BaseDataConverter
- Shared PAI conversion logic extracted into _PaiConversionMixin
- CLI --root-dir changed from required=True to default=None
- Updated docs and README to reflect the new behavior

<!--
SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe what this PR does and why. Link to any related issues. -->

## Type of Change

<!-- Check the relevant option(s): -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] My commits are GPG-signed
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally (`bazel test //...`)
- [ ] Code is formatted (`bazel run //:format`)
- [ ] I have updated documentation as needed
- [ ] My changes include SPDX license headers on all new files
