### PR TITLE
feat(colmap): support per-image masks in colmap converter

### DIFF
--- a/docs/conversions/colmap/colmap.rst
+++ b/docs/conversions/colmap/colmap.rst
@@ -40,6 +40,22 @@ Camera intrinsics are compatible with the
 - Principal axis along the camera's +z axis
 - x-axis points right, y-axis points down
 
+Per-Image Masks
+^^^^^^^^^^^^^^^
+
+The converter automatically detects per-image mask files and stores them as
+per-frame ``mask`` properties in the ``generic_data`` of each camera frame
+(grayscale ``uint8``, shape ``[H, W]``).
+
+Two mask-file conventions are supported, checked in priority order:
+
+1. **Co-located mask** — ``<image_dir>/<stem>_mask.png``
+   alongside the image file.
+2. **Separate masks directory** — ``<sequence_dir>/masks/<image_filename>``.
+
+If no mask file is found for a given image, the frame is stored without a
+``mask`` entry.  The number of masks found per camera is logged at INFO level.
+
 LiDAR Sensors
 ^^^^^^^^^^^^^
 

--- a/tools/data_converter/colmap/README.md
+++ b/tools/data_converter/colmap/README.md
@@ -18,6 +18,21 @@ design decisions to ease this conversion:
 - The pointcloud has been assigned to a single lidar frame at timestamp 0.
 - Downsampled images can be added as if they are separate cameras (with camera id suffixes `_2`, `_4`, and `_8`)
 
+## Per-Image Masks
+
+The converter automatically detects per-image mask files and stores them as
+per-frame `mask` properties in the `generic_data` of each camera frame
+(grayscale, `uint8`, shape `[H, W]`).
+
+Two mask-file conventions are supported, checked in priority order:
+
+1. **Co-located mask** — `<image_dir>/<stem>_mask.png`
+   alongside the image file.
+2. **Separate masks directory** — `<sequence_dir>/masks/<image_filename>`.
+
+If no mask file is found for a given image, the frame is stored without a
+`mask` entry.
+
 ## Prerequisites
 
 - NCore build requirements (see <CONTRIBUTING.md>)

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -19,7 +19,7 @@ import json
 import logging
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, Optional
 
 import click
 import numpy as np
@@ -390,6 +390,39 @@ class ColmapDataConverter(FileBasedDataConverter):
 
         return cameras
 
+    def _find_mask_path(self, image_path: UPath, image_name: str) -> Optional[UPath]:
+        """Find a per-image mask file using two conventions.
+
+        Checks the following locations in priority order:
+
+        1. ``<image_dir>/<stem>_mask.png`` — co-located mask
+        2. ``<sequence_dir>/masks/<image_filename>`` — separate masks directory
+
+        Parameters
+        ----------
+        image_path : UPath
+            Full path to the image file.
+        image_name : str
+            Filename of the image (e.g. ``img_00.png``).
+
+        Returns
+        -------
+        Optional[UPath]
+            Path to the mask file if found, otherwise ``None``.
+        """
+        stem = image_path.stem
+        # Convention 1: <image_dir>/<stem>_mask.png
+        mask_path = image_path.parent / f"{stem}_mask.png"
+        if mask_path.exists():
+            return mask_path
+
+        # Convention 2: <sequence_dir>/masks/<image_filename>
+        mask_path = self.sequence_path / "masks" / image_name
+        if mask_path.exists():
+            return mask_path
+
+        return None
+
     def decode_cameras(self) -> None:
         """Decodes camera frames, intrinsics, and masks from the COLMAP scene."""
 
@@ -415,13 +448,14 @@ class ColmapDataConverter(FileBasedDataConverter):
                 camera_model_parameters=colmap_camera.camera_model,
             )
 
-            # Store empty masks (as none available in dataset)
+            # Store empty static masks (per-image masks are stored as per-frame generic data below)
             self.masks_writer.store_camera_masks(
                 camera_id=camera_ncore_id,
                 mask_images={},
             )
             timestamps_us = colmap_camera.timestamps_us
 
+            masks_found = 0
             for continuous_frame_index in tqdm.tqdm(range(colmap_camera.n_images), desc=f"Decoding {camera_ncore_id}"):
                 image_name = colmap_camera.image_names[continuous_frame_index]
                 image_path = colmap_camera.image_path / image_name
@@ -442,6 +476,13 @@ class ColmapDataConverter(FileBasedDataConverter):
                 generic_data: dict[str, np.ndarray] = {}
                 generic_meta_data: dict[str, JsonLike] = {}
 
+                # Check for a per-image mask file (grayscale, stored as generic frame data)
+                mask_path = self._find_mask_path(image_path, image_name)
+                if mask_path is not None:
+                    mask_array = np.array(PILImage.open(str(mask_path)).convert("L"), dtype=np.uint8)
+                    generic_data["mask"] = mask_array
+                    masks_found += 1
+
                 camera_writer.store_frame(
                     image_binary_data=image_bytes,
                     image_format=file_extension,
@@ -449,6 +490,9 @@ class ColmapDataConverter(FileBasedDataConverter):
                     generic_data=generic_data,
                     generic_meta_data=generic_meta_data,
                 )
+
+            if masks_found > 0:
+                self.logger.info(f"Found {masks_found}/{colmap_camera.n_images} per-image masks for {camera_ncore_id}")
 
 
 @cli.command()


### PR DESCRIPTION
## Summary

- Adds automatic per-image mask detection to the COLMAP converter, storing masks as per-frame `mask` entries in `generic_data` (grayscale `uint8`, shape `[H, W]`)
- Supports two mask-file conventions: co-located `<stem>_mask.png` (3dgrut convention) and separate `masks/` directory
- Adds documentation for the new mask support in the COLMAP converter Sphinx docs and README

## Motivation

Inspired by [nv-tlabs/3dgrut#178](https://github.com/nv-tlabs/3dgrut/issues/178) which highlights the need for per-image mask support in COLMAP datasets. Many NeRF/3DGS workflows produce per-image masks (e.g. for transient object removal) that should be preserved during conversion to NCore format.

## Changes

- `tools/data_converter/colmap/converter.py`: Added `_find_mask_path()` helper method and mask loading in the frame loop of `decode_cameras()`
- `docs/conversions/colmap/colmap.rst`: New "Per-Image Masks" section documenting conventions
- `tools/data_converter/colmap/README.md`: Matching documentation update

## Testing

- Verified with a dummy COLMAP dataset containing masks in both conventions (co-located and masks/ directory)
- All 10/10 frames correctly stored with `mask` generic_data entries (shape `[100, 100]`, dtype `uint8`)
- Existing tests pass: `//ncore/impl/data:all` and `//ncore/impl/data/v4:all` (8/8 pass)
- Format check passes