### PR TITLE
feat(colmap): Include downsampled sensors by default

### DIFF
--- a/docs/conversions/colmap/colmap.rst
+++ b/docs/conversions/colmap/colmap.rst
@@ -136,7 +136,7 @@ subdirectory is treated as a separate sequence.
      - Prefix prepended to COLMAP integer camera IDs to form NCore sensor IDs
        (e.g. ``camera1``)
    * - ``--include-downsampled-images`` / ``--no-include-downsampled-images``
-     - disabled
+     - enabled
      - Include downsampled image directories (``images_2``, ``images_4``,
        ``images_8``) as additional camera sensors
    * - ``--include-3d-points`` / ``--no-include-3d-points``

--- a/tools/data_converter/colmap/README.md
+++ b/tools/data_converter/colmap/README.md
@@ -69,8 +69,8 @@ bazel run //tools/data_converter/colmap -- \
     --root-dir /data/colmap/scenes \
     --output-dir /data/ncore/colmap \
     colmap-v4 \
-    --include-3d-points false \
-    --include-downsampled-images false
+    --no-include-3d-points \
+    --no-include-downsampled-images
 ```
 
 Convert to directory format (instead of itar):

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -488,7 +488,7 @@ class ColmapDataConverter(FileBasedDataConverter):
 @click.option(
     "--include-downsampled-images/--no-include-downsampled-images",
     is_flag=True,
-    default=False,
+    default=True,
     help="Include downsampled images as additional cameras. Images should be in folders such as `images_2`, etc.",
 )
 @click.option(


### PR DESCRIPTION
This pull request updates the default behavior for handling downsampled images in the COLMAP data converter, and clarifies related documentation and usage instructions. The main change is to enable inclusion of downsampled image directories as additional camera sensors by default.

Default behavior update:

* Changed the `--include-downsampled-images` flag in `converter.py` to be enabled by default, so downsampled images are included as additional cameras unless explicitly disabled.

Documentation and usage updates:

* Updated the documentation in `colmap.rst` to reflect that inclusion of downsampled images is now enabled by default.
* Modified the example command in `README.md` to use the new `--no-include-downsampled-images` flag for disabling this feature, aligning with the updated default.