### PR TITLE
fix(colmap): Use flags for boolean options in converter

### DIFF
--- a/docs/conversions/colmap/colmap.rst
+++ b/docs/conversions/colmap/colmap.rst
@@ -135,12 +135,12 @@ subdirectory is treated as a separate sequence.
      - ``camera``
      - Prefix prepended to COLMAP integer camera IDs to form NCore sensor IDs
        (e.g. ``camera1``)
-   * - ``--include-downsampled-images BOOL``
-     - ``False``
+   * - ``--include-downsampled-images`` / ``--no-include-downsampled-images``
+     - disabled
      - Include downsampled image directories (``images_2``, ``images_4``,
        ``images_8``) as additional camera sensors
-   * - ``--include-3d-points BOOL``
-     - ``True``
+   * - ``--include-3d-points`` / ``--no-include-3d-points``
+     - enabled
      - Include the SfM point cloud as a single frame of a ``virtual_lidar``
        sensor
 

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -486,14 +486,14 @@ class ColmapDataConverter(FileBasedDataConverter):
     help="Camera name prefix (for integer camera_ids). Default is 'camera'.",
 )
 @click.option(
-    "--include-downsampled-images",
-    type=click.BOOL,
+    "--include-downsampled-images/--no-include-downsampled-images",
+    is_flag=True,
     default=False,
     help="Include downsampled images as additional cameras. Images should be in folders such as `images_2`, etc.",
 )
 @click.option(
-    "--include-3d-points",
-    type=click.BOOL,
+    "--include-3d-points/--no-include-3d-points",
+    is_flag=True,
     default=True,
     help="Include 3D Points as a lidar sensor",
 )


### PR DESCRIPTION
This pull request updates the command-line interface and documentation for the COLMAP data converter to improve clarity and usability. The most important changes are grouped below:

CLI Improvements:

* Changed the `--include-downsampled-images` and `--include-3d-points` options in `converter.py` to use boolean flags with `--no-include-downsampled-images` and `--no-include-3d-points` variants, making them easier to use and more consistent with standard CLI practices.

Documentation Updates:

* Updated the documentation in `colmap.rst` to reflect the new CLI flag syntax for `--include-downsampled-images` and `--include-3d-points`, clarifying their default states and usage.