### PR TITLE
build: cog auto-updates and version bump to 18.6.0

### DIFF
--- a/.cog.toml
+++ b/.cog.toml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Cocogitto configuration for conventional commit-based versioning and changelog generation.
+#
+# Usage:
+#   cog --config .cog.toml check                  # Validate commit messages
+#   cog --config .cog.toml bump --auto --dry-run  # Preview next version
+#   cog --config .cog.toml changelog              # Generate changelog
+#
+# See https://docs.cocogitto.io/reference/config.html
+
+tag_prefix = "v"
+
+# "HEAD" allows usage from jj's detached HEAD mode
+branch_whitelist = ["main", "HEAD"]
+
+# Update the Python wheel version in the Bazel build file before the bump commit.
+pre_bump_hooks = [
+    """sed -i 's/version = "[0-9]*\\.[0-9]*\\.[0-9]*"/version = "{{version}}"/g' ncore/BUILD.bazel""",
+]
+
+# Remove the local tag created by cog bump; tagging is handled by GH releases / CI.
+post_bump_hooks = [
+    "git tag --delete {{version_tag}}",
+]
+
+[changelog]
+path = "CHANGELOG.md"
+template = "remote"
+remote = "github.com"
+owner = "NVIDIA"
+repository = "ncore"
+
+# Commit types included in the changelog (user-facing changes only).
+# Types not listed here use cocogitto defaults (omitted from changelog).
+[commit_types]
+feat = { changelog_title = "➕ Added", order = 1 }
+fix = { changelog_title = "🪲 Fixed", order = 2 }
+perf = { changelog_title = "⚡ Performance", order = 3 }
+refactor = { changelog_title = "🔄 Changed", order = 4 }
+docs = { changelog_title = "📚 Documentation", order = 5 }
+ci = { changelog_title = "⚙️ CI", order = 6 }
+build = { changelog_title = "🏗️ Build", order = 7 }
+style = { changelog_title = "🎨 Style", order = 8 }
+chore = { changelog_title = "🔧 Chore", order = 9 }
+test = { changelog_title = "🧪 Tests", order = 10 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,9 @@ jobs:
         uses: actions/deploy-pages@v4
 
   # =============================================================================
-  # Publish to Test PyPI - runs only on main branch after build-and-test succeeds
+  # Publish to PyPI - runs only on main branch after build-and-test succeeds
   # =============================================================================
-  publish-testpypi:
+  publish-pypi:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: build-and-test
     runs-on: ubuntu-22.04
@@ -132,21 +132,21 @@ jobs:
           free-disk-space: true
           github-token: ${{ secrets.NVIDIA_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Publish to Test PyPI
+      - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: bazelisk run //ncore:ncore_wheel.publish -- --repository testpypi --verbose --skip-existing --non-interactive
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: bazelisk run //ncore:ncore_wheel.publish -- --repository pypi --verbose --skip-existing --non-interactive
 
       - name: Print installation instructions
         run: |
           echo "========================================"
-          echo "Python package published to Test PyPI!"
+          echo "Python package published to PyPI!"
           echo ""
-          echo "To install from Test PyPI:"
-          echo "  pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple nvidia-ncore"
+          echo "To install from PyPI:"
+          echo "  pip install nvidia-ncore"
           echo ""
           echo "Note: --extra-index-url is required for dependencies (numpy, torch, etc.)"
           echo ""
-          echo "View package: https://test.pypi.org/project/nvidia-ncore"
+          echo "View package: https://pypi.org/project/nvidia-ncore"
           echo "========================================"

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Check conventional commits
         uses: cocogitto/cocogitto-action@9a9fe03b31c47444290c0d7f9b1ee1b44ee13f20
         with:
-          command: check
+          command: "--config .cog.toml check"

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@ _build/
 
 .ci-keep/
 
-# Override global gitignore for .github directory
+# Override global gitignore for dotfiles that must be tracked
 !.github/
+!.cog.toml
 
 # Bazel-specific ignores
 bazel-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the NCore project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - - -
+
 ## [v18.5.0](https://github.com/NVIDIA/ncore/releases/tag/v18.5.0) - 2026-02-17
 #### ➕ Added
 - Initial open-source release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,94 @@ All notable changes to the NCore project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - - -
+## [v18.6.0](https://github.com/NVIDIA/ncore/compare/c10047427a14c8bfeaee1960d1dd922b5ceaa011..v18.6.0) - 2026-03-12
+
+### Highlights
+- New data converters for physical AI and colmap datasets, and made various improvements to existing tools and documentation.
+- Improve waymo converter performance by optimizing lidar processing, resulting in ~23x speedup.
+- Added `ncore_vis`, a viser-based tool for visualizing NCore datasets.
+- Performance improvements of the camera / lidar sensor models by skipping updates for hidden sensors and reducing redundant allocations and kernel launches.
+
+#### ➕ Added
+- (**ncore_vis**) Allow metadata to color lidar points - ([242f0bb](https://github.com/NVIDIA/ncore/commit/242f0bb25dc2f3e38d6477cb891628849a795611)) - Michael Shelley
+- (**ncore_vis**) Add up direction dropdown - ([0cdbb5b](https://github.com/NVIDIA/ncore/commit/0cdbb5b0e0fb439d22ece5b8df58c470123d23a7)) - Michael Shelley
+- (**ncore_vis**) Add ncore_vis, a viser-based tool for visualizing NCore datasets - ([52a2fe4](https://github.com/NVIDIA/ncore/commit/52a2fe44617922ecf82e58c16e1a9d7b8b4ec304)) - Janick Martinez Esturo
+- (**viser**) cache CameraModel instances, add device selector - ([3be074a](https://github.com/NVIDIA/ncore/commit/3be074afb97672d9fc340f6500f1ea7f8d35ee86)) - Janick Martinez Esturo
+- Add bazel binary for downloading clips for PAI - ([8eaae76](https://github.com/NVIDIA/ncore/commit/8eaae76765d8d07061feb4537df8c1396a3d1e82)) - Michael Shelley
+- Add physical AI to ncore v4 converter - ([43bec06](https://github.com/NVIDIA/ncore/commit/43bec0610ab72bc0d4ba78ff74e1553b04d8f38b)) - Michael Shelley
+- Add colmap to ncore converter - ([6a19ab4](https://github.com/NVIDIA/ncore/commit/6a19ab4206d9158a8a3961b0f880933d5a305fc0)) - Michael Shelley
+#### 🪲 Fixed
+- (**basedataconverter**) don't use paths in generic logic / switch to string IDs - ([3230ce9](https://github.com/NVIDIA/ncore/commit/3230ce9b44c6340a68039cd8941e0498cf03b6a2)) - Janick Martinez Esturo
+- (**ci**) Also free up disk space for wheel deployment - ([3628c2f](https://github.com/NVIDIA/ncore/commit/3628c2f51db1b44d4b18087c0cd68c09e5b3b693)) - Janick Martinez Esturo
+- (**ci**) Free up disc space also for export docs - ([c909253](https://github.com/NVIDIA/ncore/commit/c909253ab02cbbd348b34822c063a6b07487cfa3)) - Janick Martinez Esturo
+- (**colmap**) Final cleanups (code / docs) - ([14a172e](https://github.com/NVIDIA/ncore/commit/14a172eb635d856b1ddf47cd46b38ed7b416667d)) - Janick Martinez Esturo
+- (**colmap**) Prevent division by zero and crash on missing images - ([54d729f](https://github.com/NVIDIA/ncore/commit/54d729f354b2af64534fc29d50b9030961118220)) - Michael Shelley
+- (**docs**) Update bazel invocation in docs - ([c100474](https://github.com/NVIDIA/ncore/commit/c10047427a14c8bfeaee1960d1dd922b5ceaa011)) - Janick Martinez Esturo
+- (**ncore_vis**) Prevent race conditions when removing nodes in scene - ([a1a4ad4](https://github.com/NVIDIA/ncore/commit/a1a4ad4ece86b372ef779d150501e5588440b210)) - Michael Shelley
+- (**pai**) use '--hf-token' consistently - ([46a76c2](https://github.com/NVIDIA/ncore/commit/46a76c2c93e4ee07dee8fe2e0e05bb7e4c2bc3eb)) - Janick Martinez Esturo
+- (**pai**) Update readme, default dataset revision to 'main', fix copyrights - ([7cc4ffc](https://github.com/NVIDIA/ncore/commit/7cc4ffcacc6bc5255724c9df9fc405a5f0eda6df)) - Janick Martinez Esturo
+- (**pai**) Require DracoPy 2.0.0 or higher - ([10bd676](https://github.com/NVIDIA/ncore/commit/10bd676027bc8bed37586df3ccb2adf5e5e0a17a)) - Janick Martinez Esturo
+- (**pai**) Remove fallbacks, add platform_class to metadata, and close streaming provider - ([7f1fe35](https://github.com/NVIDIA/ncore/commit/7f1fe359d4352dfe7c9e48ceb17cce5f9b33dc8a)) - Janick Martinez Esturo
+- (**pai**) Licenses and static type updates - ([7afbc85](https://github.com/NVIDIA/ncore/commit/7afbc85078071cb94448f5d62257d2cd68d40044)) - Janick Martinez Esturo
+- (**pai**) Make sure to clean up temporary directories after conversion - ([10a2437](https://github.com/NVIDIA/ncore/commit/10a243775d4d06cfa27e3b435393f0af3e1e28ac)) - Janick Martinez Esturo
+- (**waymo-converter**) add type annotations and enable mypy checking - ([44dd7b2](https://github.com/NVIDIA/ncore/commit/44dd7b2052333fe82ba3cd4078ef8bb6656e742f)) - Janick Martinez Esturo
+- Add early exit on missing frames / minor cleanups - ([0bc9282](https://github.com/NVIDIA/ncore/commit/0bc9282d38212c6f516729b8dd604fde298ca5e9)) - Janick Martinez Esturo
+#### ⚡ Performance
+- (**ncore_vis**) skip updates for hidden cameras and lidars - ([251a916](https://github.com/NVIDIA/ncore/commit/251a91699b1602ded9e8ab1bb522d2c141de0615)) - Janick Martinez Esturo
+- (**sensors**) reduce redundant allocations and kernel launches in sensor models - ([625929f](https://github.com/NVIDIA/ncore/commit/625929f40e7adf4a257e5f9a26f65dafa713d06d)) - Janick Martinez Esturo
+- (**waymo-converter**) optimize lidar processing ~23x speedup - ([644dc06](https://github.com/NVIDIA/ncore/commit/644dc069d48b5fd3eb871011a7726cc0b2a80719)) - Zan Gojcic, Cursor
+#### 🔄 Changed
+- (**colmap**) Various improvements / cleanups - ([476bd1c](https://github.com/NVIDIA/ncore/commit/476bd1ccb2b9af845d42c7c1dfc8599f270176ee)) - Janick Martinez Esturo, Copilot, Copilot
+- (**data_converter**) make --root-dir optional by introducing FileBasedDataConverter - ([16acb07](https://github.com/NVIDIA/ncore/commit/16acb07ce95ef7c5765b0a2ec19a0437eaa43fba)) - Janick Martinez Esturo
+- (**ncore_vis**) Cleanup metadata colorization code, only find valid metadata at init - ([62f0257](https://github.com/NVIDIA/ncore/commit/62f02572a6f5b0614679448b658fec69537e11e9)) - Michael Shelley
+- (**pai**) Add missing copyright, remove toml file - ([75916b9](https://github.com/NVIDIA/ncore/commit/75916b9dc4b25dbc1c3caa8fc10e5affd36e9a93)) - Michael Shelley
+- (**pai**) Remove unused code in bazel file - ([a0f1039](https://github.com/NVIDIA/ncore/commit/a0f103931be8e9fad327704aa74738134e03b4a6)) - Michael Shelley
+- (**pai**) Rename pai_remote, flatten structure, remove python module - ([02e2740](https://github.com/NVIDIA/ncore/commit/02e27404bf5f7a6fd59a52740bb0b9015224bba6)) - Michael Shelley
+- (**pai**) Rename pai conversion commands - ([95336a7](https://github.com/NVIDIA/ncore/commit/95336a74d636803beb094301b0c1d9d4f8169e6b)) - Michael Shelley
+- (**tools**) remove ncore_visualize_labels and open3d dependency - ([6fc43b3](https://github.com/NVIDIA/ncore/commit/6fc43b3e82620b728c7db98a67487fa00fb21ad3)) - Janick Martinez Esturo
+- (**waymo-converter**) separate Waymo-derived and NVIDIA-original code - ([c1b4b65](https://github.com/NVIDIA/ncore/commit/c1b4b65338571526039a6539d06b505ccd822f99)) - Janick Martinez Esturo
+- split PAI converter into separate local and streaming variants with distinct config factory - ([92a1729](https://github.com/NVIDIA/ncore/commit/92a1729c883495a0790ff3939c8acbf396c7c32b)) - Janick Martinez Esturo
+- clean up unused code and rename input parameter and add readme - ([f5cca96](https://github.com/NVIDIA/ncore/commit/f5cca96c79763a972cf659908b9e71f837f4a7ca)) - Michael Shelley
+#### 📚 Documentation
+- (**contributing**) add conventional commits and linear history guidelines - ([1355d88](https://github.com/NVIDIA/ncore/commit/1355d8853d1af242d6c257dce1679048091742ca)) - Janick Martinez Esturo
+- (**converters**) Format updates - ([da7f5f7](https://github.com/NVIDIA/ncore/commit/da7f5f7a8006e2f7cb344ca5ee02b3af4dc5cefd)) - Janick Martinez Esturo
+- (**converters**) Updated converter docs to remove code samples; combined pai readmes into one. - ([a525e0d](https://github.com/NVIDIA/ncore/commit/a525e0d5caf60094c0687f668e9f20eb34e6c84e)) - Michael Shelley
+- (**pai**) indicate current default HuggingFace dataset revision - ([d179209](https://github.com/NVIDIA/ncore/commit/d179209f661a272b3e634809b092c2536b7f595e)) - Janick Martinez Esturo
+- (**pai**) Add PAI to NCore docs - ([132e538](https://github.com/NVIDIA/ncore/commit/132e5389ac5a432edda80a2c988902fb81af3cab)) - Michael Shelley
+- (**readme**) overhaul README.md for OSS readiness - ([d763103](https://github.com/NVIDIA/ncore/commit/d763103dddd6c406b7f9bf95d0252196a4fe4c48)) - Janick Martinez Esturo
+- (**sphinx**) migrate to nvidia_sphinx_theme for NVIDIA corporate branding - ([aa9c3bc](https://github.com/NVIDIA/ncore/commit/aa9c3bc0ed54b9ce6a3199d0ceb378157355bf48)) - Janick Martinez Esturo
+- (**waymo**) Update documentation for Waymo conversion tool - ([cceee95](https://github.com/NVIDIA/ncore/commit/cceee9516eecc6562b8ab2c92ed55f0d32da6d56)) - Janick Martinez Esturo
+- comprehensive documentation overhaul - ([3eda9b0](https://github.com/NVIDIA/ncore/commit/3eda9b0dacb639d8d5d5406afe71c81e0296cac5)) - Janick Martinez Esturo
+- fix duplicate data_conversions label in waymo.rst and colmap.rst - ([35c02b7](https://github.com/NVIDIA/ncore/commit/35c02b7e808e4342bfdbc9ae24daee275caa9c84)) - Janick Martinez Esturo
+- add SECURITY.md per SCM standard (NRE-2883) - ([cbd904d](https://github.com/NVIDIA/ncore/commit/cbd904d317f201ec01e998205c12c4e952c703db)) - Jonas Toelke, Claude Opus 4.6 (1M context)
+- Minor readme updates - ([1968e10](https://github.com/NVIDIA/ncore/commit/1968e10efb721d4344baaa0c28034bc9e45ab2a4)) - Janick Martinez Esturo
+- update CHANGELOG and README for v18.5.0 release - ([4a268ed](https://github.com/NVIDIA/ncore/commit/4a268ed246696d0ede32d1754d3c4e112d06650d)) - Janick Martinez Esturo
+- add CHANGELOG.md following Keep a Changelog format - ([2097286](https://github.com/NVIDIA/ncore/commit/20972864817ebf83c534c3b8d3357be4be538b10)) - Janick Martinez Esturo
+- fix typo - ([bad48b1](https://github.com/NVIDIA/ncore/commit/bad48b1a3a9205f7aa21fbd68c1925039b245fe4)) - Janick Martinez Esturo
+- fix copyright year and add SIL Lab link in documentation - ([ecc2290](https://github.com/NVIDIA/ncore/commit/ecc229090cbe65fb10fc840aae7e5afc881c3b7f)) - Janick Martinez Esturo
+- update commit signing requirements from DCO sign-off to GPG signatures - ([3fde27a](https://github.com/NVIDIA/ncore/commit/3fde27a287d43ec988bd65de533cca1f5d758837)) - Janick Martinez Esturo
+- update contributions on merge commits - ([3ded866](https://github.com/NVIDIA/ncore/commit/3ded86635bca49a780df72a3d4bf49e930f116ca)) - Janick Martinez Esturo
+#### ⚙️ CI
+- (**bazel**) Cache external dependencies - ([f97c1d6](https://github.com/NVIDIA/ncore/commit/f97c1d6c129523b3053064eb4819786d9850f3b1)) - Janick Martinez Esturo
+- (**bazel-setup**) Remove waymo modules repo cache and set bazelrc - ([e2282ba](https://github.com/NVIDIA/ncore/commit/e2282bacb34a428c903ae95f8f17aa3a77e40041)) - Janick Martinez Esturo
+- (**pipy**) publish to regular PyPI - ([a1a18d6](https://github.com/NVIDIA/ncore/commit/a1a18d62021666022ed86c893a0e6adbbb431146)) - Janick Martinez Esturo
+- support fork CI by falling back to NVIDIA_PACKAGES_TOKEN for GitHub Packages auth - ([75ba65a](https://github.com/NVIDIA/ncore/commit/75ba65aa4eab88863463518212487a162cdf8f62)) - Janick Martinez Esturo
+- add GitHub issue and pull request templates - ([5a7c905](https://github.com/NVIDIA/ncore/commit/5a7c90559ffdbb7a8892f2ec414f71865ee1598b)) - Janick Martinez Esturo
+- patch rules_python for --repo_contents_cache support - ([3cd8809](https://github.com/NVIDIA/ncore/commit/3cd8809a9e83c1b1ebb45b3920197a0a32ba8217)) - Janick Martinez Esturo
+- add conventional commits check for pull requests - ([eb7bc62](https://github.com/NVIDIA/ncore/commit/eb7bc62c39eabcd11161efdc35d558460ec7ff47)) - Janick Martinez Esturo
+#### 🏗️ Build
+- (**bazel**) Update to bazel 8.5.1 - ([60811b3](https://github.com/NVIDIA/ncore/commit/60811b3901dbd63fdfc985ef26d342b6ec58d784)) - Janick Martinez Esturo
+- (**proto**) Update to latest rules_proto - ([26972cc](https://github.com/NVIDIA/ncore/commit/26972ccba2878ab4eb7b48b3c716691d81c3a816)) - Janick Martinez Esturo
+- Add cog configuration for conventional commit linting and changelog generation - ([4822d29](https://github.com/NVIDIA/ncore/commit/4822d2922b59e4e26f5b30621bcf7cfd0e5832aa)) - Janick Martinez Esturo
+- remove pyside6 dependency (LGPL-licensed) - ([8c27d3d](https://github.com/NVIDIA/ncore/commit/8c27d3da9449f161eff214803cb4487d4b6aabe0)) - Janick Martinez Esturo
+#### 🎨 Style
+- (**waymo-converter**) modernize type annotations for Python 3.11 - ([c01da20](https://github.com/NVIDIA/ncore/commit/c01da202fd6ad8ea72d82412f13a4a9c08a901cc)) - Janick Martinez Esturo
+#### 🔧 Chore
+- (**waymo**) update Waymo Open Dataset to version 1.6.1 in MODULE.bazel and related files - ([fb04dfa](https://github.com/NVIDIA/ncore/commit/fb04dfa467e8ab95879099ff88574a9314281b03)) - Janick Martinez Esturo
+- Clean up Python code for public release - ([21751a1](https://github.com/NVIDIA/ncore/commit/21751a1603b4e90f9fdaeaa053323dd42cf27bbb)) - Janick Martinez Esturo
+
+- - -
+
 
 ## [v18.5.0](https://github.com/NVIDIA/ncore/releases/tag/v18.5.0) - 2026-02-17
 #### ➕ Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,21 @@ This repository enforces a **linear commit history** of commits with conventiona
 
 PRs are merged via **rebase only** (no merge commits).
 
-Before submitting your PR, ensure your branch is *rebased* on the latest `main` and is free of merge commits.
+Before submitting your PR, ensure your branch is _rebased_ on the latest `main` and is free of merge commits.
+
+## Releases & Versioning
+
+NCore uses [Semantic Versioning](https://semver.org/) with versions determined automatically from [Conventional Commits](https://www.conventionalcommits.org/) via [cocogitto](https://docs.cocogitto.io/).
+
+### Cocogitto Configuration
+
+Cocogitto is configured via `.cog.toml` in the repository root. All `cog` commands must reference this config:
+
+```bash
+cog --config .cog.toml check                   # Validate commit messages
+cog --config .cog.toml bump --auto --dry-run   # Preview next version
+cog --config .cog.toml changelog               # Generate changelog
+```
 
 ## Commit Signatures
 

--- a/docs/conversions/pai/pai.rst
+++ b/docs/conversions/pai/pai.rst
@@ -265,9 +265,9 @@ The output for each clip is written to::
      - HuggingFace API token. Reads from the ``HF_TOKEN`` environment variable
        if not provided
    * - ``--revision TEXT``
-     - ``main``
+     - ``ncore``
      - HuggingFace dataset branch or tag to stream from. Note: the
-       ``pai-clip-dl`` download tool uses ``ncore_test`` as its default revision
+       ``pai-clip-dl`` download tool uses ``ncore`` as its current default revision
 
 For the complete implementation, see ``tools/data_converter/pai/converter.py``.
 

--- a/ncore/BUILD.bazel
+++ b/ncore/BUILD.bazel
@@ -67,7 +67,7 @@ py_wheel(
         "universal_pathlib",
     ],
     summary = "A unified data format and library for AV / robotics",
-    version = "18.5.0",
+    version = "18.6.0",
     deps = [
         ":ncore_pkg",
     ],

--- a/tools/data_converter/pai/README.md
+++ b/tools/data_converter/pai/README.md
@@ -154,7 +154,7 @@ bazel run //tools/data_converter/pai:convert -- \
     --hf-token <your-hf-token>
 ```
 
-`--revision` selects the HuggingFace dataset branch/tag (default: `main`). Video data is
+`--revision` selects the HuggingFace dataset branch/tag (current default: `ncore`). Video data is
 temporarily written to disk and cleaned up after each clip.
 
 ### Shared conversion options

--- a/tools/data_converter/pai/converter.py
+++ b/tools/data_converter/pai/converter.py
@@ -823,7 +823,7 @@ def pai_v4(ctx, *_, **kwargs):
 @click.option(
     "--revision",
     type=str,
-    default="main",
+    default="ncore",
     show_default=True,
     help="HuggingFace dataset revision (branch/tag).",
 )

--- a/tools/data_converter/pai/pai_remote/cli.py
+++ b/tools/data_converter/pai/pai_remote/cli.py
@@ -81,7 +81,7 @@ def main() -> None:
 )
 @click.option("--features", "-f", multiple=True, help="Feature names to download. Repeat for multiple. Default: all.")
 @click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
-@click.option("--revision", default="main", help="Git branch/revision of the dataset.")
+@click.option("--revision", default="ncore", help="Git branch/revision of the dataset.")
 @click.option("--no-skip-missing", is_flag=True, default=False, help="Don't skip features where the sensor is absent.")
 @click.option("--no-metadata", is_flag=True, default=False, help="Skip downloading metadata parquets.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
@@ -121,7 +121,7 @@ def download(
 @main.command()
 @click.argument("clip_ids", nargs=-1, required=True)
 @click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
-@click.option("--revision", default="main", help="Git branch/revision of the dataset.")
+@click.option("--revision", default="ncore", help="Git branch/revision of the dataset.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
 def info(clip_ids: tuple[str, ...], hf_token: str | None, revision: str, verbose: bool) -> None:
     """Show information about one or more clips (chunk, split, sensors)."""
@@ -156,7 +156,7 @@ def info(clip_ids: tuple[str, ...], hf_token: str | None, revision: str, verbose
 
 @main.command("list-features")
 @click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
-@click.option("--revision", default="main", help="Git branch/revision of the dataset.")
+@click.option("--revision", default="ncore", help="Git branch/revision of the dataset.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
 def list_features(hf_token: str | None, revision: str, verbose: bool) -> None:
     """List all available features in the dataset."""
@@ -187,7 +187,7 @@ def list_features(hf_token: str | None, revision: str, verbose: bool) -> None:
     "--output", "-o", type=click.Path(path_type=Path), default=None, help="Save output to file instead of stdout."
 )
 @click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
-@click.option("--revision", default="main", help="Git branch/revision of the dataset.")
+@click.option("--revision", default="ncore", help="Git branch/revision of the dataset.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
 def stream(
     clip_id: str,


### PR DESCRIPTION
This pull request introduces several improvements to the release, versioning, and publishing processes for the project, with a focus on automating version management, updating default dataset revisions, and publishing to PyPI. The main changes include adding a `cocogitto` configuration for conventional commit-based versioning, updating the CI workflow to publish to PyPI instead of Test PyPI, and changing the default HuggingFace dataset revision from `main` to `ncore` in the PAI tools and documentation.

**Release & Versioning Automation:**

- Added `.cog.toml` configuration file for [cocogitto](https://docs.cocogitto.io/) to automate semantic versioning and changelog generation based on conventional commits. This includes hooks for updating the Python wheel version and cleaning up tags after version bumps. (`.cog.toml`)
- Updated the `CONTRIBUTING.md` with guidance on releases, versioning, and cocogitto usage.

**Continuous Integration & Publishing:**

- Changed the GitHub Actions workflow to publish the Python package to PyPI (using the `PYPI_API_TOKEN` secret) instead of Test PyPI, and updated the job, step names, and installation instructions accordingly. (`.github/workflows/ci.yml`) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL117-R119) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL135-R151)
- Updated the commit linting workflow to explicitly pass the `.cog.toml` config to the cocogitto action. (`.github/workflows/commit-lint.yml`)

**Default Dataset Revision Updates (PAI tools):**

- Changed the default HuggingFace dataset revision from `main` to `ncore` in all relevant PAI converter CLI options and documentation. (`tools/data_converter/pai/converter.py`, `tools/data_converter/pai/pai_remote/cli.py`, `docs/conversions/pai/pai.rst`, `tools/data_converter/pai/README.md`) [[1]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fL826-R826) [[2]](diffhunk://#diff-077ad5a0f5847be08dae615ea0640aacf736a98f9489e7eaccb301c2fc52292bL84-R84) [[3]](diffhunk://#diff-077ad5a0f5847be08dae615ea0640aacf736a98f9489e7eaccb301c2fc52292bL124-R124) [[4]](diffhunk://#diff-077ad5a0f5847be08dae615ea0640aacf736a98f9489e7eaccb301c2fc52292bL159-R159) [[5]](diffhunk://#diff-077ad5a0f5847be08dae615ea0640aacf736a98f9489e7eaccb301c2fc52292bL190-R190) [[6]](diffhunk://#diff-8680e4005f677a122e669f219163f76767be34b591384b16119f94245da32d70L268-R270) [[7]](diffhunk://#diff-bfc97aca793fa776180dc1b19eabbf2e6f1c8b7ba0064f6cfc9d9deba6d4040eL157-R157)

**Release Artifacts:**

- Bumped the Python wheel version in `ncore/BUILD.bazel` from `18.5.0` to `18.6.0`.
- Added a new release section for `v18.6.0` in `CHANGELOG.md` documenting user-facing changes.

These changes streamline the release workflow, ensure consistent versioning, and update the default dataset revision for PAI tools to match current usage.This pull request introduces a new release (v18.6.0) of the NCore project, updates the release and CI infrastructure to use conventional commit-based versioning with Cocogitto, and publishes Python packages to PyPI instead of Test PyPI. It also documents the new release and versioning process, and updates the Bazel build configuration to the new version.

**Release and Versioning Infrastructure:**
- Added `.cog.toml` configuration file for Cocogitto, enabling automated semantic versioning and changelog generation based on conventional commits.
- Updated `CONTRIBUTING.md` to document the new release and versioning process using Cocogitto and conventional commits.

**Continuous Integration (CI) and Publishing:**
- Changed the CI workflow to publish the Python package to PyPI instead of Test PyPI, updated environment variables, and installation instructions accordingly. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL117-R119) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL135-R151)
- Updated the commit linting workflow to use the new `.cog.toml` configuration.

**Release and Build Updates:**
- Updated the Bazel build file to set the Python wheel version to `18.6.0`.
- Added a new section to `CHANGELOG.md` for v18.6.0, summarizing highlights, new features, fixes, performance improvements, and documentation updates.This pull request introduces automated versioning and changelog generation using Cocogitto, updates project documentation to reflect these changes, and bumps the Python wheel version to v18.6.0 for release. The main changes are grouped below:

**Automated Versioning & Changelog**

* Added a `.cog.toml` configuration file to set up Cocogitto for conventional commit linting, semantic versioning, and changelog generation. This includes hooks for updating the Bazel build version and customizing changelog sections.
* Updated the commit linting GitHub Actions workflow to use the new `.cog.toml` config.

**Documentation Updates**

* Expanded `CONTRIBUTING.md` with a new section detailing release/versioning procedures and Cocogitto usage, including command examples.
* Updated `CHANGELOG.md` with the v18.6.0 release notes, summarizing new features, fixes, and improvements.

**Build System**

* Bumped the `version` field in the Bazel `py_wheel` build rule from 18.5.0 to 18.6.0 to match the new release.<!--
SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe what this PR does and why. Link to any related issues. -->

## Type of Change

<!-- Check the relevant option(s): -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] My commits are GPG-signed
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally (`bazel test //...`)
- [ ] Code is formatted (`bazel run //:format`)
- [ ] I have updated documentation as needed
- [ ] My changes include SPDX license headers on all new files
