### PR TITLE
colmap: Don't include downsampled images by default

### DIFF
--- a/docs/conversions/colmap/colmap.rst
+++ b/docs/conversions/colmap/colmap.rst
@@ -136,7 +136,7 @@ subdirectory is treated as a separate sequence.
      - Prefix prepended to COLMAP integer camera IDs to form NCore sensor IDs
        (e.g. ``camera1``)
    * - ``--include-downsampled-images BOOL``
-     - ``True``
+     - ``False``
      - Include downsampled image directories (``images_2``, ``images_4``,
        ``images_8``) as additional camera sensors
    * - ``--include-3d-points BOOL``

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -55,7 +55,7 @@ class ColmapConverter4Config(FileBasedDataConverterConfig):
     store_sequence_meta: bool = True
     start_time_sec: float = 0.0
     camera_prefix: str = "camera"
-    include_downsampled_images: bool = True
+    include_downsampled_images: bool = False
     include_3d_points: bool = True
 
 
@@ -488,7 +488,7 @@ class ColmapDataConverter(FileBasedDataConverter):
 @click.option(
     "--include-downsampled-images",
     type=click.BOOL,
-    default=True,
+    default=False,
     help="Include downsampled images as additional cameras. Images should be in folders such as `images_2`, etc.",
 )
 @click.option(


### PR DESCRIPTION
This pull request updates the default behavior for handling downsampled images in the COLMAP data converter. The primary change is that downsampled images are no longer included as additional cameras by default, to avoid downstream issues in 3DGRUT/GSplat. This affects both the codebase and the documentation to ensure consistent behavior and clear communication to users.

**Default behavior changes:**

* Changed the default value of the `include_downsampled_images` configuration option in the `ColmapConverter4Config` class from `True` to `False`, so downsampled images are not included as additional cameras unless explicitly specified. (`tools/data_converter/colmap/converter.py`)
* Updated the default value of the `--include-downsampled-images` CLI option to `False` to match the new default behavior. (`tools/data_converter/colmap/converter.py`)

**Documentation updates:**

* Updated the documentation to reflect that the default value for `--include-downsampled-images` is now `False` instead of `True`. (`docs/conversions/colmap/colmap.rst`)