### PR TITLE
General ncore_vis updates and fixes

### DIFF
--- a/tools/ncore_vis/BUILD.bazel
+++ b/tools/ncore_vis/BUILD.bazel
@@ -15,6 +15,7 @@
 
 load("@ncore_pip_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel/pytest:defs.bzl", "pytest_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -32,11 +33,34 @@ py_library(
 )
 
 py_library(
+    name = "pylib_tracks",
+    srcs = [
+        "tracks.py",
+    ],
+    deps = [
+        "//ncore/impl/common:pylib_transformations",
+        "//ncore/impl/data:pylib_types",
+        requirement("numpy"),
+    ],
+)
+
+pytest_test(
+    name = "pytest_tracks",
+    srcs = ["tracks_test.py"],
+    deps = [
+        ":pylib_tracks",
+        "//ncore/impl/data:pylib_types",
+        requirement("numpy"),
+    ],
+)
+
+py_library(
     name = "pylib_data_loader",
     srcs = [
         "data_loader.py",
     ],
     deps = [
+        ":pylib_tracks",
         "//ncore/impl/common:pylib_transformations",
         "//ncore/impl/data:pylib_compat",
         "//ncore/impl/data:pylib_types",

--- a/tools/ncore_vis/components/camera.py
+++ b/tools/ncore_vis/components/camera.py
@@ -30,7 +30,7 @@ import viser
 
 from scipy.spatial.transform import Rotation as RotLib
 
-from ncore.impl.common.transformations import HalfClosedInterval, se3_inverse, transform_point_cloud
+from ncore.impl.common.transformations import HalfClosedInterval, transform_point_cloud
 from ncore.impl.data.types import FrameTimepoint, LabelSource
 from ncore.impl.sensors.camera import CameraModel
 from tools.ncore_vis.components.base import VisualizationComponent, register_component
@@ -587,9 +587,9 @@ class CameraComponent(VisualizationComponent):
         T_lidar_world = lidar_sensor.get_frames_T_sensor_target(world_id, lidar_frame, FrameTimepoint.END)
         pc_world = transform_point_cloud(pc_sensor.xyz_m_end, T_lidar_world)
 
-        # Get camera world-to-sensor transforms (T_world_sensor = inverse of T_sensor_world)
-        T_world_camera_start = se3_inverse(cam.get_frames_T_sensor_target(world_id, frame, FrameTimepoint.START))
-        T_world_camera_end = se3_inverse(cam.get_frames_T_sensor_target(world_id, frame, FrameTimepoint.END))
+        # Get camera world-to-sensor transforms (T_world_camera)
+        T_world_camera_start = cam.get_frames_T_source_sensor(world_id, frame, FrameTimepoint.START)
+        T_world_camera_end = cam.get_frames_T_source_sensor(world_id, frame, FrameTimepoint.END)
 
         # Project world points to image coordinates
         mode = self._project_mode

--- a/tools/ncore_vis/components/camera.py
+++ b/tools/ncore_vis/components/camera.py
@@ -472,7 +472,7 @@ class CameraComponent(VisualizationComponent):
 
             if self._overlay_cuboids:
                 try:
-                    image = self._overlay_cuboids_on_image(camera_id, frame, image)
+                    image = self._overlay_cuboids_on_image(camera_id, image)
                 except Exception:
                     logger.debug("Cuboid overlay failed for %s frame %d", camera_id, frame, exc_info=True)
 
@@ -672,15 +672,17 @@ class CameraComponent(VisualizationComponent):
     # Cuboid overlay projection
     # ------------------------------------------------------------------
 
-    def _overlay_cuboids_on_image(self, camera_id: str, frame: int, image: np.ndarray) -> np.ndarray:
-        """Project 3D cuboid edges onto the camera image using rolling-shutter-aware projection.
+    def _overlay_cuboids_on_image(self, camera_id: str, image: np.ndarray) -> np.ndarray:
+        """Project 3D cuboid edges onto the camera image using per-cuboid observation timestamps.
 
-        Cuboid observations are queried at the scene's reference timestamp in world
-        coordinates and projected onto the camera image.
+        Cuboid observations are queried at their individual observation timestamps in world
+        coordinates.  For each cuboid, the camera pose is evaluated at the cuboid's
+        ``timestamp_us`` via the pose graph, and the cuboid corners are projected using
+        a static (non-rolling-shutter) camera model.  This ensures correct alignment even
+        when the cuboid observation time differs from the camera frame's exposure time.
 
         Args:
             camera_id: Camera sensor to project onto.
-            frame: Camera frame index.
             image: RGB image array (H, W, 3), uint8.
 
         Returns:
@@ -690,23 +692,18 @@ class CameraComponent(VisualizationComponent):
         camera_model = self._camera_models[camera_id]
 
         world_id = self.data_loader.world_frame_id
-        T_world_sensor_start = cam.get_frames_T_source_sensor(world_id, frame, FrameTimepoint.START)
-        T_world_sensor_end = cam.get_frames_T_source_sensor(world_id, frame, FrameTimepoint.END)
-        timestamp_start_us = cam.get_frame_timestamp_us(frame, FrameTimepoint.START)
-        timestamp_end_us = cam.get_frame_timestamp_us(frame, FrameTimepoint.END)
-
-        cuboid_source = self._cuboid_source
+        pose_graph = self.data_loader.pose_graph
 
         output_image = image.copy()
         image_height, image_width = output_image.shape[:2]
         image_rect = (0, 0, image_width, image_height)
 
-        # Query cuboid observations in world coordinates for the reference frame's time window.
-        interval_us = self.renderer.reference_frame_interval_us
-        observations = self.data_loader.get_cuboid_observations_in_world(interval_us, cuboid_source)
-
-        for obs in observations:
+        # Query cuboid observations in world coordinates, each at its own observation time.
+        for obs in self.data_loader.get_cuboid_observations_in_world(
+            self.renderer.reference_frame_interval_us, "observation-time", self._cuboid_source
+        ):
             bbox = obs.bbox3
+
             # Observations are in world coordinates — compute corners directly.
             dimensions = np.array(bbox.dim, dtype=np.float32)
             corners_local = _UNIT_CUBE_CORNERS * dimensions
@@ -714,12 +711,13 @@ class CameraComponent(VisualizationComponent):
             translation = np.array(bbox.centroid, dtype=np.float32)
             corners_world = (corners_local @ rotation.T + translation).astype(np.float32)
 
-            projection = camera_model.world_points_to_image_points_shutter_pose(
+            # Evaluate camera pose at the cuboid's observation time for correct alignment
+            T_world_sensor = pose_graph.evaluate_poses(
+                world_id, cam.sensor_id, np.array(obs.timestamp_us, dtype=np.uint64)
+            )
+            projection = camera_model.world_points_to_image_points_static_pose(
                 torch.from_numpy(corners_world),
-                T_world_sensor_start,
-                T_world_sensor_end,
-                start_timestamp_us=int(timestamp_start_us),
-                end_timestamp_us=int(timestamp_end_us),
+                T_world_sensor,
                 return_valid_indices=True,
                 return_all_projections=True,
             )

--- a/tools/ncore_vis/components/camera.py
+++ b/tools/ncore_vis/components/camera.py
@@ -474,7 +474,7 @@ class CameraComponent(VisualizationComponent):
 
             if self._overlay_cuboids:
                 try:
-                    image = self._overlay_cuboids_on_image(camera_id, image)
+                    image = self._overlay_cuboids_on_image(camera_id, frame_idx, image)
                 except Exception:
                     logger.debug("Cuboid overlay failed for %s frame %d", camera_id, frame_idx, exc_info=True)
 
@@ -639,6 +639,7 @@ class CameraComponent(VisualizationComponent):
         T_world_camera_start: np.ndarray,
         T_world_camera_end: np.ndarray,
         mode: str,
+        return_all_projections: bool = False,
     ) -> CameraModel.WorldPointsToImagePointsReturn:
         """Project world points using the specified projection mode."""
         if mode == "rolling-shutter":
@@ -648,6 +649,7 @@ class CameraComponent(VisualizationComponent):
                 T_world_camera_end,
                 return_valid_indices=True,
                 return_T_world_sensors=True,
+                return_all_projections=return_all_projections,
             )
         if mode == "mean":
             return camera_model.world_points_to_image_points_mean_pose(
@@ -656,6 +658,7 @@ class CameraComponent(VisualizationComponent):
                 T_world_camera_end,
                 return_valid_indices=True,
                 return_T_world_sensors=True,
+                return_all_projections=return_all_projections,
             )
         if mode == "start":
             return camera_model.world_points_to_image_points_static_pose(
@@ -663,6 +666,7 @@ class CameraComponent(VisualizationComponent):
                 T_world_camera_start,
                 return_valid_indices=True,
                 return_T_world_sensors=True,
+                return_all_projections=return_all_projections,
             )
         # "end"
         return camera_model.world_points_to_image_points_static_pose(
@@ -670,23 +674,25 @@ class CameraComponent(VisualizationComponent):
             T_world_camera_end,
             return_valid_indices=True,
             return_T_world_sensors=True,
+            return_all_projections=return_all_projections,
         )
 
     # ------------------------------------------------------------------
     # Cuboid overlay projection
     # ------------------------------------------------------------------
 
-    def _overlay_cuboids_on_image(self, camera_id: str, image: np.ndarray) -> np.ndarray:
-        """Project 3D cuboid edges onto the camera image using per-cuboid observation timestamps.
+    def _overlay_cuboids_on_image(self, camera_id: str, frame_idx: int, image: np.ndarray) -> np.ndarray:
+        """Project 3D cuboid edges onto the camera image, interpolated to the mid-of-frame time.
 
-        Cuboid observations are queried at their individual observation timestamps in world
-        coordinates.  For each cuboid, the camera pose is evaluated at the cuboid's
-        ``timestamp_us`` via the pose graph, and the cuboid corners are projected using
-        a static (non-rolling-shutter) camera model.  This ensures correct alignment even
-        when the cuboid observation time differs from the camera frame's exposure time.
+        Each cuboid track is interpolated to the camera frame's mid-of-frame timestamp so
+        that the projected box position reflects the object's estimated location at the
+        moment the camera was actually exposing.  The interpolated observation is then
+        transformed to world coordinates and projected using the shared projection mode
+        (rolling-shutter / mean / start / end).
 
         Args:
             camera_id: Camera sensor to project onto.
+            frame_idx: Current frame index for this camera.
             image: RGB image array (H, W, 3), uint8.
 
         Returns:
@@ -702,40 +708,61 @@ class CameraComponent(VisualizationComponent):
         image_height, image_width = output_image.shape[:2]
         image_rect = (0, 0, image_width, image_height)
 
-        # Query cuboid observations in world coordinates, each at its own observation time.
-        for obs in self.data_loader.get_cuboid_observations_in_world(
-            self.renderer.reference_frame_interval_us, "observation-time", self._cuboid_source
-        ):
+        # Approximate the track / camera association with mid-frame interpolation
+        timestamp_start_us = cam.get_frame_timestamp_us(frame_idx, FrameTimepoint.START)
+        timestamp_end_us = cam.get_frame_timestamp_us(frame_idx, FrameTimepoint.END)
+        mid_timestamp_us = (timestamp_start_us + timestamp_end_us) // 2
+
+        # Camera poses at start/end of frame for rolling-shutter-aware projection
+        T_world_camera_start = cam.get_frames_T_source_sensor(world_id, frame_idx, FrameTimepoint.START)
+        T_world_camera_end = cam.get_frames_T_source_sensor(world_id, frame_idx, FrameTimepoint.END)
+
+        # Iterate over all tracks; interpolate each to the mid-frame time
+        for track in self.data_loader.get_cuboid_tracks():
+            # Filter by label source
+            if track.source.name != self._cuboid_source:
+                continue
+
+            if (obs := track.interpolate_at(mid_timestamp_us)) is None:
+                continue
+
+            # Transform the interpolated observation at mid-of-frame time to world coordinates at mid-frame time
+            obs = obs.transform(
+                target_frame_id=world_id,
+                target_frame_timestamp_us=mid_timestamp_us,
+                pose_graph=pose_graph,
+            )
             bbox = obs.bbox3
 
-            # Observations are in world coordinates — compute corners directly.
+            # Compute 8 corners in world coordinates
             dimensions = np.array(bbox.dim, dtype=np.float32)
             corners_local = _UNIT_CUBE_CORNERS * dimensions
             rotation = RotLib.from_euler("XYZ", bbox.rot).as_matrix().astype(np.float32)
             translation = np.array(bbox.centroid, dtype=np.float32)
             corners_world = (corners_local @ rotation.T + translation).astype(np.float32)
 
-            # Evaluate camera pose at the cuboid's observation time for correct alignment
-            T_world_sensor = pose_graph.evaluate_poses(
-                world_id, cam.sensor_id, np.array(obs.timestamp_us, dtype=np.uint64)
-            )
-            projection = camera_model.world_points_to_image_points_static_pose(
-                torch.from_numpy(corners_world),
-                T_world_sensor,
-                return_valid_indices=True,
+            # Project using the shared projection mode (rolling-shutter / mean / start / end)
+            projection = self._project_points(
+                camera_model,
+                corners_world,
+                T_world_camera_start,
+                T_world_camera_end,
+                self._project_mode,
                 return_all_projections=True,
             )
 
             if projection.valid_indices is None or projection.image_points.shape[0] == 0:
                 continue
 
-            projected_pts = projection.image_points.cpu().numpy().astype(np.float32)
+            projected_pts = projection.image_points.cpu().numpy()
             valid_mask = np.zeros(projected_pts.shape[0], dtype=bool)
-            valid_mask[projection.valid_indices.cpu().numpy().astype(np.int32)] = True
+            valid_mask[projection.valid_indices.cpu().numpy()] = True
 
             # Deterministic color per class
             line_color = self.renderer.get_class_color(obs.class_id)
 
+            # Draw the 12 edges of the cuboid if either corner is valid (visible);
+            # use OpenCV's clipLine to handle partially visible edges
             for corner_a, corner_b in _CUBOID_EDGES:
                 if not (valid_mask[corner_a] or valid_mask[corner_b]):
                     continue

--- a/tools/ncore_vis/components/camera.py
+++ b/tools/ncore_vis/components/camera.py
@@ -713,17 +713,22 @@ class CameraComponent(VisualizationComponent):
         timestamp_end_us = cam.get_frame_timestamp_us(frame_idx, FrameTimepoint.END)
         mid_timestamp_us = (timestamp_start_us + timestamp_end_us) // 2
 
+        # Use the reference-time range as the clamp boundary so tracks are
+        # currently selected remain visible at the scene boundary
+        ref_interval = self.renderer.reference_frame_interval_us
+        max_clamp_us = ref_interval.stop - ref_interval.start
+
         # Camera poses at start/end of frame for rolling-shutter-aware projection
         T_world_camera_start = cam.get_frames_T_source_sensor(world_id, frame_idx, FrameTimepoint.START)
         T_world_camera_end = cam.get_frames_T_source_sensor(world_id, frame_idx, FrameTimepoint.END)
 
-        # Iterate over all tracks; interpolate each to the mid-frame time
+        # Iterate over all tracks; interpolate each to the mid-frame time.
         for track in self.data_loader.get_cuboid_tracks():
             # Filter by label source
             if track.source.name != self._cuboid_source:
                 continue
 
-            if (obs := track.interpolate_at(mid_timestamp_us)) is None:
+            if (obs := track.interpolate_at(mid_timestamp_us, max_clamp_us=max_clamp_us)) is None:
                 continue
 
             # Transform the interpolated observation at mid-of-frame time to world coordinates at mid-frame time

--- a/tools/ncore_vis/components/camera.py
+++ b/tools/ncore_vis/components/camera.py
@@ -443,11 +443,13 @@ class CameraComponent(VisualizationComponent):
             if label := self._labels.pop(camera_id, None):
                 label.remove()
 
-            frame = self._frame_sliders[camera_id].value
+            frame_idx = self._frame_sliders[camera_id].value
             visible = self._visible[camera_id]
 
             cam = self.data_loader.get_camera_sensor(camera_id)
-            T_camera_world = cam.get_frames_T_sensor_target(self.data_loader.world_frame_id, frame, FrameTimepoint.END)
+            T_camera_world = cam.get_frames_T_sensor_target(
+                self.data_loader.world_frame_id, frame_idx, FrameTimepoint.END
+            )
             position, wxyz = se3_to_position_wxyz(T_camera_world)
 
             # Pose frame
@@ -462,25 +464,25 @@ class CameraComponent(VisualizationComponent):
             self._poses[camera_id] = pose_handle
 
             # Image (with optional overlays)
-            image = cam.get_frame_image_array(frame)
+            image = cam.get_frame_image_array(frame_idx)
 
             if self._project_lidar:
                 try:
-                    image = self._overlay_lidar_projection(camera_id, frame, image)
+                    image = self._overlay_lidar_projection(camera_id, frame_idx, image)
                 except Exception:
-                    logger.debug("Lidar projection overlay failed for %s frame %d", camera_id, frame, exc_info=True)
+                    logger.debug("Lidar projection overlay failed for %s frame %d", camera_id, frame_idx, exc_info=True)
 
             if self._overlay_cuboids:
                 try:
                     image = self._overlay_cuboids_on_image(camera_id, image)
                 except Exception:
-                    logger.debug("Cuboid overlay failed for %s frame %d", camera_id, frame, exc_info=True)
+                    logger.debug("Cuboid overlay failed for %s frame %d", camera_id, frame_idx, exc_info=True)
 
             if self._show_mask:
                 try:
                     image = self._overlay_mask(camera_id, image)
                 except Exception:
-                    logger.debug("Mask overlay failed for %s frame %d", camera_id, frame, exc_info=True)
+                    logger.debug("Mask overlay failed for %s frame %d", camera_id, frame_idx, exc_info=True)
 
             frustum_handle = self.client.scene.add_camera_frustum(
                 f"/cameras/{camera_id}/pose/frustum",
@@ -557,12 +559,12 @@ class CameraComponent(VisualizationComponent):
     # Lidar projection overlay
     # ------------------------------------------------------------------
 
-    def _overlay_lidar_projection(self, camera_id: str, frame: int, image: np.ndarray) -> np.ndarray:
+    def _overlay_lidar_projection(self, camera_id: str, frame_idx: int, image: np.ndarray) -> np.ndarray:
         """Project a lidar point cloud onto the camera image with range-based coloring.
 
         Args:
             camera_id: Camera sensor to project onto.
-            frame: Camera frame index.
+            frame_idx: Camera frame index.
             image: RGB image array (H, W, 3), uint8.
 
         Returns:
@@ -577,19 +579,21 @@ class CameraComponent(VisualizationComponent):
         camera_model = self._camera_models[camera_id]
 
         # Find closest lidar frame to the camera frame (by center-of-frame timestamp)
-        cam_interval = self.data_loader.get_sensor_frame_interval_us(camera_id, frame)
+        cam_interval = self.data_loader.get_sensor_frame_interval_us(camera_id, frame_idx)
         cam_center_us = cam_interval.start + (cam_interval.end - cam_interval.start) // 2
-        lidar_frame = lidar_sensor.get_closest_frame_index(cam_center_us, relative_frame_time=0.5)
+        lidar_frame_idx = lidar_sensor.get_closest_frame_index(cam_center_us, relative_frame_time=0.5)
 
         # Load point cloud and transform to world coordinates
-        pc_sensor = lidar_sensor.get_frame_point_cloud(lidar_frame, motion_compensation=True, with_start_points=False)
+        pc_sensor = lidar_sensor.get_frame_point_cloud(
+            lidar_frame_idx, motion_compensation=True, with_start_points=False
+        )
         world_id = self.data_loader.world_frame_id
-        T_lidar_world = lidar_sensor.get_frames_T_sensor_target(world_id, lidar_frame, FrameTimepoint.END)
+        T_lidar_world = lidar_sensor.get_frames_T_sensor_target(world_id, lidar_frame_idx, FrameTimepoint.END)
         pc_world = transform_point_cloud(pc_sensor.xyz_m_end, T_lidar_world)
 
         # Get camera world-to-sensor transforms (T_world_camera)
-        T_world_camera_start = cam.get_frames_T_source_sensor(world_id, frame, FrameTimepoint.START)
-        T_world_camera_end = cam.get_frames_T_source_sensor(world_id, frame, FrameTimepoint.END)
+        T_world_camera_start = cam.get_frames_T_source_sensor(world_id, frame_idx, FrameTimepoint.START)
+        T_world_camera_end = cam.get_frames_T_source_sensor(world_id, frame_idx, FrameTimepoint.END)
 
         # Project world points to image coordinates
         mode = self._project_mode

--- a/tools/ncore_vis/components/cuboids.py
+++ b/tools/ncore_vis/components/cuboids.py
@@ -112,7 +112,9 @@ class CuboidsComponent(VisualizationComponent):
             visible = self._enabled
             show_labels = self._show_labels
 
-            observations = self.data_loader.get_cuboid_observations_in_world(interval_us, source_filter=source)
+            observations = self.data_loader.get_cuboid_observations_in_world(
+                interval_us, "end-of-interval", source_filter=source
+            )
 
             # Observations are already in world coordinates.
             for i, obs in enumerate(observations):

--- a/tools/ncore_vis/components/lidar.py
+++ b/tools/ncore_vis/components/lidar.py
@@ -335,7 +335,7 @@ class LidarComponent(VisualizationComponent):
             if point_cloud := self._point_clouds.pop(lidar_id, None):
                 point_cloud.remove()
 
-            frame = self._frame_sliders[lidar_id].value
+            frame_idx = self._frame_sliders[lidar_id].value
             is_fused = self._is_fused[lidar_id]
             fused_range = self._fused_range[lidar_id]
             fused_step = self._fused_frame_step[lidar_id]
@@ -344,7 +344,7 @@ class LidarComponent(VisualizationComponent):
 
             pc_handle = self._create_point_cloud(
                 lidar_id,
-                frame,
+                frame_idx,
                 is_fused,
                 fused_range,
                 fused_step,
@@ -357,7 +357,7 @@ class LidarComponent(VisualizationComponent):
     def _create_point_cloud(
         self,
         lidar_id: str,
-        frame: int,
+        frame_idx: int,
         is_fused: bool,
         fused_range: Tuple[int, int],
         fused_step: int,
@@ -379,12 +379,12 @@ class LidarComponent(VisualizationComponent):
                 points_world, points_sensor = self._get_fused_point_cloud(
                     lidar_id, fused_range[0], fused_range[1], fused_step
                 )
-                colors = self._colorize_points(lidar_id, frame, points_sensor, points_world)
+                colors = self._colorize_points(lidar_id, frame_idx, points_sensor, points_world)
         else:
             handle_name = f"/lidars/{lidar_id}/point_cloud"
-            points_sensor = self._get_point_cloud_sensor(lidar_id, frame)
-            points_world = self._transform_to_world(lidar_id, frame, points_sensor)
-            colors = self._colorize_points(lidar_id, frame, points_sensor, points_world)
+            points_sensor = self._get_point_cloud_sensor(lidar_id, frame_idx)
+            points_world = self._transform_to_world(lidar_id, frame_idx, points_sensor)
+            colors = self._colorize_points(lidar_id, frame_idx, points_sensor, points_world)
 
         return self.client.scene.add_point_cloud(
             handle_name,
@@ -399,24 +399,26 @@ class LidarComponent(VisualizationComponent):
     # Point cloud loading
     # ------------------------------------------------------------------
 
-    def _get_point_cloud_sensor(self, lidar_id: str, frame: int) -> np.ndarray:
+    def _get_point_cloud_sensor(self, lidar_id: str, frame_idx: int) -> np.ndarray:
         """Load a single-frame point cloud in sensor coordinates."""
         sensor = self.data_loader.get_lidar_sensor(lidar_id)
         motion_comp = self._motion_comp[lidar_id]
-        pc = sensor.get_frame_point_cloud(frame, motion_compensation=motion_comp, with_start_points=False)
+        pc = sensor.get_frame_point_cloud(frame_idx, motion_compensation=motion_comp, with_start_points=False)
         return pc.xyz_m_end
 
-    def _transform_to_world(self, lidar_id: str, frame: int, points_sensor: np.ndarray) -> np.ndarray:
+    def _transform_to_world(self, lidar_id: str, frame_idx: int, points_sensor: np.ndarray) -> np.ndarray:
         """Transform sensor-frame points to world coordinates."""
         sensor = self.data_loader.get_lidar_sensor(lidar_id)
-        T_sensor_world = sensor.get_frames_T_sensor_target(self.data_loader.world_frame_id, frame, FrameTimepoint.END)
+        T_sensor_world = sensor.get_frames_T_sensor_target(
+            self.data_loader.world_frame_id, frame_idx, FrameTimepoint.END
+        )
         return transform_point_cloud(points_sensor, T_sensor_world)
 
     def _get_fused_point_cloud(
         self,
         lidar_id: str,
-        start_frame: int,
-        end_frame: int,
+        start_frame_idx: int,
+        end_frame_idx: int,
         step: int,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """Accumulate point clouds over a frame range (parallel frame loading).
@@ -424,14 +426,14 @@ class LidarComponent(VisualizationComponent):
         Returns:
             Tuple of (world-frame points, sensor-frame points).
         """
-        frames = list(range(start_frame, end_frame + 1, max(1, step)))
+        frame_idxs = list(range(start_frame_idx, end_frame_idx + 1, max(1, step)))
 
-        def _load(frame: int) -> Tuple[np.ndarray, np.ndarray]:
-            pts_sensor = self._get_point_cloud_sensor(lidar_id, frame)
-            pts_world = self._transform_to_world(lidar_id, frame, pts_sensor)
+        def _load(frame_idx: int) -> Tuple[np.ndarray, np.ndarray]:
+            pts_sensor = self._get_point_cloud_sensor(lidar_id, frame_idx)
+            pts_world = self._transform_to_world(lidar_id, frame_idx, pts_sensor)
             return pts_world, pts_sensor
 
-        results = list(self.renderer._executor.map(_load, frames))
+        results = list(self.renderer._executor.map(_load, frame_idxs))
         all_world = [r[0] for r in results]
         all_sensor = [r[1] for r in results]
         return np.concatenate(all_world), np.concatenate(all_sensor)
@@ -439,8 +441,8 @@ class LidarComponent(VisualizationComponent):
     def _get_fused_point_cloud_with_colors(
         self,
         lidar_id: str,
-        start_frame: int,
-        end_frame: int,
+        start_frame_idx: int,
+        end_frame_idx: int,
         step: int,
     ) -> Tuple[np.ndarray, np.ndarray]:
         """Accumulate point clouds with per-frame coloring over a frame range (parallel).
@@ -451,15 +453,15 @@ class LidarComponent(VisualizationComponent):
         Returns:
             Tuple of (world-frame points, colors).
         """
-        frames = list(range(start_frame, end_frame + 1, max(1, step)))
+        frame_idxs = list(range(start_frame_idx, end_frame_idx + 1, max(1, step)))
 
-        def _load_and_color(frame: int) -> Tuple[np.ndarray, np.ndarray]:
-            pts_sensor = self._get_point_cloud_sensor(lidar_id, frame)
-            pts_world = self._transform_to_world(lidar_id, frame, pts_sensor)
-            colors = self._colorize_points(lidar_id, frame, pts_sensor, pts_world)
+        def _load_and_color(frame_idx: int) -> Tuple[np.ndarray, np.ndarray]:
+            pts_sensor = self._get_point_cloud_sensor(lidar_id, frame_idx)
+            pts_world = self._transform_to_world(lidar_id, frame_idx, pts_sensor)
+            colors = self._colorize_points(lidar_id, frame_idx, pts_sensor, pts_world)
             return pts_world, colors
 
-        results = list(self.renderer._executor.map(_load_and_color, frames))
+        results = list(self.renderer._executor.map(_load_and_color, frame_idxs))
         all_world = [r[0] for r in results]
         all_colors = [r[1] for r in results]
         return np.concatenate(all_world), np.concatenate(all_colors)
@@ -471,7 +473,7 @@ class LidarComponent(VisualizationComponent):
     def _colorize_points(
         self,
         lidar_id: str,
-        frame: int,
+        frame_idx: int,
         points_sensor: np.ndarray,
         points_world: np.ndarray,
     ) -> np.ndarray:
@@ -479,7 +481,7 @@ class LidarComponent(VisualizationComponent):
 
         Args:
             lidar_id: Lidar sensor ID.
-            frame: Current frame index (used for per-frame data lookups).
+            frame_idx: Current frame index (used for per-frame data lookups).
             points_sensor: Point cloud in sensor coordinates ``[N, 3]``.
             points_world: Point cloud in world coordinates ``[N, 3]``.
 
@@ -494,22 +496,22 @@ class LidarComponent(VisualizationComponent):
         if color_style == "Height (turbo)":
             return self._color_height_turbo(points_world, lidar_id)
         if color_style == "Timestamp":
-            return self._color_timestamp(lidar_id, frame, n_points)
+            return self._color_timestamp(lidar_id, frame_idx, n_points)
         if color_style == "Model Row":
-            return self._color_model_element(lidar_id, frame, n_points, column=0)
+            return self._color_model_element(lidar_id, frame_idx, n_points, column=0)
         if color_style == "Model Column":
-            return self._color_model_element(lidar_id, frame, n_points, column=1)
+            return self._color_model_element(lidar_id, frame_idx, n_points, column=1)
         if color_style in self._metadata_color_fields.get(lidar_id, []):
-            return self._color_metadata_field(lidar_id, frame, color_style, n_points)
+            return self._color_metadata_field(lidar_id, frame_idx, color_style, n_points)
 
         # Intensity-based modes
-        return self._color_intensity(lidar_id, frame, color_style, n_points)
+        return self._color_intensity(lidar_id, frame_idx, color_style, n_points)
 
-    def _color_intensity(self, lidar_id: str, frame: int, style: str, n_points: int) -> np.ndarray:
+    def _color_intensity(self, lidar_id: str, frame_idx: int, style: str, n_points: int) -> np.ndarray:
         """Intensity-based coloring with optional gamma correction."""
         sensor = self.data_loader.get_lidar_sensor(lidar_id)
         try:
-            intensity = sensor.get_frame_ray_bundle_return_intensity(frame, return_index=0)
+            intensity = sensor.get_frame_ray_bundle_return_intensity(frame_idx, return_index=0)
         except Exception:
             return np.tile(_DEFAULT_POINT_COLOR, (n_points, 1))
 
@@ -540,11 +542,11 @@ class LidarComponent(VisualizationComponent):
         rgba = _TURBO_CMAP(normalized)  # [N, 4] float in [0, 1]
         return (rgba[:, :3] * 255.0).astype(np.uint8)
 
-    def _color_timestamp(self, lidar_id: str, frame: int, n_points: int) -> np.ndarray:
+    def _color_timestamp(self, lidar_id: str, frame_idx: int, n_points: int) -> np.ndarray:
         """Color by per-point timestamp within the frame using the turbo colormap."""
         sensor = self.data_loader.get_lidar_sensor(lidar_id)
         try:
-            timestamps = sensor.get_frame_ray_bundle_timestamp_us(frame)
+            timestamps = sensor.get_frame_ray_bundle_timestamp_us(frame_idx)
         except Exception:
             return np.tile(_DEFAULT_POINT_COLOR, (n_points, 1))
 
@@ -555,19 +557,19 @@ class LidarComponent(VisualizationComponent):
         rgba = _TURBO_CMAP(normalized)
         return (rgba[:, :3] * 255.0).astype(np.uint8)
 
-    def _color_model_element(self, lidar_id: str, frame: int, n_points: int, column: int) -> np.ndarray:
+    def _color_model_element(self, lidar_id: str, frame_idx: int, n_points: int, column: int) -> np.ndarray:
         """Color by model element index (row or column) using the turbo colormap.
 
         Args:
             lidar_id: Lidar sensor ID.
-            frame: Frame index.
+            frame_idx: Frame index.
             n_points: Number of points (for fallback).
             column: 0 for row index, 1 for column index.
         """
         sensor = self.data_loader.get_lidar_sensor(lidar_id)
         model_elements: Optional[np.ndarray] = None
         try:
-            model_elements = sensor.get_frame_ray_bundle_model_element(frame)
+            model_elements = sensor.get_frame_ray_bundle_model_element(frame_idx)
         except Exception:
             pass
 
@@ -580,7 +582,7 @@ class LidarComponent(VisualizationComponent):
         rgba = _TURBO_CMAP(normalized)
         return (rgba[:, :3] * 255.0).astype(np.uint8)
 
-    def _color_metadata_field(self, lidar_id: str, frame: int, field_name: str, n_points: int) -> np.ndarray:
+    def _color_metadata_field(self, lidar_id: str, frame_idx: int, field_name: str, n_points: int) -> np.ndarray:
         """Color by a generic_data metadata field.
 
         Single-channel fields are treated as intensity (grayscale).
@@ -591,7 +593,7 @@ class LidarComponent(VisualizationComponent):
         """
         try:
             sensor = self.data_loader.get_lidar_sensor(lidar_id)
-            ts = sensor.frames_timestamps_us[frame, 1].item()
+            ts = sensor.frames_timestamps_us[frame_idx, 1].item()
             data = np.asarray(sensor.get_frame_generic_data(ts, field_name))
         except KeyError:
             # No metadata of this type at this timestamp

--- a/tools/ncore_vis/data_loader.py
+++ b/tools/ncore_vis/data_loader.py
@@ -21,7 +21,7 @@ import dataclasses
 import functools
 import logging
 
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 import numpy as np
 import pandas as pd
@@ -214,15 +214,16 @@ class DataLoader:
     def get_cuboid_observations_in_world(
         self,
         interval_us: HalfClosedInterval,
+        target_time: Literal["end-of-interval", "observation-time"],
         source_filter: Optional[str] = None,
     ) -> List[CuboidTrackObservation]:
         """Return cuboid observations within a time window, transformed to world coordinates.
 
         Selects all observations whose ``timestamp_us`` falls within *interval_us*,
-        then transforms each one into the world coordinate frame at the interval's
-        end timestamp (``interval_us.end``) via the pose graph.  The returned
-        observations have ``reference_frame_id == self.world_frame_id`` and their
-        ``bbox3`` expressed in world coordinates, ready for direct rendering.
+        then transforms each one into the world coordinate frame at the specified
+        target time via the pose graph.  The returned observations have
+        ``reference_frame_id == self.world_frame_id`` and their ``bbox3`` expressed
+        in world coordinates, ready for direct rendering.
 
         This method is sensor-agnostic: observations can originate from any reference
         frame in the pose graph (lidar, camera, rig, etc.) and will be correctly
@@ -232,6 +233,8 @@ class DataLoader:
             interval_us: Half-closed ``[start, stop)`` timestamp interval in
                 microseconds.  Typically obtained from
                 :meth:`get_sensor_frame_interval_us`.
+            target_time: Whether to evaluate the pose graph at the end of the interval
+                or at the observation's own timestamp.
             source_filter: If set, only return observations from this :class:`LabelSource` name.
 
         Returns:
@@ -252,13 +255,12 @@ class DataLoader:
 
         pose_graph = self.pose_graph
         world_frame_id = self._world_frame_id
-        end_timestamp_us = interval_us.end
         result: List[CuboidTrackObservation] = []
         for _, row in matched_rows.iterrows():
             obs = CuboidTrackObservation.from_dict(row.to_dict())
             obs = obs.transform(
                 target_frame_id=world_frame_id,
-                target_frame_timestamp_us=end_timestamp_us,
+                target_frame_timestamp_us=interval_us.end if target_time == "end-of-interval" else obs.timestamp_us,
                 pose_graph=pose_graph,
             )
             result.append(obs)

--- a/tools/ncore_vis/data_loader.py
+++ b/tools/ncore_vis/data_loader.py
@@ -51,8 +51,17 @@ class DataLoader:
         self._loader: SequenceLoaderProtocol = loader
         self._rig_frame_id: Optional[str] = rig_frame_id
         self._world_frame_id: str = world_frame_id
-        self._cuboid_df: Optional[pd.DataFrame] = None
-        self._cuboid_tracks: Optional[List[CuboidTrack]] = None
+
+        # Build cuboid DataFrame and tracks eagerly (thread-safe: done once at init)
+        observations = list(self._loader.get_cuboid_track_observations())
+        if observations:
+            self._cuboid_df: pd.DataFrame = pd.DataFrame.from_records(
+                [obs.to_dict() for obs in observations],
+                columns=[field.name for field in dataclasses.fields(CuboidTrackObservation)],
+            )
+        else:
+            self._cuboid_df = pd.DataFrame(columns=[field.name for field in dataclasses.fields(CuboidTrackObservation)])
+        self._cuboid_tracks: List[CuboidTrack] = CuboidTrack.from_observations(observations)
 
     # ------------------------------------------------------------------
     # Sensor access
@@ -198,21 +207,6 @@ class DataLoader:
         """Available label source names derived from the :class:`LabelSource` enum."""
         return [s.name for s in LabelSource]
 
-    def _ensure_cuboid_df(self) -> pd.DataFrame:
-        """Lazily load cuboid observations into a DataFrame for efficient querying."""
-        if self._cuboid_df is None:
-            observations = list(self._loader.get_cuboid_track_observations())
-            if observations:
-                self._cuboid_df = pd.DataFrame.from_records(
-                    [obs.to_dict() for obs in observations],
-                    columns=[field.name for field in dataclasses.fields(CuboidTrackObservation)],
-                )
-            else:
-                self._cuboid_df = pd.DataFrame(
-                    columns=[field.name for field in dataclasses.fields(CuboidTrackObservation)]
-                )
-        return self._cuboid_df
-
     def get_cuboid_observations_in_world(
         self,
         interval_us: HalfClosedInterval,
@@ -242,7 +236,7 @@ class DataLoader:
         Returns:
             List of :class:`CuboidTrackObservation` in world coordinates.
         """
-        cuboid_df = self._ensure_cuboid_df()
+        cuboid_df = self._cuboid_df
         if cuboid_df.empty:
             return []
 
@@ -269,12 +263,9 @@ class DataLoader:
         return result
 
     def get_cuboid_tracks(self) -> List[CuboidTrack]:
-        """Return all cuboid tracks for the sequence, lazily built and cached.
+        """Return all cuboid tracks for the sequence (built once at init time).
 
-        Tracks are constructed once from the full set of cuboid observations
-        (i.e. the entire sequence, not filtered by any time interval) and then
-        cached for the lifetime of this :class:`DataLoader`.  Each
-        :class:`~tools.ncore_vis.tracks.CuboidTrack` covers all labelled
+        Each :class:`~tools.ncore_vis.tracks.CuboidTrack` covers all labelled
         keyframes for one tracked object.
 
         Callers that need the interpolated cuboid pose at a specific timestamp
@@ -287,11 +278,4 @@ class DataLoader:
             unique ``track_id`` in the sequence.  Returns an empty list when
             no cuboid observations are available.
         """
-        if self._cuboid_tracks is None:
-            cuboid_df = self._ensure_cuboid_df()
-            if cuboid_df.empty:
-                self._cuboid_tracks = []
-            else:
-                all_obs = [CuboidTrackObservation.from_dict(row.to_dict()) for _, row in cuboid_df.iterrows()]
-                self._cuboid_tracks = CuboidTrack.from_observations(all_obs)
         return self._cuboid_tracks

--- a/tools/ncore_vis/data_loader.py
+++ b/tools/ncore_vis/data_loader.py
@@ -29,6 +29,7 @@ import pandas as pd
 from ncore.impl.common.transformations import HalfClosedInterval, PoseGraphInterpolator
 from ncore.impl.data.compat import CameraSensorProtocol, LidarSensorProtocol, SensorProtocol, SequenceLoaderProtocol
 from ncore.impl.data.types import CuboidTrackObservation, FrameTimepoint, LabelSource
+from tools.ncore_vis.tracks import CuboidTrack
 
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ class DataLoader:
         self._rig_frame_id: Optional[str] = rig_frame_id
         self._world_frame_id: str = world_frame_id
         self._cuboid_df: Optional[pd.DataFrame] = None
+        self._cuboid_tracks: Optional[List[CuboidTrack]] = None
 
     # ------------------------------------------------------------------
     # Sensor access
@@ -265,3 +267,31 @@ class DataLoader:
             )
             result.append(obs)
         return result
+
+    def get_cuboid_tracks(self) -> List[CuboidTrack]:
+        """Return all cuboid tracks for the sequence, lazily built and cached.
+
+        Tracks are constructed once from the full set of cuboid observations
+        (i.e. the entire sequence, not filtered by any time interval) and then
+        cached for the lifetime of this :class:`DataLoader`.  Each
+        :class:`~tools.ncore_vis.tracks.CuboidTrack` covers all labelled
+        keyframes for one tracked object.
+
+        Callers that need the interpolated cuboid pose at a specific timestamp
+        (e.g. a camera frame's mid-of-frame time) should call
+        :meth:`~tools.ncore_vis.tracks.CuboidTrack.interpolate_at` on each
+        returned track.
+
+        Returns:
+            List of :class:`~tools.ncore_vis.tracks.CuboidTrack`, one per
+            unique ``track_id`` in the sequence.  Returns an empty list when
+            no cuboid observations are available.
+        """
+        if self._cuboid_tracks is None:
+            cuboid_df = self._ensure_cuboid_df()
+            if cuboid_df.empty:
+                self._cuboid_tracks = []
+            else:
+                all_obs = [CuboidTrackObservation.from_dict(row.to_dict()) for _, row in cuboid_df.iterrows()]
+                self._cuboid_tracks = CuboidTrack.from_observations(all_obs)
+        return self._cuboid_tracks

--- a/tools/ncore_vis/renderer.py
+++ b/tools/ncore_vis/renderer.py
@@ -94,14 +94,14 @@ class NCoreVisRenderer:
                 self._class_colors[class_id] = (int(color[0]), int(color[1]), int(color[2]))
             return self._class_colors[class_id]
 
-    def update_all_sensor_frames(self, ref_frame: int) -> None:
+    def update_all_sensor_frames(self, ref_frame_idx: int) -> None:
         """Synchronize all sensor frame sliders to the reference sensor's *ref_frame*.
 
         Computes the reference frame interval from the reference sensor and
         triggers ``on_reference_frame_change`` on each component.
         """
         self.reference_frame_interval_us = self.data_loader.get_sensor_frame_interval_us(
-            self.reference_sensor, ref_frame
+            self.reference_sensor, ref_frame_idx
         )
         for component in self._components:
             component.on_reference_frame_change(self.reference_frame_interval_us)
@@ -159,7 +159,7 @@ class NCoreVisRenderer:
         self.reference_sensor = all_sensor_ids[0]
 
         # Determine initial frame range from first sensor
-        max_frame = self._get_sensor_max_frame(self.reference_sensor)
+        max_frame_idx = self._get_sensor_max_frame_idx(self.reference_sensor)
 
         # Set initial reference frame interval from frame 0.
         self.reference_frame_interval_us = self.data_loader.get_sensor_frame_interval_us(self.reference_sensor, 0)
@@ -169,7 +169,7 @@ class NCoreVisRenderer:
             self._ref_frame_slider = self.client.gui.add_slider(
                 "Reference Frame",
                 min=0,
-                max=max_frame,
+                max=max_frame_idx,
                 initial_value=0,
                 step=1,
                 hint="0-based frame index of the reference sensor",
@@ -235,14 +235,14 @@ class NCoreVisRenderer:
             @reference_dropdown.on_update
             def _on_ref_sensor_update(_: viser.GuiEvent) -> None:
                 self.reference_sensor = reference_dropdown.value
-                new_max = self._get_sensor_max_frame(reference_dropdown.value)
+                new_max_idx = self._get_sensor_max_frame_idx(reference_dropdown.value)
 
                 # Recreate the slider with the new range
                 self._ref_frame_slider.remove()
                 self._ref_frame_slider = self.client.gui.add_slider(
                     "Reference Frame",
                     min=0,
-                    max=new_max,
+                    max=new_max_idx,
                     initial_value=0,
                     step=1,
                     hint="0-based frame index of the reference sensor",
@@ -258,20 +258,20 @@ class NCoreVisRenderer:
     def _run_playback(self) -> None:
         """Advance the reference frame at the configured FPS until paused or stopped."""
         while self._playing:
-            max_frame = self._get_sensor_max_frame(self.reference_sensor)
-            current = self._ref_frame_slider.value
-            next_frame = current + 1
+            max_frame_idx = self._get_sensor_max_frame_idx(self.reference_sensor)
+            current_idx = self._ref_frame_slider.value
+            next_frame_idx = current_idx + 1
 
-            if next_frame > max_frame:
+            if next_frame_idx > max_frame_idx:
                 if self._loop:
-                    next_frame = 0
+                    next_frame_idx = 0
                 else:
                     self._playing = False
                     # Reset button to Play state — access via the GUI handle
                     break
 
-            self._ref_frame_slider.value = next_frame
-            self.update_all_sensor_frames(next_frame)
+            self._ref_frame_slider.value = next_frame_idx
+            self.update_all_sensor_frames(next_frame_idx)
             time.sleep(1.0 / max(1.0, self._playback_fps))
 
     # ------------------------------------------------------------------
@@ -282,7 +282,7 @@ class NCoreVisRenderer:
         """Handle reference frame slider value changes."""
         self.update_all_sensor_frames(self._ref_frame_slider.value)
 
-    def _get_sensor_max_frame(self, sensor_id: str) -> int:
+    def _get_sensor_max_frame_idx(self, sensor_id: str) -> int:
         """Get the maximum frame index for a sensor."""
         if sensor_id in self.data_loader.camera_ids:
             return max(0, self.data_loader.get_camera_sensor(sensor_id).frames_count - 1)

--- a/tools/ncore_vis/tracks.py
+++ b/tools/ncore_vis/tracks.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cuboid track type with temporal interpolation.
+
+A :class:`CuboidTrack` groups all :class:`~ncore.impl.data.types.CuboidTrackObservation`
+instances that share the same ``track_id`` and exposes
+:meth:`CuboidTrack.interpolate_at` to obtain an interpolated observation at any
+target timestamp.  Translation is interpolated linearly and rotation via SLERP,
+using :class:`~ncore.impl.common.transformations.PoseInterpolator`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from ncore.impl.common.transformations import PoseInterpolator, bbox_pose, pose_bbox
+from ncore.impl.data.types import BBox3, CuboidTrackObservation
+
+
+@dataclass
+class CuboidTrack:
+    """Temporal sequence of cuboid observations for a single tracked object.
+
+    All observations must share the same ``track_id``.  The sequence need not be
+    dense; observations represent the labelled keyframes provided by the label source.
+
+    Use :meth:`interpolate_at` to obtain a smoothly blended observation at any
+    target timestamp within the track's time range.  Queries outside the range
+    return ``None``.
+
+    Use the :meth:`from_observations` factory to build a list of tracks from a
+    flat, heterogeneous list of observations (e.g. the full sequence cache).
+    """
+
+    observations: List[CuboidTrackObservation]
+    """Observations sorted by ``timestamp_us`` ascending (enforced in ``__post_init__``)."""
+
+    def __post_init__(self) -> None:
+        if not self.observations:
+            raise ValueError("CuboidTrack requires at least one observation")
+        track_ids = {obs.track_id for obs in self.observations}
+        if len(track_ids) != 1:
+            raise ValueError(f"CuboidTrack observations must all share the same track_id, got: {sorted(track_ids)}")
+        # Ensure chronological order (may arrive unsorted from the loader)
+        self.observations = sorted(self.observations, key=lambda o: o.timestamp_us)
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def track_id(self) -> str:
+        """Unique track identifier shared by all observations."""
+        return self.observations[0].track_id
+
+    @property
+    def class_id(self) -> str:
+        """Object class label (from the first observation; assumed stable across the track)."""
+        return self.observations[0].class_id
+
+    @property
+    def source(self):
+        """Label source (from the first observation)."""
+        return self.observations[0].source
+
+    # ------------------------------------------------------------------
+    # Interpolation
+    # ------------------------------------------------------------------
+
+    def interpolate_at(self, timestamp_us: int) -> Optional[CuboidTrackObservation]:
+        """Return an interpolated observation at *timestamp_us*, or ``None`` if out of range.
+
+        The interpolated bbox pose (centroid + orientation) is computed by
+        finding the two observations that bracket *timestamp_us* and blending
+        them via :class:`~ncore.impl.common.transformations.PoseInterpolator`
+        (linear translation + SLERP rotation).  ``bbox3.dim`` (dimensions) are
+        taken from the earlier bracketing observation and are **not** interpolated.
+
+        Out-of-range queries return ``None``:
+
+        * Before the first observation's timestamp → ``None``.
+        * After the last observation's timestamp → ``None``.
+
+        For a single-observation track, only a query exactly at that observation's
+        timestamp returns a result; all other times return ``None``.
+
+        Args:
+            timestamp_us: Target timestamp in microseconds.
+
+        Returns:
+            A :class:`~ncore.impl.data.types.CuboidTrackObservation` whose
+            ``timestamp_us`` equals *timestamp_us* and whose ``bbox3`` is
+            interpolated to that time, or ``None`` if *timestamp_us* is outside
+            the track's time range.
+        """
+
+        obs = self.observations
+
+        # --- Out-of-range: return None ---
+        if timestamp_us < obs[0].timestamp_us or timestamp_us > obs[-1].timestamp_us:
+            return None
+
+        # --- Exact endpoint match, also handles single-observation tracks if matching ---
+        if timestamp_us == obs[0].timestamp_us:
+            return replace(obs[0], timestamp_us=timestamp_us, reference_frame_timestamp_us=timestamp_us)
+        if timestamp_us == obs[-1].timestamp_us:
+            return replace(obs[-1], timestamp_us=timestamp_us, reference_frame_timestamp_us=timestamp_us)
+
+        # --- Find bracketing pair via binary search ---
+
+        # searchsorted(..., side="right") gives the first index strictly greater than timestamp_us
+        idx_after = int(np.searchsorted([o.timestamp_us for o in obs], timestamp_us, side="right"))
+        idx_before = idx_after - 1
+        obs_before = obs[idx_before]
+        obs_after = obs[idx_after]
+
+        alpha = (float(timestamp_us) - obs_before.timestamp_us) / (
+            obs_after.timestamp_us - obs_before.timestamp_us
+        )  # in (0, 1)
+
+        # Build SE3 matrices from both bboxes and let PoseInterpolator blend them.
+        # We parametrise the two keyframes at t=0.0 and t=1.0, query at alpha.
+        poses = np.stack(
+            [
+                bbox_pose(obs_before.bbox3.to_array()),
+                bbox_pose(obs_after.bbox3.to_array()),
+            ],
+            axis=0,
+        )  # (2, 4, 4)
+        blended_pose = PoseInterpolator(poses, [0.0, 1.0]).interpolate_to_timestamps(alpha)[0]  # (4, 4)
+
+        # Reconstruct BBox3: preserve dimensions from the earlier observation
+        blended_bbox = BBox3.from_array(pose_bbox(blended_pose, np.array(obs_before.bbox3.dim)))
+
+        return replace(
+            obs_before,
+            timestamp_us=timestamp_us,
+            reference_frame_timestamp_us=timestamp_us,
+            bbox3=blended_bbox,
+        )
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def from_observations(observations: List[CuboidTrackObservation]) -> List["CuboidTrack"]:
+        """Group a flat list of observations into per-track :class:`CuboidTrack` objects.
+
+        Observations are grouped by ``track_id``.  The order of tracks in the
+        returned list is deterministic (insertion order of first occurrence).
+
+        Args:
+            observations: Flat list of :class:`~ncore.impl.data.types.CuboidTrackObservation`
+                instances, potentially spanning multiple tracks.
+
+        Returns:
+            One :class:`CuboidTrack` per unique ``track_id`` found in *observations*.
+            Returns an empty list when *observations* is empty.
+        """
+        by_track: Dict[str, List[CuboidTrackObservation]] = {}
+        for obs in observations:
+            by_track.setdefault(obs.track_id, []).append(obs)
+        return [CuboidTrack(observations=group) for group in by_track.values()]

--- a/tools/ncore_vis/tracks.py
+++ b/tools/ncore_vis/tracks.py
@@ -83,8 +83,10 @@ class CuboidTrack:
     # Interpolation
     # ------------------------------------------------------------------
 
-    def interpolate_at(self, timestamp_us: int) -> Optional[CuboidTrackObservation]:
-        """Return an interpolated observation at *timestamp_us*, or ``None`` if out of range.
+    def interpolate_at(
+        self, timestamp_us: int, *, max_clamp_us: Optional[int] = None
+    ) -> Optional[CuboidTrackObservation]:
+        """Return an interpolated observation at *timestamp_us*.
 
         The interpolated bbox pose (centroid + orientation) is computed by
         finding the two observations that bracket *timestamp_us* and blending
@@ -92,34 +94,37 @@ class CuboidTrack:
         (linear translation + SLERP rotation).  ``bbox3.dim`` (dimensions) are
         taken from the earlier bracketing observation and are **not** interpolated.
 
-        Out-of-range queries return ``None``:
+        Out-of-range behaviour depends on *max_clamp_us*:
 
-        * Before the first observation's timestamp → ``None``.
-        * After the last observation's timestamp → ``None``.
-
-        For a single-observation track, only a query exactly at that observation's
-        timestamp returns a result; all other times return ``None``.
+        * ``None`` (default): out-of-range queries return ``None``.
+        * An ``int`` value: queries up to *max_clamp_us* microseconds outside
+          the track's time range are clamped to the nearest boundary observation.
+          Queries further away return ``None``.
 
         Args:
             timestamp_us: Target timestamp in microseconds.
+            max_clamp_us: Maximum number of microseconds to clamp beyond the
+                track's first/last observation.  ``None`` disables clamping.
 
         Returns:
             A :class:`~ncore.impl.data.types.CuboidTrackObservation` whose
             ``timestamp_us`` equals *timestamp_us* and whose ``bbox3`` is
-            interpolated to that time, or ``None`` if *timestamp_us* is outside
-            the track's time range.
+            interpolated to that time, or ``None`` when *timestamp_us* is outside
+            the (optionally extended) time range.
         """
 
         obs = self.observations
 
-        # --- Out-of-range: return None ---
-        if timestamp_us < obs[0].timestamp_us or timestamp_us > obs[-1].timestamp_us:
-            return None
-
-        # --- Exact endpoint match, also handles single-observation tracks if matching ---
-        if timestamp_us == obs[0].timestamp_us:
+        # --- Out-of-range handling ---
+        if timestamp_us <= obs[0].timestamp_us:
+            if max_clamp_us is None or obs[0].timestamp_us - timestamp_us > max_clamp_us:
+                if timestamp_us < obs[0].timestamp_us:
+                    return None
             return replace(obs[0], timestamp_us=timestamp_us, reference_frame_timestamp_us=timestamp_us)
-        if timestamp_us == obs[-1].timestamp_us:
+        if timestamp_us >= obs[-1].timestamp_us:
+            if max_clamp_us is None or timestamp_us - obs[-1].timestamp_us > max_clamp_us:
+                if timestamp_us > obs[-1].timestamp_us:
+                    return None
             return replace(obs[-1], timestamp_us=timestamp_us, reference_frame_timestamp_us=timestamp_us)
 
         # --- Find bracketing pair via binary search ---

--- a/tools/ncore_vis/tracks_test.py
+++ b/tools/ncore_vis/tracks_test.py
@@ -111,6 +111,30 @@ class TestCuboidTrackInterpolation(unittest.TestCase):
         result = track.interpolate_at(2_000_000)
         self.assertIsNone(result)
 
+    def test_interpolate_before_range_clamp_within_limit(self):
+        track = self._make_track()  # range [0, 1_000_000]
+        result = track.interpolate_at(-100_000, max_clamp_us=200_000)
+        self.assertIsNotNone(result)
+        np.testing.assert_allclose(result.bbox3.centroid, (0.0, 0.0, 0.0), atol=1e-5)
+        self.assertEqual(result.timestamp_us, -100_000)
+
+    def test_interpolate_before_range_clamp_exceeds_limit(self):
+        track = self._make_track()
+        result = track.interpolate_at(-500_000, max_clamp_us=200_000)
+        self.assertIsNone(result)
+
+    def test_interpolate_after_range_clamp_within_limit(self):
+        track = self._make_track()
+        result = track.interpolate_at(1_100_000, max_clamp_us=200_000)
+        self.assertIsNotNone(result)
+        np.testing.assert_allclose(result.bbox3.centroid, (10.0, 0.0, 0.0), atol=1e-5)
+        self.assertEqual(result.timestamp_us, 1_100_000)
+
+    def test_interpolate_after_range_clamp_exceeds_limit(self):
+        track = self._make_track()
+        result = track.interpolate_at(2_000_000, max_clamp_us=200_000)
+        self.assertIsNone(result)
+
     def test_single_observation_exact_match(self):
         obs = _make_obs("t1", 500_000, 3.0, 4.0, 5.0)
         track = CuboidTrack(observations=[obs])
@@ -127,6 +151,30 @@ class TestCuboidTrackInterpolation(unittest.TestCase):
         obs = _make_obs("t1", 500_000, 3.0, 4.0, 5.0)
         track = CuboidTrack(observations=[obs])
         self.assertIsNone(track.interpolate_at(1_000_000))
+
+    def test_single_observation_before_clamp_within_limit(self):
+        obs = _make_obs("t1", 500_000, 3.0, 4.0, 5.0)
+        track = CuboidTrack(observations=[obs])
+        result = track.interpolate_at(400_000, max_clamp_us=200_000)
+        self.assertIsNotNone(result)
+        np.testing.assert_allclose(result.bbox3.centroid, (3.0, 4.0, 5.0), atol=1e-5)
+
+    def test_single_observation_before_clamp_exceeds_limit(self):
+        obs = _make_obs("t1", 500_000, 3.0, 4.0, 5.0)
+        track = CuboidTrack(observations=[obs])
+        self.assertIsNone(track.interpolate_at(0, max_clamp_us=200_000))
+
+    def test_single_observation_after_clamp_within_limit(self):
+        obs = _make_obs("t1", 500_000, 3.0, 4.0, 5.0)
+        track = CuboidTrack(observations=[obs])
+        result = track.interpolate_at(600_000, max_clamp_us=200_000)
+        self.assertIsNotNone(result)
+        np.testing.assert_allclose(result.bbox3.centroid, (3.0, 4.0, 5.0), atol=1e-5)
+
+    def test_single_observation_after_clamp_exceeds_limit(self):
+        obs = _make_obs("t1", 500_000, 3.0, 4.0, 5.0)
+        track = CuboidTrack(observations=[obs])
+        self.assertIsNone(track.interpolate_at(1_000_000, max_clamp_us=200_000))
 
     def test_dimensions_unchanged(self):
         track = self._make_track()

--- a/tools/ncore_vis/tracks_test.py
+++ b/tools/ncore_vis/tracks_test.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from ncore.impl.data.types import BBox3, CuboidTrackObservation, LabelSource
+from tools.ncore_vis.tracks import CuboidTrack
+
+
+def _make_obs(
+    track_id: str,
+    timestamp_us: int,
+    x: float,
+    y: float = 0.0,
+    z: float = 0.0,
+    yaw: float = 0.0,
+) -> CuboidTrackObservation:
+    return CuboidTrackObservation(
+        track_id=track_id,
+        class_id="Vehicle",
+        timestamp_us=timestamp_us,
+        reference_frame_id="world",
+        reference_frame_timestamp_us=timestamp_us,
+        bbox3=BBox3(
+            centroid=(x, y, z),
+            dim=(4.0, 2.0, 1.5),
+            rot=(0.0, 0.0, yaw),
+        ),
+        source=LabelSource.GT_ANNOTATION,
+    )
+
+
+class TestCuboidTrackConstruction(unittest.TestCase):
+    """Test CuboidTrack construction and validation"""
+
+    def test_rejects_empty_observations(self):
+        with self.assertRaises(ValueError):
+            CuboidTrack(observations=[])
+
+    def test_rejects_mixed_track_ids(self):
+        obs_a = _make_obs("a", 0, 0.0)
+        obs_b = _make_obs("b", 1_000_000, 1.0)
+        with self.assertRaises(ValueError):
+            CuboidTrack(observations=[obs_a, obs_b])
+
+    def test_properties(self):
+        obs0 = _make_obs("t1", 0, 0.0)
+        obs1 = _make_obs("t1", 1_000_000, 10.0)
+        track = CuboidTrack(observations=[obs0, obs1])
+        self.assertEqual(track.track_id, "t1")
+        self.assertEqual(track.class_id, "Vehicle")
+        self.assertEqual(len(track.observations), 2)
+
+    def test_observations_sorted_by_timestamp(self):
+        obs1 = _make_obs("t1", 1_000_000, 10.0)
+        obs0 = _make_obs("t1", 0, 0.0)
+        track = CuboidTrack(observations=[obs1, obs0])  # reversed order
+        self.assertEqual(track.observations[0].timestamp_us, 0)
+        self.assertEqual(track.observations[1].timestamp_us, 1_000_000)
+
+
+class TestCuboidTrackInterpolation(unittest.TestCase):
+    """Test CuboidTrack.interpolate_at"""
+
+    def _make_track(self) -> CuboidTrack:
+        obs0 = _make_obs("t1", 0, 0.0)
+        obs1 = _make_obs("t1", 1_000_000, 10.0)
+        return CuboidTrack(observations=[obs0, obs1])
+
+    def test_interpolate_exact_start(self):
+        track = self._make_track()
+        result = track.interpolate_at(0)
+        self.assertIsNotNone(result)
+        np.testing.assert_allclose(result.bbox3.centroid, (0.0, 0.0, 0.0), atol=1e-5)
+
+    def test_interpolate_exact_end(self):
+        track = self._make_track()
+        result = track.interpolate_at(1_000_000)
+        self.assertIsNotNone(result)
+        np.testing.assert_allclose(result.bbox3.centroid, (10.0, 0.0, 0.0), atol=1e-5)
+
+    def test_interpolate_midpoint_centroid(self):
+        track = self._make_track()
+        result = track.interpolate_at(500_000)
+        self.assertIsNotNone(result)
+        np.testing.assert_allclose(result.bbox3.centroid, (5.0, 0.0, 0.0), atol=1e-5)
+
+    def test_interpolate_before_range_returns_none(self):
+        track = self._make_track()
+        result = track.interpolate_at(-500_000)
+        self.assertIsNone(result)
+
+    def test_interpolate_after_range_returns_none(self):
+        track = self._make_track()
+        result = track.interpolate_at(2_000_000)
+        self.assertIsNone(result)
+
+    def test_single_observation_exact_match(self):
+        obs = _make_obs("t1", 500_000, 3.0, 4.0, 5.0)
+        track = CuboidTrack(observations=[obs])
+        result = track.interpolate_at(500_000)
+        self.assertIsNotNone(result)
+        np.testing.assert_allclose(result.bbox3.centroid, (3.0, 4.0, 5.0), atol=1e-5)
+
+    def test_single_observation_before_returns_none(self):
+        obs = _make_obs("t1", 500_000, 3.0, 4.0, 5.0)
+        track = CuboidTrack(observations=[obs])
+        self.assertIsNone(track.interpolate_at(0))
+
+    def test_single_observation_after_returns_none(self):
+        obs = _make_obs("t1", 500_000, 3.0, 4.0, 5.0)
+        track = CuboidTrack(observations=[obs])
+        self.assertIsNone(track.interpolate_at(1_000_000))
+
+    def test_dimensions_unchanged(self):
+        track = self._make_track()
+        result = track.interpolate_at(500_000)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.bbox3.dim, (4.0, 2.0, 1.5))
+
+    def test_result_timestamp_matches_query(self):
+        track = self._make_track()
+        result = track.interpolate_at(750_000)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.timestamp_us, 750_000)
+        self.assertEqual(result.reference_frame_timestamp_us, 750_000)
+
+    def test_interpolate_rotation_midpoint(self):
+        import math
+
+        obs0 = _make_obs("t1", 0, 0.0, yaw=0.0)
+        obs1 = _make_obs("t1", 1_000_000, 0.0, yaw=math.pi / 2)
+        track = CuboidTrack(observations=[obs0, obs1])
+        result = track.interpolate_at(500_000)
+        self.assertIsNotNone(result)
+        # Mid-point yaw should be ~pi/4
+        np.testing.assert_allclose(result.bbox3.rot[2], math.pi / 4, atol=1e-4)
+
+    def test_interpolate_quarter_point(self):
+        track = self._make_track()
+        result = track.interpolate_at(250_000)
+        self.assertIsNotNone(result)
+        np.testing.assert_allclose(result.bbox3.centroid, (2.5, 0.0, 0.0), atol=1e-5)
+
+    def test_result_reference_frame_id_preserved(self):
+        track = self._make_track()
+        result = track.interpolate_at(500_000)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.reference_frame_id, "world")
+
+    def test_result_class_id_preserved(self):
+        track = self._make_track()
+        result = track.interpolate_at(500_000)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.class_id, "Vehicle")
+
+
+class TestCuboidTrackFromObservations(unittest.TestCase):
+    """Test CuboidTrack.from_observations factory"""
+
+    def test_groups_by_track_id(self):
+        obs_t1_a = _make_obs("t1", 0, 0.0)
+        obs_t1_b = _make_obs("t1", 1_000_000, 1.0)
+        obs_t2_a = _make_obs("t2", 0, 5.0)
+        tracks = CuboidTrack.from_observations([obs_t1_a, obs_t1_b, obs_t2_a])
+        self.assertEqual(len(tracks), 2)
+        track_ids = {t.track_id for t in tracks}
+        self.assertIn("t1", track_ids)
+        self.assertIn("t2", track_ids)
+
+    def test_single_track(self):
+        obs = _make_obs("t1", 0, 0.0)
+        tracks = CuboidTrack.from_observations([obs])
+        self.assertEqual(len(tracks), 1)
+        self.assertEqual(tracks[0].track_id, "t1")
+
+    def test_empty_list(self):
+        tracks = CuboidTrack.from_observations([])
+        self.assertEqual(tracks, [])
+
+    def test_observation_counts_per_track(self):
+        obs = [_make_obs("t1", i * 100_000, float(i)) for i in range(5)]
+        obs += [_make_obs("t2", 0, 99.0)]
+        tracks = CuboidTrack.from_observations(obs)
+        by_id = {t.track_id: t for t in tracks}
+        self.assertEqual(len(by_id["t1"].observations), 5)
+        self.assertEqual(len(by_id["t2"].observations), 1)


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the visualization components for camera, lidar, and cuboid overlays. The main focus is on improving the accuracy of projections (especially for cuboids), standardizing frame index naming, and enhancing code clarity and maintainability. The changes also add new Bazel build targets for testing and modularization.

### Projection and interpolation improvements

* Cuboid overlays now interpolate each track to the camera frame's mid-of-frame timestamp, ensuring that the projected position reflects the object's estimated location during exposure. The projection uses the shared mode (rolling-shutter, mean, start, end) for consistency. (`tools/ncore_vis/components/camera.py`) [[1]](diffhunk://#diff-e701576bcdf48a208f5af48973d1cf57031b4038f56056daf563a56534b79126R661-R695) [[2]](diffhunk://#diff-e701576bcdf48a208f5af48973d1cf57031b4038f56056daf563a56534b79126L693-R770)
* The `_project_points` helper now supports a `return_all_projections` argument and passes it through to projection calls, allowing more flexible projection results. (`tools/ncore_vis/components/camera.py`) [[1]](diffhunk://#diff-e701576bcdf48a208f5af48973d1cf57031b4038f56056daf563a56534b79126R642) [[2]](diffhunk://#diff-e701576bcdf48a208f5af48973d1cf57031b4038f56056daf563a56534b79126R652)

### Frame index naming and consistency

* All references to `frame` are renamed to `frame_idx` in camera and lidar components, clarifying intent and reducing confusion between frame numbers and indices. (`tools/ncore_vis/components/camera.py`, `tools/ncore_vis/components/lidar.py`) [[1]](diffhunk://#diff-e701576bcdf48a208f5af48973d1cf57031b4038f56056daf563a56534b79126L446-R452) [[2]](diffhunk://#diff-e701576bcdf48a208f5af48973d1cf57031b4038f56056daf563a56534b79126L465-R485) [[3]](diffhunk://#diff-c52af9467ef85a11cc21466ef8502a565313f89e1e6c015d58f28523057d4247L338-R338) [[4]](diffhunk://#diff-c52af9467ef85a11cc21466ef8502a565313f89e1e6c015d58f28523057d4247L347-R347) [[5]](diffhunk://#diff-c52af9467ef85a11cc21466ef8502a565313f89e1e6c015d58f28523057d4247L360-R360) [[6]](diffhunk://#diff-c52af9467ef85a11cc21466ef8502a565313f89e1e6c015d58f28523057d4247L382-R387) [[7]](diffhunk://#diff-c52af9467ef85a11cc21466ef8502a565313f89e1e6c015d58f28523057d4247L402-R445)

### API and method updates

* The cuboid observation query now explicitly specifies the interpolation mode ("end-of-interval") for improved clarity and correctness. (`tools/ncore_vis/components/cuboids.py`)
* Lidar point cloud fusion and transformation methods are updated to use `frame_idx` and more descriptive argument names, improving parallel loading and clarity. (`tools/ncore_vis/components/lidar.py`)

### Build system enhancements

* Added a new `py_library` target for `tracks.py` and a corresponding `pytest_test` target for `tracks_test.py` in the Bazel build file, improving modularity and testability. (`tools/ncore_vis/BUILD.bazel`) [[1]](diffhunk://#diff-21f5263a02154b4f5d4a651d3bdfef9a1d3fae0540296d0429e05a2e5e08c736R35-R63) [[2]](diffhunk://#diff-21f5263a02154b4f5d4a651d3bdfef9a1d3fae0540296d0429e05a2e5e08c736R18)

### Code cleanup

* Removed unused import of `se3_inverse` in the camera component, streamlining dependencies. (`tools/ncore_vis/components/camera.py`)