### PR TITLE
fix(pai): Update to default HF revision 'main', update caching

### DIFF
--- a/docs/conversions/pai/pai.rst
+++ b/docs/conversions/pai/pai.rst
@@ -265,9 +265,8 @@ The output for each clip is written to::
      - HuggingFace API token. Reads from the ``HF_TOKEN`` environment variable
        if not provided
    * - ``--revision TEXT``
-     - ``ncore``
-     - HuggingFace dataset branch or tag to stream from. Note: the
-       ``pai-clip-dl`` download tool uses ``ncore`` as its current default revision
+     - ``main``
+     - HuggingFace dataset branch or tag to stream from.
 
 For the complete implementation, see ``tools/data_converter/pai/converter.py``.
 

--- a/tools/data_converter/pai/README.md
+++ b/tools/data_converter/pai/README.md
@@ -28,7 +28,7 @@ The dataset contains 306,152 clips organized into ~3,146 chunks of ~100 clips ea
 | **Camera**      | 7 cameras (front wide, front tele, cross L/R, rear L/R, rear tele) | zip (mp4 + timestamps + blurred_boxes per clip) | ~2 GB |
 | **Lidar**       | lidar_top_360fov | zip (per-clip parquets) | ~20 GB |
 | **Radar**       | 19 radar sensors | zip (per-clip parquets) | varies |
-| **Metadata**    | data_collection, sensor_presence | parquet (global) | ~11 MB |
+| **Metadata**    | data_collection, feature_presence | parquet (global) | ~11 MB |
 
 Some features have `.offline` variants. These are used automatically by the streaming converter when available.
 
@@ -108,7 +108,7 @@ bazel run //tools/data_converter/pai/pai_remote:pai-clip-dl -- \
 ├── radar/
 │   └── {clip_id}.radar_*.parquet          (present sensors only)
 └── metadata/
