### PR TITLE
fix(ty): Fix type error in context manager exit method

### DIFF
--- a/ncore/impl/data/stores.py
+++ b/ncore/impl/data/stores.py
@@ -192,7 +192,7 @@ class IndexedTarStore(Store):
     def __enter__(self):
         return self
 
-    def __exit__(self, *_):
+    def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
     def close(self):

--- a/ncore/impl/sensors/camera.py
+++ b/ncore/impl/sensors/camera.py
@@ -24,7 +24,7 @@ from typing import Optional, Tuple, Union, cast
 import numpy as np
 import torch
 
-from ncore.impl.common.util import map_optional
+from ncore.impl.common.util import map_optional, unpack_optional
 from ncore.impl.data import types
 from ncore.impl.sensors.common import (
     BaseModel,
@@ -733,7 +733,7 @@ class CameraModel(BaseModel, ABC):
                 valid[torch.argwhere(valid).squeeze()] = image_points_rs.valid_flag
                 valid_indices = torch.argwhere(valid).squeeze(1)
             else:
-                valid_indices = return_var.valid_indices  # type: ignore
+                valid_indices = unpack_optional(return_var.valid_indices)
 
             return_var.image_points = init_image_points
             return_var.image_points[valid_indices] = image_points_rs.image_points[image_points_rs.valid_flag]


### PR DESCRIPTION
This pull request introduces a small bug fix and a minor refactor to improve code clarity and consistency. The main changes involve updating a context manager's exit method signature and improving how optional values are handled in camera sensor code.

**Context manager and utility improvements:**

* Updated the `__exit__` method in the `Store` class (`ncore/impl/data/stores.py`) to explicitly accept `exc_type`, `exc_value`, and `traceback` parameters, ensuring proper context manager protocol compliance.

**Camera sensor code enhancements:**

* Imported the `unpack_optional` utility in `ncore/impl/sensors/camera.py` and replaced direct usage of `return_var.valid_indices` with `unpack_optional(return_var.valid_indices)` in `world_points_to_image_points_shutter_pose`, improving handling of optional values and reducing potential errors. [[1]](diffhunk://#diff-c8fd3899733116e1bc59f76ec6bb29fab3f8e7a9450f155a3aee35c0bb3fc88dL27-R27) [[2]](diffhunk://#diff-c8fd3899733116e1bc59f76ec6bb29fab3f8e7a9450f155a3aee35c0bb3fc88dL736-R736)