### PR TITLE
build: Add CI remote cache

### DIFF
--- a/.github/actions/setup-bazel/action.yml
+++ b/.github/actions/setup-bazel/action.yml
@@ -28,6 +28,22 @@ inputs:
   github-token:
     description: 'GitHub token for package authentication'
     required: true
+  bazel-remote-cache:
+    description: 'Remote cache gRPC/HTTP endpoint'
+    required: true
+  bazel-remote-cache-header:
+    description: 'Authentication header for remote cache (format: header-name=value)'
+    required: true
+  bazel-remote-cache-upload:
+    description: 'Whether to upload results to the remote cache (disable for PRs to prevent cache pollution)'
+    required: false
+    default: 'true'
+  bazel-bes-backend:
+    description: 'Build Event Service backend endpoint'
+    required: true
+  bazel-bes-results-url:
+    description: 'Build Event Service results URL'
+    required: true
 
 runs:
   using: 'composite'
@@ -62,8 +78,9 @@ runs:
       with:
         # Avoid downloading Bazel every time
         bazelisk-cache: true
-        # Store build cache per workflow
-        disk-cache: ${{ github.workflow }}
+        # Disk cache is not needed in CI, using remote cache.
+        # Local developer builds still use --disk_cache from .bazelrc.
+        disk-cache: false
         # Share repository cache between workflows.
         # The repo contents cache (--repo_contents_cache, enabled by default since Bazel 8.3.0)
         # lives under the repository cache directory, so caching it here also persists
@@ -75,10 +92,18 @@ runs:
         # Only save caches on push (not on PRs) to avoid cache pollution
         cache-save: ${{ github.event_name != 'pull_request' }}
         # Bump to force-invalidate all CI caches (e.g. after changing cache structure)
-        cache-version: 2
-        # Add custom bazelrc options: color / timestamps / no GPU for CI builds
+        cache-version: 3
+        # Add custom bazelrc options
         bazelrc: |
             build --color=yes
             build --show_timestamps
+            build --build_metadata=REPO_URL=https://github.com/NVIDIA/ncore.git
             test --config=no-gpu
             common --repo_contents_cache=~/.cache/bazel-repo/contents
+            common --remote_cache=${{ inputs.bazel-remote-cache }}
+            common --remote_cache_compression
+            common --remote_timeout=10m
+            common --remote_header=${{ inputs.bazel-remote-cache-header }}
+            build --remote_upload_local_results=${{ inputs.bazel-remote-cache-upload }}
+            build --bes_backend=${{ inputs.bazel-bes-backend }}
+            build --bes_results_url=${{ inputs.bazel-bes-results-url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
           install-pandoc: true
           free-disk-space: true
           github-token: ${{ secrets.NVIDIA_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          bazel-remote-cache: ${{ secrets.BAZEL_REMOTE_CACHE }}
+          bazel-remote-cache-header: ${{ secrets.BAZEL_REMOTE_CACHE_HEADER }}
+          bazel-remote-cache-upload: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
+          bazel-bes-backend: ${{ secrets.BAZEL_BES_BACKEND }}
+          bazel-bes-results-url: ${{ secrets.BAZEL_BES_RESULTS_URL }}
 
       - name: Check code format
         run: bazelisk run format.check
@@ -88,6 +93,10 @@ jobs:
           install-pandoc: true
           free-disk-space: true
           github-token: ${{ secrets.NVIDIA_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          bazel-remote-cache: ${{ secrets.BAZEL_REMOTE_CACHE }}
+          bazel-remote-cache-header: ${{ secrets.BAZEL_REMOTE_CACHE_HEADER }}
+          bazel-bes-backend: ${{ secrets.BAZEL_BES_BACKEND }}
+          bazel-bes-results-url: ${{ secrets.BAZEL_BES_RESULTS_URL }}
 
       - name: Build documentation
         run: bazelisk build //docs:ncore
@@ -131,6 +140,10 @@ jobs:
           install-pandoc: false
           free-disk-space: true
           github-token: ${{ secrets.NVIDIA_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+          bazel-remote-cache: ${{ secrets.BAZEL_REMOTE_CACHE }}
+          bazel-remote-cache-header: ${{ secrets.BAZEL_REMOTE_CACHE_HEADER }}
+          bazel-bes-backend: ${{ secrets.BAZEL_BES_BACKEND }}
+          bazel-bes-results-url: ${{ secrets.BAZEL_BES_RESULTS_URL }}
 
       - name: Publish to PyPI
         env:


### PR DESCRIPTION
This pull request enhances the Bazel CI workflow by integrating support for remote caching and Build Event Service (BES) endpoints, improving build performance and observability. Key changes include updating the Bazel setup GitHub Action to accept new remote cache and BES configuration inputs, adjusting cache usage to avoid pollution on pull requests, and propagating the relevant secrets and configuration through the CI workflow jobs.

**Bazel Remote Cache & BES Integration:**

* Added new required and optional inputs to `.github/actions/setup-bazel/action.yml` for remote cache endpoints, authentication headers, upload control, and BES endpoints. These inputs allow the action to be configured for remote caching and build event streaming.
* Updated the Bazel setup action to disable local disk cache in CI (favoring remote cache), incremented the cache version to invalidate old caches, and appended new Bazel flags for remote cache and BES configuration in the `bazelrc` section. [[1]](diffhunk://#diff-1f91ebd28df4135f081b557b94e7ce505a9cf34ab5be4b86c19e53351e523126L65-R83) [[2]](diffhunk://#diff-1f91ebd28df4135f081b557b94e7ce505a9cf34ab5be4b86c19e53351e523126L78-R109)

**CI Workflow Configuration:**

* Propagated the new remote cache and BES configuration inputs into all relevant jobs in `.github/workflows/ci.yml`, sourcing secrets for endpoints and authentication headers, and conditionally enabling remote cache uploads only for non-pull request events to prevent cache pollution. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR64-R68) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR96-R99) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR143-R146)