-    ├── sensor_presence.parquet
+    ├── feature_presence.parquet
     ├── data_collection.parquet
     └── provenance.json                    (download source, optional)
 ```
@@ -174,7 +174,7 @@ Both subcommands support:
 
 1. **Index resolution** — `clip_index.parquet` maps each clip UUID to a chunk ID. `features.csv` describes all feature types and their chunk path templates.
 
-2. **Sensor filtering** — `sensor_presence.parquet` records which sensors were active for each clip. Features with absent sensors are skipped automatically.
+2. **Sensor filtering** — `feature_presence.parquet` records which sensors were active for each clip. Features with absent sensors are skipped automatically.
 
 3. **Offline variants** — when streaming, `.offline` pre-processed variants of features (e.g. `egomotion.offline`, `sensor_extrinsics.offline`) are preferred over raw features when available.
 
@@ -201,7 +201,7 @@ pai/
 └── pai_remote/
     ├── config.py      # Config dataclass, constants, env var handling
     ├── remote.py      # HFRemote: authenticated HTTP, CDN URL resolution, downloads
-    ├── index.py       # ClipIndex: clip_index.parquet, features.csv, sensor_presence
+    ├── index.py       # ClipIndex: clip_index.parquet, features.csv, feature_presence
     ├── streaming.py   # StreamingZipAccess: HTTP range access into remote zips
     ├── downloader.py  # ClipDownloader: orchestrates multi-clip download with batching
     └── cli.py         # pai-clip-dl CLI: download, info, list-features, stream

--- a/tools/data_converter/pai/converter.py
+++ b/tools/data_converter/pai/converter.py
@@ -79,7 +79,7 @@ from ncore.impl.data.types import (
 from ncore.impl.data.v4.types import ComponentGroupAssignments
 from tools.data_converter.cli import cli
 from tools.data_converter.pai.data_provider import ClipDataProvider, LocalClipDataProvider, StreamingClipDataProvider
-from tools.data_converter.pai.pai_remote.config import Config
+from tools.data_converter.pai.pai_remote.config import DEFAULT_REVISION, Config
 from tools.data_converter.pai.pai_remote.index import ClipIndex
 from tools.data_converter.pai.pai_remote.remote import HFRemote
 from tools.data_converter.pai.utils import (
@@ -823,7 +823,7 @@ def pai_v4(ctx, *_, **kwargs):
 @click.option(
     "--revision",
     type=str,
-    default="ncore",
+    default=DEFAULT_REVISION,
     show_default=True,
     help="HuggingFace dataset revision (branch/tag).",
 )

--- a/tools/data_converter/pai/data_provider.py
+++ b/tools/data_converter/pai/data_provider.py
@@ -147,12 +147,12 @@ class LocalClipDataProvider(ClipDataProvider):
         return key in self._files and self._files[key].exists()
 
     def get_sensor_presence(self) -> pd.Series:
-        sp_path = self._metadata_dir / "sensor_presence.parquet"
+        sp_path = self._metadata_dir / "feature_presence.parquet"
         if sp_path.exists():
             df = pd.read_parquet(str(sp_path))
             return df.loc[self._clip_id]  # type: ignore[return-value]
         # Fallback: infer from extrinsics
-        logger.info("sensor_presence.parquet not found, inferring from extrinsics")
+        logger.info("feature_presence.parquet not found, inferring from extrinsics")
         ext_df = self.load_parquet("sensor_extrinsics")
         sensor_names = ext_df.index.get_level_values("sensor_name").unique()
         return pd.Series(True, index=sensor_names)

--- a/tools/data_converter/pai/pai_remote/cli.py
+++ b/tools/data_converter/pai/pai_remote/cli.py
@@ -27,7 +27,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from tools.data_converter.pai.pai_remote.config import Config
+from tools.data_converter.pai.pai_remote.config import DEFAULT_REVISION, Config
 from tools.data_converter.pai.pai_remote.downloader import ClipDownloader
 from tools.data_converter.pai.pai_remote.index import ClipIndex
 from tools.data_converter.pai.pai_remote.remote import HFRemote
@@ -81,7 +81,7 @@ def main() -> None:
 )
 @click.option("--features", "-f", multiple=True, help="Feature names to download. Repeat for multiple. Default: all.")
 @click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
-@click.option("--revision", default="ncore", help="Git branch/revision of the dataset.")
+@click.option("--revision", default=DEFAULT_REVISION, show_default=True, help="Git branch/revision of the dataset.")
 @click.option("--no-skip-missing", is_flag=True, default=False, help="Don't skip features where the sensor is absent.")
 @click.option("--no-metadata", is_flag=True, default=False, help="Skip downloading metadata parquets.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
@@ -121,7 +121,7 @@ def download(
 @main.command()
 @click.argument("clip_ids", nargs=-1, required=True)
 @click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
-@click.option("--revision", default="ncore", help="Git branch/revision of the dataset.")
+@click.option("--revision", default=DEFAULT_REVISION, show_default=True, help="Git branch/revision of the dataset.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
 def info(clip_ids: tuple[str, ...], hf_token: str | None, revision: str, verbose: bool) -> None:
     """Show information about one or more clips (chunk, split, sensors)."""
@@ -156,7 +156,7 @@ def info(clip_ids: tuple[str, ...], hf_token: str | None, revision: str, verbose
 
 @main.command("list-features")
 @click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
-@click.option("--revision", default="ncore", help="Git branch/revision of the dataset.")
+@click.option("--revision", default=DEFAULT_REVISION, show_default=True, help="Git branch/revision of the dataset.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
 def list_features(hf_token: str | None, revision: str, verbose: bool) -> None:
     """List all available features in the dataset."""
@@ -187,7 +187,7 @@ def list_features(hf_token: str | None, revision: str, verbose: bool) -> None:
     "--output", "-o", type=click.Path(path_type=Path), default=None, help="Save output to file instead of stdout."
 )
 @click.option("--hf-token", envvar="HF_TOKEN", help="HuggingFace API token.")
-@click.option("--revision", default="ncore", help="Git branch/revision of the dataset.")
+@click.option("--revision", default=DEFAULT_REVISION, show_default=True, help="Git branch/revision of the dataset.")
 @click.option("--verbose", "-v", is_flag=True, default=False)
 def stream(
     clip_id: str,

--- a/tools/data_converter/pai/pai_remote/downloader.py
+++ b/tools/data_converter/pai/pai_remote/downloader.py
@@ -79,7 +79,7 @@ class ClipDownloader:
         │   └── ...
         └── metadata/
             ├── data_collection.parquet
-            └── sensor_presence.parquet
+            └── feature_presence.parquet
     """
 
     def __init__(self, remote: HFRemote, index: ClipIndex) -> None:
@@ -114,7 +114,7 @@ class ClipDownloader:
         features:
             If given, only download these feature names.  Otherwise all.
         skip_missing_sensors:
-            Check sensor_presence and skip features where the sensor is
+            Check feature_presence and skip features where the sensor is
             absent for a given clip.
         include_metadata:
             Also download and filter the global metadata parquets.
@@ -301,7 +301,7 @@ class ClipDownloader:
         output_dir: Path,
     ) -> None:
         """Download each global metadata parquet once, then filter per clip."""
-        for name in ("data_collection", "sensor_presence"):
+        for name in ("data_collection", "feature_presence"):
             repo_path = f"metadata/{name}.parquet"
             try:
                 raw = self.remote.download_bytes(repo_path)

--- a/tools/data_converter/pai/pai_remote/index.py
+++ b/tools/data_converter/pai/pai_remote/index.py
@@ -144,14 +144,14 @@ class ClipIndex:
         return seen
 
     # ------------------------------------------------------------------
-    # sensor_presence.parquet
+    # feature_presence.parquet
     # ------------------------------------------------------------------
 
     @property
     def sensor_presence_df(self) -> pd.DataFrame:
-        """Lazy-load metadata/sensor_presence.parquet."""
+        """Lazy-load metadata/feature_presence.parquet."""
         if self._sensor_presence_df is None:
-            path = self._remote.get_cached_or_download("metadata/sensor_presence.parquet")
+            path = self._remote.get_cached_or_download("metadata/feature_presence.parquet")
             self._sensor_presence_df = pd.read_parquet(path)
             log.info("Loaded sensor presence: %d clips", len(self._sensor_presence_df))
         return self._sensor_presence_df

--- a/tools/data_converter/pai/pai_remote/remote.py
+++ b/tools/data_converter/pai/pai_remote/remote.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import io
 import logging
+import shutil
 import time
 
 from pathlib import Path
@@ -134,16 +135,71 @@ class HFRemote:
     # Cached index files
     # ------------------------------------------------------------------
 
+    @property
+    def _cache_rev_dir(self) -> Path:
+        """Cache directory for the current revision."""
+        return self.config.cache_dir / self.config.revision
+
+    @property
+    def _commit_sha_file(self) -> Path:
+        """Path to the file storing the cached commit SHA."""
+        return self._cache_rev_dir / ".commit_sha"
+
+    def _resolve_remote_sha(self) -> str | None:
+        """Resolve the current commit SHA for this revision via a lightweight HEAD request.
+
+        The result is cached in ``self._commit_sha`` so at most one HEAD
+        request is made per session.
+        """
+        if self._commit_sha is not None:
+            return self._commit_sha
+        try:
+            resp = self._session.head(self._repo_url("features.csv"), allow_redirects=True, timeout=30)
+            resp.raise_for_status()
+            self._capture_commit_sha(resp)
+        except Exception:
+            log.warning("Failed to resolve remote commit SHA; will re-download cached files")
+        return self._commit_sha
+
+    def _is_cache_valid(self) -> bool:
+        """Check whether the local cache matches the remote commit SHA.
+
+        Returns ``True`` only when the stored SHA equals the remote SHA.
+        On any failure (missing file, network error) returns ``False`` so
+        that stale data is never served silently.
+        """
+        if not self._commit_sha_file.exists():
+            return False
+        cached_sha = self._commit_sha_file.read_text().strip()
+        remote_sha = self._resolve_remote_sha()
+        if remote_sha is None:
+            return False
+        if cached_sha != remote_sha:
+            log.info("Cache stale (cached=%s, remote=%s), invalidating", cached_sha[:12], remote_sha[:12])
+            shutil.rmtree(self._cache_rev_dir, ignore_errors=True)
+            self._cache_rev_dir.mkdir(parents=True, exist_ok=True)
+            return False
+        return True
+
+    def _save_commit_sha(self) -> None:
+        """Persist the resolved commit SHA alongside the cached files."""
+        if self._commit_sha is not None:
+            self._commit_sha_file.parent.mkdir(parents=True, exist_ok=True)
+            self._commit_sha_file.write_text(self._commit_sha)
+
     def get_cached_or_download(self, repo_path: str) -> Path:
         """Return a local cached copy of a repo file, downloading if needed.
 
         Files are cached under ``config.cache_dir / revision / repo_path``.
-        To force a refresh, delete the cached file.
+        On each session a single HEAD request verifies that the cached commit
+        SHA still matches the remote; if not the cache is invalidated and
+        files are re-downloaded.
         """
-        local = self.config.cache_dir / self.config.revision / repo_path
-        if local.exists():
+        local = self._cache_rev_dir / repo_path
+        if local.exists() and self._is_cache_valid():
             log.debug("Using cached %s", local)
             return local
         log.info("Downloading %s ...", repo_path)
         self.download_file(repo_path, local)
+        self._save_commit_sha()
         return local

--- a/tools/data_converter/pai/utils.py
+++ b/tools/data_converter/pai/utils.py
@@ -98,7 +98,7 @@ def find_clip_files(clip_dir: UPath, clip_id: str) -> Dict[str, UPath]:
             lidar/
                 <clip_id>.lidar_top_360fov.parquet
             metadata/
-                sensor_presence.parquet
+                feature_presence.parquet
                 data_collection.parquet
 
     Args:


### PR DESCRIPTION
This pull request makes several updates to the PAI data converter tools and documentation, mainly to standardize the naming of metadata files (from `sensor_presence.parquet` to `feature_presence.parquet`) and to improve revision handling for HuggingFace dataset downloads. The changes ensure consistency across documentation, code, and CLI, and add cache validation for revisioned downloads.

Metadata file naming standardization:

* Replaced all references to `sensor_presence.parquet` with `feature_presence.parquet` in documentation (`README.md`, `pai.rst`), code comments, and file access logic throughout the codebase, including `data_provider.py`, `downloader.py`, `index.py`, and `utils.py`. [[1]](diffhunk://#diff-bfc97aca793fa776180dc1b19eabbf2e6f1c8b7ba0064f6cfc9d9deba6d4040eL31-R31) [[2]](diffhunk://#diff-bfc97aca793fa776180dc1b19eabbf2e6f1c8b7ba0064f6cfc9d9deba6d4040eL111-R111) [[3]](diffhunk://#diff-bfc97aca793fa776180dc1b19eabbf2e6f1c8b7ba0064f6cfc9d9deba6d4040eL177-R177) [[4]](diffhunk://#diff-bfc97aca793fa776180dc1b19eabbf2e6f1c8b7ba0064f6cfc9d9deba6d4040eL204-R204) [[5]](diffhunk://#diff-4acb1781ab147112f3ce781eb133ad46e1033151bc087457bc855c5538421bbeL150-R155) [[6]](diffhunk://#diff-97ef49e3394c07864ea61bc9c189a5ef10ba9e08285ea76775afa8e7b38aadcaL82-R82) [[7]](diffhunk://#diff-97ef49e3394c07864ea61bc9c189a5ef10ba9e08285ea76775afa8e7b38aadcaL117-R117) [[8]](diffhunk://#diff-97ef49e3394c07864ea61bc9c189a5ef10ba9e08285ea76775afa8e7b38aadcaL304-R304) [[9]](diffhunk://#diff-2e346546789817156f15318423b4ff31bfdc5c2d0139f2530ba3c80e730bc817L147-R154) [[10]](diffhunk://#diff-030b01bfae77042ace8448a63d58aa4ecacb647257499baa573b728574a66d26L101-R101)

Revision handling improvements:

* Updated CLI and converter defaults to use a `DEFAULT_REVISION` constant (now set to `"main"` instead of `"ncore"`), ensuring consistent revision selection across commands and making the revision easier to change in one place. [[1]](diffhunk://#diff-8680e4005f677a122e669f219163f76767be34b591384b16119f94245da32d70L268-R269) [[2]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fL82-R82) [[3]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fL826-R826) [[4]](diffhunk://#diff-077ad5a0f5847be08dae615ea0640aacf736a98f9489e7eaccb301c2fc52292bL30-R30) [[5]](diffhunk://#diff-077ad5a0f5847be08dae615ea0640aacf736a98f9489e7eaccb301c2fc52292bL84-R84) [[6]](diffhunk://#diff-077ad5a0f5847be08dae615ea0640aacf736a98f9489e7eaccb301c2fc52292bL124-R124) [[7]](diffhunk://#diff-077ad5a0f5847be08dae615ea0640aacf736a98f9489e7eaccb301c2fc52292bL159-R159) [[8]](diffhunk://#diff-077ad5a0f5847be08dae615ea0640aacf736a98f9489e7eaccb301c2fc52292bL190-R190)

Cache validation for remote dataset revision:

* Added logic in `pai_remote/remote.py` to validate the local cache against the remote commit SHA for the selected revision, ensuring that cached files are not stale and are re-downloaded if the revision has changed.

Minor improvements and fixes:

* Updated import statements to include `DEFAULT_REVISION` and fixed documentation to reflect the new default revision. [[1]](diffhunk://#diff-daec823f571406685025998b8eed07dae9116ac56e8d64d86b89e487e028c80fL82-R82) [[2]](diffhunk://#diff-077ad5a0f5847be08dae615ea0640aacf736a98f9489e7eaccb301c2fc52292bL30-R30)
* Added missing import for `shutil` in `pai_remote/remote.py` to support cache invalidation.