### PR TITLE
feat(colmap): add OPENCV_FISHEYE support, scannetpp-v4 subcommand, and configurable paths

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -109,11 +109,15 @@ http_archive(
     urls = ["https://github.com/waymo-research/waymo-open-dataset/archive/refs/tags/v1.6.1.tar.gz"],
 )
 
-# pycolmap-reader
+# pycolmap-reader (Python COLMAP model reader by trueprice)
+# The patch fixes Python 2 -> 3 incompatibility: map() returns an iterator in
+# Python 3, breaking text-format (.txt) loading.  See patch header for details.
 http_archive(
     name = "pycolmap",
     build_file = "//deps/pycolmap:pycolmap.BUILD",
     integrity = "sha256-cOv2KrC75S1ABt9zdcoLE+TP7lnM4o6QZM9RxN1TdPA=",
+    patch_strip = 1,
+    patches = ["//deps/pycolmap:fix-python3-map.patch"],
     strip_prefix = "pycolmap-fe7a7c45df803b6c391777e349f0d8d65d39d777",
     urls = ["https://github.com/trueprice/pycolmap/archive/fe7a7c45df803b6c391777e349f0d8d65d39d777.tar.gz"],
 )

--- a/deps/pycolmap/BUILD.bazel
+++ b/deps/pycolmap/BUILD.bazel
@@ -12,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+exports_files(["fix-python3-map.patch"])

--- a/deps/pycolmap/fix-python3-map.patch
+++ b/deps/pycolmap/fix-python3-map.patch
@@ -1,0 +1,72 @@
+# fix-python3-map.patch
+#
+# The upstream pycolmap library (trueprice/pycolmap) was written for Python 2
+# where map() returns a list.  In Python 3, map() returns a lazy iterator which
+# is not subscriptable and cannot be directly passed to np.array() or used with
+# indexing (params[0], params[:4], etc.).
+#
+# This patch wraps all map() calls with list() so that the library works
+# correctly on Python 3.  Without this patch, loading COLMAP text-format files
+# (.txt) fails with:
+#   TypeError: 'map' object is not subscriptable
+#
+# The binary format (.bin) code path is unaffected because it does not use map().
+#
+# Upstream issue: the library appears unmaintained (last commit 2019).
+diff -ruN a/pycolmap/camera.py b/pycolmap/camera.py
+--- a/pycolmap/camera.py	2026-03-25 13:52:25.966357510 +0100
++++ b/pycolmap/camera.py	2026-03-25 13:52:38.637623274 +0100
+@@ -87,6 +87,7 @@
+     #---------------------------------------------------------------------------
+ 
+     def __init__(self, type_, width_, height_, params):
++        params = list(params)
+         self.width = width_
+         self.height = height_
+ 
+diff -ruN a/pycolmap/scene_manager.py b/pycolmap/scene_manager.py
+--- a/pycolmap/scene_manager.py	2026-03-25 13:52:25.966357510 +0100
++++ b/pycolmap/scene_manager.py	2026-03-25 13:52:38.659623735 +0100
+@@ -119,7 +119,7 @@
+                 data = line.split()
+                 camera_id = int(data[0])
+                 self.cameras[camera_id] = Camera(
+-                    data[1], int(data[2]), int(data[3]), map(float, data[4:]))
++                    data[1], int(data[2]), int(data[3]), list(map(float, data[4:])))
+                 self.last_camera_id = max(self.last_camera_id, camera_id)
+ 
+     #---------------------------------------------------------------------------
+@@ -195,12 +195,12 @@
+                 if is_camera_description_line:
+                     image_id = int(data[0])
+                     image = Image(data[-1], int(data[-2]),
+-                                  Quaternion(np.array(map(float, data[1:5]))),
+-                                  np.array(map(float, data[5:8])))
++                                  Quaternion(np.array(list(map(float, data[1:5])))),
++                                  np.array(list(map(float, data[5:8]))))
+                 else:
+                     image.points2D = np.array(
+-                        [map(float, data[::3]), map(float, data[1::3])]).T
+-                    image.point3D_ids = np.array(map(np.uint64, data[2::3]))
++                        [list(map(float, data[::3])), list(map(float, data[1::3]))]).T
++                    image.point3D_ids = np.array(list(map(np.uint64, data[2::3])))
+ 
+                     # automatically remove points without an associated 3D point
+                     #mask = (image.point3D_ids != SceneManager.INVALID_POINT3D)
+@@ -272,13 +272,13 @@
+ 
+                 self.point3D_ids.append(point3D_id)
+                 self.point3D_id_to_point3D_idx[point3D_id] = len(self.points3D)
+-                self.points3D.append(map(np.float64, data[1:4]))
+-                self.point3D_colors.append(map(np.uint8, data[4:7]))
++                self.points3D.append(list(map(np.float64, data[1:4])))
++                self.point3D_colors.append(list(map(np.uint8, data[4:7])))
+                 self.point3D_errors.append(np.float64(data[7]))
+ 
+                 # load (image id, point2D idx) pairs
+                 self.point3D_id_to_images[point3D_id] = \
+-                    np.array(map(np.uint32, data[8:])).reshape(-1, 2)
++                    np.array(list(map(np.uint32, data[8:]))).reshape(-1, 2)
+ 
+         self.points3D = np.array(self.points3D)
+         self.point3D_ids = np.array(self.point3D_ids)

--- a/docs/conversions/colmap/colmap.rst
+++ b/docs/conversions/colmap/colmap.rst
@@ -34,8 +34,11 @@ Example sensor IDs:
 - **camera2** — full-resolution images from COLMAP camera 2
 
 Camera intrinsics are compatible with the
-:class:`~ncore.data.OpenCVPinholeCameraModelParameters` model.
-[#opencv_fisheye]_ COLMAP uses the same local camera convention as NCore:
+:class:`~ncore.data.OpenCVPinholeCameraModelParameters` model for COLMAP camera
+types 0–4 (``SIMPLE_PINHOLE``, ``PINHOLE``, ``SIMPLE_RADIAL``, ``RADIAL``,
+``OPENCV``), and :class:`~ncore.data.OpenCVFisheyeCameraModelParameters` for
+COLMAP camera type 5 (``OPENCV_FISHEYE``). COLMAP uses the same local camera
+convention as NCore:
 
 - Principal axis along the camera's +z axis
 - x-axis points right, y-axis points down
@@ -47,11 +50,13 @@ The converter automatically detects per-image mask files and stores them as
 per-frame ``mask`` properties in the ``generic_data`` of each camera frame
 (grayscale ``uint8``, shape ``[H, W]``).
 
-Two mask-file conventions are supported, checked in priority order:
+Three mask-file conventions are supported, checked in priority order:
 
-1. **Co-located mask** — ``<image_dir>/<stem>_mask.png``
+1. **Explicit masks directory** — ``<sequence_dir>/<masks_dir>/<stem>.png``
+   when ``--masks-dir`` is configured.
+2. **Co-located mask** — ``<image_dir>/<stem>_mask.png``
    alongside the image file.
-2. **Separate masks directory** — ``<sequence_dir>/masks/<image_filename>``.
+3. **Separate masks directory** — ``<sequence_dir>/masks/<image_filename>``.
 
 If no mask file is found for a given image, the frame is stored without a
 ``mask`` entry.  The number of masks found per camera is logged at INFO level.
@@ -73,7 +78,7 @@ Conversion
 ----------
 
 The converter uses NCore V4's component-based architecture. Each COLMAP scene is
-parsed from a ``sparse/0/`` binary directory and written to NCore format via
+parsed from a COLMAP reconstruction directory (default: ``sparse/0/``) and written to NCore format via
 :class:`~ncore.data.v4.SequenceComponentGroupsWriter` with specialized component
 writers for poses, intrinsics, cameras, and optionally a virtual lidar.
 
@@ -159,6 +164,17 @@ subdirectory is treated as a separate sequence.
      - enabled
      - Include the SfM point cloud as a single frame of a ``virtual_lidar``
        sensor
+   * - ``--colmap-dir TEXT``
+     - ``sparse/0``
+     - Relative path to the COLMAP reconstruction directory within each
+       sequence
+   * - ``--images-dir TEXT``
+     - ``images``
+     - Relative path to the image directory within each sequence
+   * - ``--masks-dir TEXT``
+     - (auto-detect)
+     - Explicit masks directory relative to each sequence root. When set,
+       looks for ``<masks_dir>/<stem>.png``
 
 For the complete implementation, see
 ``tools/data_converter/colmap/converter.py``.
@@ -186,12 +202,45 @@ API Reference
 
 **Sensor Models** (:mod:`ncore.data`):
 
-- :class:`~ncore.data.OpenCVPinholeCameraModelParameters` - Camera intrinsics
-  model
+- :class:`~ncore.data.OpenCVPinholeCameraModelParameters` - Pinhole camera
+  intrinsics model
+- :class:`~ncore.data.OpenCVFisheyeCameraModelParameters` - Fisheye camera
+  intrinsics model
 
-.. rubric:: Footnotes
+ScanNet++ Conversion
+^^^^^^^^^^^^^^^^^^^^
 
-.. [#opencv_fisheye] Support for
-    :class:`~ncore.data.OpenCVFisheyeCameraModelParameters` could be added in
-    the future to additionally handle fisheye lens distortion models from
-    Colmap.
+The ``scannetpp-v4`` subcommand converts ScanNet++ DSLR scenes using the resized
+fisheye images (``dslr/resized_images/``) with the COLMAP ``OPENCV_FISHEYE``
+camera model. Train/test split metadata from ``train_test_lists.json`` is stored
+in the sequence-level ``generic_meta_data``.
+
+.. code-block:: bash
+
+    bazel run //tools/data_converter/colmap:convert -- \
+        --root-dir /path/to/scannetpp/scene_id \
+        --output-dir /path/to/output \
+        scannetpp-v4
+
+When ``--root-dir`` points to a parent directory containing multiple scenes,
+each subdirectory with a ``dslr/colmap/`` directory is treated as a separate
+scene.
+
+**Subcommand arguments** (``scannetpp-v4``):
+
+.. list-table::
+   :widths: 35 20 45
+   :header-rows: 1
+
+   * - Argument
+     - Default
+     - Description
+   * - ``--store-type {itar,directory}``
+     - ``itar``
+     - Output store format
+   * - ``--profile {default,separate-sensors,separate-all}``
+     - ``separate-sensors``
+     - Component group layout
+   * - ``--include-3d-points`` / ``--no-include-3d-points``
+     - enabled
+     - Include COLMAP SfM point cloud as virtual lidar

--- a/docs/conversions/index.rst
+++ b/docs/conversions/index.rst
@@ -5,7 +5,8 @@ Data Conversions
 ================
 
 NCore provides conversion tools for importing 3rd-party dataset formats into
-the NCore V4 component-based format.
+the NCore V4 component-based format. Supported formats include Waymo, COLMAP
+(including ScanNet++), and PAI.
 
 .. toctree::
    :maxdepth: 1

--- a/ncore/impl/sensors/camera.py
+++ b/ncore/impl/sensors/camera.py
@@ -1674,6 +1674,73 @@ class OpenCVFisheyeCameraModel(CameraModel):
     dforward_poly: torch.Tensor
     approx_backward_poly: torch.Tensor
 
+    @staticmethod
+    def compute_max_angle(
+        resolution: np.ndarray,
+        focal_length: np.ndarray,
+        principal_point: np.ndarray,
+        radial_coeffs: np.ndarray,
+    ) -> float:
+        """Estimate ``max_angle`` from the farthest image corner.
+
+        Computes the angle *theta* such that the OpenCV fisheye forward
+        distortion model
+
+        .. math::
+            r(\\theta) = \\theta\\,(1 + k_1\\theta^2 + k_2\\theta^4 + k_3\\theta^6 + k_4\\theta^8)
+
+        maps *theta* to the normalised pixel distance of the farthest image
+        corner.  Uses Newton-Raphson iteration to invert the forward
+        polynomial.
+
+        Parameters
+        ----------
+        resolution : np.ndarray
+            Image resolution ``[width, height]`` (uint64 or int, ``[2,]``).
+        focal_length : np.ndarray
+            Focal lengths ``[fu, fv]`` (float32, ``[2,]``).
+        principal_point : np.ndarray
+            Principal point ``[cu, cv]`` (float32, ``[2,]``).
+        radial_coeffs : np.ndarray
+            Fisheye radial distortion coefficients ``[k1, k2, k3, k4]``
+            (float32, ``[4,]``).
+
+        Returns
+        -------
+        float
+            Maximum angle in radians.
+        """
+        # Normalised distance from principal point to each image corner
+        corners = np.array(
+            [[0, 0], [resolution[0], 0], [0, resolution[1]], [resolution[0], resolution[1]]],
+            dtype=np.float64,
+        )
+        normalised = (corners - principal_point) / focal_length
+        max_r: float = np.max(np.linalg.norm(normalised, axis=1))
+
+        k = torch.from_numpy(radial_coeffs.astype(np.float64))
+
+        # Forward polynomial r(theta) = theta * (1 + k1*t^2 + k2*t^4 + k3*t^6 + k4*t^8)
+        #   Horner form on u = t^2:  r(t) = t * eval_poly_horner([1, k1, k2, k3, k4], u)
+        # Derivative r'(theta) = 1 + 3*k1*t^2 + 5*k2*t^4 + 7*k3*t^6 + 9*k4*t^8
+        #   Horner form on u = t^2:  r'(t) = eval_poly_horner([1, 3*k1, 5*k2, 7*k3, 9*k4], u)
+        fw = torch.tensor([1.0, k[0], k[1], k[2], k[3]], dtype=torch.float64)
+        dfw = torch.tensor([1.0, 3.0 * k[0], 5.0 * k[1], 7.0 * k[2], 9.0 * k[3]], dtype=torch.float64)
+
+        # Newton-Raphson: solve r(theta) - max_r = 0
+        theta = torch.tensor(max_r, dtype=torch.float64)
+        for _ in range(20):
+            t2 = theta * theta
+            r = theta * eval_poly_horner(fw, t2)
+            dr = eval_poly_horner(dfw, t2)
+            if abs(dr) < 1e-12:
+                break
+            theta = theta - (r - max_r) / dr
+            if abs(r - max_r) < 1e-10:
+                break
+
+        return theta.item()
+
     def __init__(
         self,
         camera_model_parameters: types.OpenCVFisheyeCameraModelParameters,

--- a/ncore/impl/sensors/camera_test.py
+++ b/ncore/impl/sensors/camera_test.py
@@ -1708,5 +1708,99 @@ class TestBivariateWindshieldModel(CommonTestCase):
         torch.testing.assert_close(res_w, rays, rtol=1e-4, atol=1e-5)
 
 
+class TestOpenCVFisheyeMaxAngle(unittest.TestCase):
+    """Tests for OpenCVFisheyeCameraModel.compute_max_angle."""
+
+    # Shared camera intrinsics (real-world ScanNet++ DSLR values)
+    RESOLUTION = np.array([1752, 1168], dtype=np.uint64)
+    FOCAL_LENGTH = np.array([789.28, 789.46], dtype=np.float32)
+    PRINCIPAL_POINT = np.array([883.03, 581.78], dtype=np.float32)
+    RADIAL_COEFFS = np.array([-0.0542, 0.0301, -0.0229, 0.0064], dtype=np.float32)
+
+    def test_compute_max_angle_basic(self):
+        """compute_max_angle returns a plausible angle for typical fisheye intrinsics."""
+        angle = OpenCVFisheyeCameraModel.compute_max_angle(
+            self.RESOLUTION, self.FOCAL_LENGTH, self.PRINCIPAL_POINT, self.RADIAL_COEFFS
+        )
+        # Should be a reasonable fisheye half-FOV (roughly 60-100 degrees)
+        self.assertGreater(angle, np.deg2rad(60))
+        self.assertLess(angle, np.deg2rad(100))
+
+    def test_compute_max_angle_zero_distortion(self):
+        """With zero distortion the model is equidistant: r = f * theta, so theta = r/f."""
+        resolution = np.array([2000, 2000], dtype=np.uint64)
+        focal_length = np.array([1000.0, 1000.0], dtype=np.float32)
+        principal_point = np.array([1000.0, 1000.0], dtype=np.float32)  # centred
+        radial_coeffs = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+
+        angle = OpenCVFisheyeCameraModel.compute_max_angle(resolution, focal_length, principal_point, radial_coeffs)
+        # Farthest corner is at (0,0) or (2000,2000), distance = sqrt(1^2 + 1^2) = sqrt(2)
+        expected = np.sqrt(2.0)  # normalised distance = corner distance / f = 1000/1000 * sqrt(2)
+        self.assertAlmostEqual(angle, expected, places=5)
+
+    def test_compute_max_angle_forward_inverse_consistency(self):
+        """The computed angle, when passed through the forward polynomial, should give the max corner distance."""
+        angle = OpenCVFisheyeCameraModel.compute_max_angle(
+            self.RESOLUTION, self.FOCAL_LENGTH, self.PRINCIPAL_POINT, self.RADIAL_COEFFS
+        )
+
+        # Forward polynomial: r(theta) = theta * (1 + k1*t^2 + k2*t^4 + k3*t^6 + k4*t^8)
+        k1, k2, k3, k4 = self.RADIAL_COEFFS.astype(np.float64)
+        t2 = angle**2
+        r_forward = angle * (1.0 + k1 * t2 + k2 * t2**2 + k3 * t2**3 + k4 * t2**4)
+
+        # Max normalised corner distance
+        corners = np.array([[0, 0], [1752, 0], [0, 1168], [1752, 1168]], dtype=np.float64)
+        normalised = (corners - self.PRINCIPAL_POINT.astype(np.float64)) / self.FOCAL_LENGTH.astype(np.float64)
+        max_r = float(np.max(np.linalg.norm(normalised, axis=1)))
+
+        self.assertAlmostEqual(r_forward, max_r, places=6)
+
+    def test_explicit_max_angle_preserved(self):
+        """An explicitly provided max_angle is stored as-is on the parameters."""
+        explicit = 1.234
+        params = OpenCVFisheyeCameraModelParameters(
+            resolution=self.RESOLUTION.copy(),
+            shutter_type=ShutterType.GLOBAL,
+            principal_point=self.PRINCIPAL_POINT.copy(),
+            focal_length=self.FOCAL_LENGTH.copy(),
+            radial_coeffs=self.RADIAL_COEFFS.copy(),
+            external_distortion_parameters=None,
+            max_angle=explicit,
+        )
+        self.assertAlmostEqual(params.max_angle, explicit, places=6)
+
+    def test_json_round_trip(self):
+        """Serialise and deserialise with a computed max_angle; the value should survive the round-trip."""
+        max_angle = OpenCVFisheyeCameraModel.compute_max_angle(
+            self.RESOLUTION, self.FOCAL_LENGTH, self.PRINCIPAL_POINT, self.RADIAL_COEFFS
+        )
+        original = OpenCVFisheyeCameraModelParameters(
+            resolution=self.RESOLUTION.copy(),
+            shutter_type=ShutterType.GLOBAL,
+            principal_point=self.PRINCIPAL_POINT.copy(),
+            focal_length=self.FOCAL_LENGTH.copy(),
+            radial_coeffs=self.RADIAL_COEFFS.copy(),
+            external_distortion_parameters=None,
+            max_angle=max_angle,
+        )
+        json_dict = original.to_dict()
+        restored = OpenCVFisheyeCameraModelParameters.from_dict(json_dict)
+        self.assertAlmostEqual(restored.max_angle, max_angle, places=5)
+
+    def test_asymmetric_principal_point(self):
+        """max_angle picks the farthest corner, not the nearest."""
+        # Principal point near top-left corner -> farthest corner is bottom-right
+        angle_tl = OpenCVFisheyeCameraModel.compute_max_angle(
+            self.RESOLUTION, self.FOCAL_LENGTH, np.array([100.0, 100.0], dtype=np.float32), self.RADIAL_COEFFS
+        )
+        # Principal point near centre
+        angle_c = OpenCVFisheyeCameraModel.compute_max_angle(
+            self.RESOLUTION, self.FOCAL_LENGTH, np.array([876.0, 584.0], dtype=np.float32), self.RADIAL_COEFFS
+        )
+        # Off-centre principal point should give a larger max_angle
+        self.assertGreater(angle_tl, angle_c)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/data_converter/colmap/BUILD.bazel
+++ b/tools/data_converter/colmap/BUILD.bazel
@@ -14,19 +14,34 @@
 # limitations under the License.
 
 load("@ncore_pip_deps//:requirements.bzl", "requirement")
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 # targets might be used in various places also outside of the repo, so make it public
 package(default_visibility = ["//visibility:public"])
 
+# Reusable library for the COLMAP converter (used by other converters, e.g. scannetpp)
+py_library(
+    name = "pylib",
+    srcs = ["converter.py"],
+    deps = [
+        "@pycolmap",
+        requirement("click"),
+        requirement("numpy"),
+        requirement("tqdm"),
+        requirement("universal_pathlib"),
+        requirement("pillow"),
+        "//ncore:pylib",
+        "//tools/data_converter:pylib_cli",
+    ],
+)
+
 # Standalone CLI binary for converting Colmap data to NCore V4
 py_binary(
     name = "convert",
-    srcs = [
-        "converter.py",
-    ],
+    srcs = ["converter.py"],
     main = "converter.py",
     deps = [
+        ":pylib",
         "@pycolmap",
         requirement("click"),
         requirement("numpy"),

--- a/tools/data_converter/colmap/README.md
+++ b/tools/data_converter/colmap/README.md
@@ -15,7 +15,7 @@ Because Colmap data does not adhere to the usual AV data conventions, we have ma
 design decisions to ease this conversion:
 
 - Camera images have been assigned timestamps at 1FPS.
-- The pointcloud has been assigned to a single lidar frame at timestamp 0.
+- The pointcloud has been assigned to a single lidar frame at timestamp 0 - point colors are stored as generic `rgb` frame data.
 - Downsampled images can be added as if they are separate cameras (with camera id suffixes `_2`, `_4`, and `_8`)
 
 ## Per-Image Masks

--- a/tools/data_converter/colmap/README.md
+++ b/tools/data_converter/colmap/README.md
@@ -65,6 +65,9 @@ bazel run //tools/data_converter/colmap -- \
 | `--store-type` | Output store type (`itar` or `directory`) | `itar` |
 | `--profile` | Component group profile (`default`, `separate-sensors`, `separate-all`) | `separate-sensors` |
 | `--sequence-meta` / `--no-sequence-meta` | Generate sequence meta-data file | True |
+| `--colmap-dir` | Relative path to COLMAP reconstruction directory | `sparse/0` |
+| `--images-dir` | Relative path to images directory | `images` |
+| `--masks-dir` | Explicit masks directory (auto-detect if not set) | None |
 
 ### Examples
 
@@ -96,6 +99,45 @@ bazel run //tools/data_converter/colmap -- \
     --output-dir /data/ncore/colmap \
     --store-type directory \
     colmap-v4
+```
+
+### ScanNet++ Conversion
+
+The `scannetpp-v4` subcommand converts ScanNet++ DSLR scenes. It uses the
+resized fisheye images (`dslr/resized_images/`) with the COLMAP `OPENCV_FISHEYE`
+camera model and stores train/test split metadata from `train_test_lists.json`.
+
+Convert a single scene:
+
+```bash
+bazel run //tools/data_converter/colmap:convert -- \
+    --root-dir /path/to/scannetpp/scene_id \
+    --output-dir /path/to/output \
+    scannetpp-v4
+```
+
+Convert all scenes under a parent directory:
+
+```bash
+bazel run //tools/data_converter/colmap:convert -- \
+    --root-dir /path/to/scannetpp/ \
+    --output-dir /path/to/output \
+    scannetpp-v4
+```
+
+You can also convert ScanNet++ data manually via the generic `colmap-v4` subcommand
+with explicit path options:
+
+```bash
+bazel run //tools/data_converter/colmap:convert -- \
+    --root-dir /path/to/scannetpp/scene_id \
+    --output-dir /path/to/output \
+    colmap-v4 \
+    --colmap-dir dslr/colmap \
+    --images-dir dslr/resized_images \
+    --masks-dir dslr/resized_anon_masks \
+    --camera-prefix dslr \
+    --no-include-downsampled-images
 ```
 
 ## License

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -327,6 +327,7 @@ class ColmapDataConverter(FileBasedDataConverter):
             intensity=np.zeros((1, num_points), dtype=np.float32),
             # Frame start/end timestamps (uint64, [2])
             frame_timestamps_us=np.array([start_timestamp_us, start_timestamp_us], dtype=np.uint64),
+            # Store COLMAP SfM point colors as generic data (uint8, [N, 3])
             generic_data={
                 "rgb": self.scene_manager.point3D_colors,  # uint8
             },

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -40,7 +40,7 @@ from ncore.data.v4 import (
     SequenceComponentGroupsWriter,
 )
 from ncore.data_converter import FileBasedDataConverter, FileBasedDataConverterConfig
-from ncore.impl.common.transformations import HalfClosedInterval
+from ncore.impl.common.transformations import HalfClosedInterval, se3_inverse
 from ncore.impl.data.types import JsonLike, OpenCVPinholeCameraModelParameters, ShutterType
 from ncore.impl.data.v4.types import ComponentGroupAssignments
 from tools.data_converter.cli import cli
@@ -80,13 +80,13 @@ class ColmapCamera:
         return (1e6 * (start_time_sec + np.linspace(0.0, self.n_images - 1, self.n_images))).astype(np.uint64)
 
     @property
-    def T_camera_ref(self) -> np.ndarray:
-        T_ref_camera_mats = np.stack(self.T_ref_camera_list, axis=0)
+    def T_camera_refs(self) -> np.ndarray:
+        T_ref_cameras = np.stack(self.T_ref_camera_list, axis=0)
 
-        # Convert extrinsics to camera-to-reference_frame.
+        # Convert extrinsics to camera-to-reference frame.
         # NOTE: colmap already assumes OpenCV convention
-        T_camera_ref = np.linalg.inv(T_ref_camera_mats)
-        return T_camera_ref[:, :4, :4].astype(np.float32)
+        T_camera_refs = se3_inverse(T_ref_cameras)
+        return T_camera_refs[:, :4, :4].astype(np.float32)
 
     @property
     def camera_model(self) -> OpenCVPinholeCameraModelParameters:
@@ -429,7 +429,7 @@ class ColmapDataConverter(FileBasedDataConverter):
             self.poses_writer.store_dynamic_pose(
                 source_frame_id=camera_ncore_id,
                 target_frame_id=colmap_camera.reference_frame,
-                poses=colmap_camera.T_camera_ref,
+                poses=colmap_camera.T_camera_refs,
                 timestamps_us=colmap_camera.timestamps_us,
                 require_sequence_time_coverage=False,  # Some cameras may have more poses than others
             )

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -19,7 +19,7 @@ import json
 import logging
 
 from dataclasses import dataclass, field
-from typing import Literal, Optional
+from typing import List, Literal, Optional, Union, cast
 
 import click
 import numpy as np
@@ -41,8 +41,14 @@ from ncore.data.v4 import (
 )
 from ncore.data_converter import FileBasedDataConverter, FileBasedDataConverterConfig
 from ncore.impl.common.transformations import HalfClosedInterval, se3_inverse
-from ncore.impl.data.types import JsonLike, OpenCVPinholeCameraModelParameters, ShutterType
+from ncore.impl.data.types import (
+    JsonLike,
+    OpenCVFisheyeCameraModelParameters,
+    OpenCVPinholeCameraModelParameters,
+    ShutterType,
+)
 from ncore.impl.data.v4.types import ComponentGroupAssignments
+from ncore.impl.sensors.camera import OpenCVFisheyeCameraModel
 from tools.data_converter.cli import cli
 
 
@@ -57,6 +63,10 @@ class ColmapConverter4Config(FileBasedDataConverterConfig):
     camera_prefix: str = "camera"
     include_downsampled_images: bool = False
     include_3d_points: bool = True
+    colmap_dir: str = "sparse/0"
+    images_dir: str = "images"
+    masks_dir: Optional[str] = None
+    generic_meta_data: dict[str, JsonLike] = field(default_factory=dict)
 
 
 @dataclass(kw_only=True, slots=True)
@@ -89,30 +99,15 @@ class ColmapCamera:
         return T_camera_refs[:, :4, :4].astype(np.float32)
 
     @property
-    def camera_model(self) -> OpenCVPinholeCameraModelParameters:
+    def camera_model(self) -> Union[OpenCVPinholeCameraModelParameters, OpenCVFisheyeCameraModelParameters]:
         camera = self.colmap_camera
 
-        # Get distortion parameters.
         assert camera.camera_type in [0, 1, 2, 3, 4, 5], f"Unsupported camera type: {camera.camera_type}"
-        radial_coeffs = np.array([0, 0, 0, 0, 0, 0], dtype=np.float32)
-        tangential_coeffs = np.array([0, 0], dtype=np.float32)
-
-        # 0: SIMPLE_PINHOLE, 1: PINHOLE, 2: SIMPLE_RADIAL, 3: RADIAL, 4: OpenCV, 5: OpenCVFisheye
-        if camera.camera_type > 1:
-            radial_coeffs[0] = camera.k1
-        if camera.camera_type > 2:
-            radial_coeffs[1] = camera.k2
-        if camera.camera_type == 4:
-            tangential_coeffs[0] = camera.p1
-            tangential_coeffs[1] = camera.p2
-        if camera.camera_type == 5:
-            raise NotImplementedError("OpenCV fisheye camera model not supported yet in converter")
 
         width = round(camera.width / self.downsample_factor)
         height = round(camera.height / self.downsample_factor)
 
-        # This is kind of a hack, but sometimes COLMAP downsampled images have a resolution different from what
-        # is expected. Specifically 0.5 does not always round up. This might cause issues with the camera model.
+        # Resolution check for downsampled images
         if self.downsample_factor != 1:
             with PILImage.open(str(self.image_path / self.image_names[0])) as img:
                 if img.width != width or img.height != height:
@@ -128,6 +123,35 @@ class ColmapCamera:
         principal_point = np.array(
             [camera.cx / self.downsample_factor, camera.cy / self.downsample_factor], dtype=np.float32
         )
+
+        # 5: OpenCVFisheye -> OpenCVFisheyeCameraModelParameters
+        if camera.camera_type == 5:
+            resolution = np.array([width, height], dtype=np.uint64)
+            radial_coeffs = np.array([camera.k1, camera.k2, camera.k3, camera.k4], dtype=np.float32)
+            max_angle = OpenCVFisheyeCameraModel.compute_max_angle(
+                resolution, focal_length, principal_point, radial_coeffs
+            )
+            return OpenCVFisheyeCameraModelParameters(
+                resolution=resolution,
+                shutter_type=ShutterType.GLOBAL,
+                external_distortion_parameters=None,
+                principal_point=principal_point,
+                focal_length=focal_length,
+                radial_coeffs=radial_coeffs,
+                max_angle=max_angle,
+            )
+
+        # 0: SIMPLE_PINHOLE, 1: PINHOLE, 2: SIMPLE_RADIAL, 3: RADIAL, 4: OpenCV
+        radial_coeffs = np.array([0, 0, 0, 0, 0, 0], dtype=np.float32)
+        tangential_coeffs = np.array([0, 0], dtype=np.float32)
+
+        if camera.camera_type > 1:
+            radial_coeffs[0] = camera.k1
+        if camera.camera_type > 2:
+            radial_coeffs[1] = camera.k2
+        if camera.camera_type == 4:
+            tangential_coeffs[0] = camera.p1
+            tangential_coeffs[1] = camera.p2
 
         return OpenCVPinholeCameraModelParameters(
             resolution=np.array([width, height], dtype=np.uint64),
@@ -162,6 +186,10 @@ class ColmapDataConverter(FileBasedDataConverter):
         # Downsampled images in folders images_2, images_4, etc will be included as additional cameras
         self.include_downsampled_images = config.include_downsampled_images
         self.include_3d_points = config.include_3d_points
+        self.colmap_dir = config.colmap_dir
+        self.images_dir = config.images_dir
+        self.masks_dir = config.masks_dir
+        self.generic_meta_data: dict[str, JsonLike] = config.generic_meta_data
         self.logger = logging.getLogger(__name__)
 
     @staticmethod
@@ -192,7 +220,7 @@ class ColmapDataConverter(FileBasedDataConverter):
         self.sequence_path = sequence_path
         self.sequence_name = sequence_path.name
 
-        bin_path = self.sequence_path / "sparse" / "0"
+        bin_path = self.sequence_path / self.colmap_dir
 
         image_path = self.sequence_path / self.images_dir
         self.scene_manager = pycolmap.SceneManager(str(bin_path), image_path=str(image_path))
@@ -202,6 +230,7 @@ class ColmapDataConverter(FileBasedDataConverter):
             parent_dir=self.sequence_path,
             camera_prefix=self.camera_prefix,
             downsample=self.include_downsampled_images,
+            images_dir=self.images_dir,
         )
 
         camera_ids = list(self.cameras.keys())
@@ -231,7 +260,7 @@ class ColmapDataConverter(FileBasedDataConverter):
             sequence_id=self.sequence_name,
             sequence_timestamp_interval_us=sequence_timestamp_interval_us,
             store_type=self.store_type,
-            generic_meta_data={},  # no generic sequence meta data
+            generic_meta_data=self.generic_meta_data,
         )
 
         # Create poses component
@@ -334,7 +363,9 @@ class ColmapDataConverter(FileBasedDataConverter):
             generic_meta_data={},
         )
 
-    def populate_camera_data(self, parent_dir: UPath, camera_prefix: str, downsample: bool) -> dict[str, ColmapCamera]:
+    def populate_camera_data(
+        self, parent_dir: UPath, camera_prefix: str, downsample: bool, images_dir: str = "images"
+    ) -> dict[str, ColmapCamera]:
         """Populates the camera data from the COLMAP scene, including extrinsics and intrinsics
 
         Returns a dictionary of ColmapCamera instances indexed by the NCore camera IDs."""
@@ -359,42 +390,42 @@ class ColmapDataConverter(FileBasedDataConverter):
                 cameras[ncore_camera_id] = ColmapCamera(
                     camera_id=ncore_camera_id,
                     colmap_camera=self.scene_manager.cameras[imdata[k].camera_id],
-                    image_path=parent_dir / "images",
+                    image_path=parent_dir / images_dir,
                 )
             cameras[ncore_camera_id].T_ref_camera_list.append(T_ref_camera)
             cameras[ncore_camera_id].image_names.append(imdata[k].name)
 
-        if not downsample:
-            return cameras
-
-        # Add extra cameras if we are downsampling and data exists.
-        for camera_id, camera in self.scene_manager.cameras.items():
-            assert isinstance(camera, pycolmap.Camera)
-            for downsample_factor in [2, 4, 8]:
-                reference_camera_id = camera_prefix + str(camera_id)
-                ncore_camera_id = camera_prefix + str(camera_id) + "_" + str(downsample_factor)
-                image_root = "images_" + str(downsample_factor)
-                if not (parent_dir / image_root).exists():
-                    self.logger.warning(f"Skipping missing downsampled image directory: {image_root}")
-                    continue
-                image_names = cameras[reference_camera_id].image_names
-                cameras[ncore_camera_id] = ColmapCamera(
-                    camera_id=ncore_camera_id,
-                    colmap_camera=self.scene_manager.cameras[imdata[k].camera_id],
-                    image_path=parent_dir / image_root,
-                    reference_frame=reference_camera_id,
-                    T_ref_camera_list=[np.eye(4)] * len(image_names),
-                    image_names=image_names,
-                    downsample_factor=downsample_factor,
-                )
+        if downsample:
+            # Add extra cameras if we are downsampling and data exists.
+            for camera_id, camera in self.scene_manager.cameras.items():
+                assert isinstance(camera, pycolmap.Camera)
+                for downsample_factor in [2, 4, 8]:
+                    reference_camera_id = camera_prefix + str(camera_id)
+                    ncore_camera_id = camera_prefix + str(camera_id) + "_" + str(downsample_factor)
+                    image_root = "images_" + str(downsample_factor)
+                    if not (parent_dir / image_root).exists():
+                        self.logger.warning(f"Skipping missing downsampled image directory: {image_root}")
+                        continue
+                    image_names = cameras[reference_camera_id].image_names
+                    cameras[ncore_camera_id] = ColmapCamera(
+                        camera_id=ncore_camera_id,
+                        colmap_camera=self.scene_manager.cameras[imdata[k].camera_id],
+                        image_path=parent_dir / image_root,
+                        reference_frame=reference_camera_id,
+                        T_ref_camera_list=[np.eye(4)] * len(image_names),
+                        image_names=image_names,
+                        downsample_factor=downsample_factor,
+                    )
 
         return cameras
 
     def _find_mask_path(self, image_path: UPath, image_name: str) -> Optional[UPath]:
-        """Find a per-image mask file using two conventions.
+        """Find a per-image mask file using multiple conventions.
 
         Checks the following locations in priority order:
 
+        0. ``<sequence_dir>/<masks_dir>/<stem>.png`` or ``<sequence_dir>/<masks_dir>/<image_filename>``
+           — explicit masks directory (from config)
         1. ``<image_dir>/<stem>_mask.png`` — co-located mask
         2. ``<sequence_dir>/masks/<image_filename>`` — separate masks directory
 
@@ -411,6 +442,16 @@ class ColmapDataConverter(FileBasedDataConverter):
             Path to the mask file if found, otherwise ``None``.
         """
         stem = image_path.stem
+
+        # Convention 0: explicit masks directory (from config)
+        if self.masks_dir is not None:
+            mask_path = self.sequence_path / self.masks_dir / f"{stem}.png"
+            if mask_path.exists():
+                return mask_path
+            mask_path = self.sequence_path / self.masks_dir / image_name
+            if mask_path.exists():
+                return mask_path
+
         # Convention 1: <image_dir>/<stem>_mask.png
         mask_path = image_path.parent / f"{stem}_mask.png"
         if mask_path.exists():
@@ -541,6 +582,26 @@ class ColmapDataConverter(FileBasedDataConverter):
     default=True,
     help="Include 3D Points as a lidar sensor",
 )
+@click.option(
+    "--colmap-dir",
+    type=str,
+    default="sparse/0",
+    show_default=True,
+    help="Path to the COLMAP sparse reconstruction directory (relative to sequence root).",
+)
+@click.option(
+    "--images-dir",
+    type=str,
+    default="images",
+    show_default=True,
+    help="Path to the images directory (relative to sequence root).",
+)
+@click.option(
+    "--masks-dir",
+    type=str,
+    default=None,
+    help="Path to the masks directory (relative to sequence root). If not set, masks are discovered via conventions.",
+)
 @click.pass_context
 def colmap_v4(ctx, *_, **kwargs):
     """Colmap-specific data conversion (V4 format)"""
@@ -549,6 +610,169 @@ def colmap_v4(ctx, *_, **kwargs):
     config = ColmapConverter4Config(**{**vars(ctx.obj), **kwargs})
 
     ColmapDataConverter.convert(config)
+
+
+# ---------------------------------------------------------------------------
+# ScanNet++ subcommand
+# ---------------------------------------------------------------------------
+
+
+def _discover_scannetpp_scenes(root_dir: UPath) -> list[UPath]:
+    """Discover ScanNet++ scenes under *root_dir*.
+
+    A valid scene is a subdirectory containing ``dslr/colmap/``.
+    """
+    scenes = []
+    for child in sorted(root_dir.iterdir()):
+        if child.is_dir() and (child / "dslr" / "colmap").is_dir():
+            scenes.append(child)
+    return scenes
+
+
+def _build_scannetpp_split_metadata(
+    scene_path: UPath,
+    image_names: list[str],
+    camera_id: str,
+    start_time_sec: float,
+) -> dict[str, JsonLike]:
+    """Build train/test split metadata from ScanNet++ ``train_test_lists.json``.
+
+    Returns a dict suitable for sequence-level ``generic_meta_data``.
+    """
+    train_test_path = scene_path / "dslr" / "train_test_lists.json"
+    if not train_test_path.exists():
+        logging.getLogger(__name__).warning(f"No train_test_lists.json found at {train_test_path}")
+        return {}
+
+    with train_test_path.open("r") as f:
+        train_test = json.load(f)
+
+    train_set = set(train_test.get("train", []))
+    test_set = set(train_test.get("test", []))
+
+    # Associate image file names with virtual frame timestamps
+    sorted_names = sorted(image_names)
+    name_to_ts = {name: int(1e6 * (start_time_sec + i)) for i, name in enumerate(sorted_names)}
+
+    train_filenames = [n for n in sorted_names if n in train_set]
+    test_filenames = [n for n in sorted_names if n in test_set]
+
+    camera_splits: dict[str, JsonLike] = {}
+    if train_filenames:
+        camera_splits["train"] = {
+            "frame_timestamps_us": [name_to_ts[n] for n in train_filenames],
+            "source_filenames": cast(List[JsonLike], train_filenames),
+        }
+    if test_filenames:
+        camera_splits["test"] = {
+            "frame_timestamps_us": [name_to_ts[n] for n in test_filenames],
+            "source_filenames": cast(List[JsonLike], test_filenames),
+        }
+
+    return {
+        "source_dataset": "scannetpp",
+        "scene_id": scene_path.name,
+        "splits": {camera_id: camera_splits} if camera_splits else {},
+    }
+
+
+@cli.command()
+@click.option(
+    "--store-type",
+    type=click.Choice(["itar", "directory"], case_sensitive=False),
+    default="itar",
+    show_default=True,
+    help="Output store type.",
+)
+@click.option(
+    "component_group_profile",
+    "--profile",
+    type=click.Choice(["default", "separate-sensors", "separate-all"], case_sensitive=False),
+    default="separate-sensors",
+    show_default=True,
+    help="Output component group profile.",
+)
+@click.option(
+    "--include-3d-points/--no-include-3d-points",
+    is_flag=True,
+    default=True,
+    help="Include COLMAP SfM point cloud as virtual lidar.",
+)
+@click.pass_context
+def scannetpp_v4(ctx, **kwargs):
+    """ScanNet++ dataset conversion (V4 format).
+
+    Converts ScanNet++ DSLR scenes to NCore V4 by configuring the COLMAP
+    converter for the ScanNet++ directory layout.  Uses the resized fisheye
+    images (``dslr/resized_images/``) with the COLMAP OPENCV_FISHEYE camera
+    model.
+
+    Expects ``--root-dir`` to point either to a single scene directory or
+    to a parent directory containing multiple scene subdirectories.
+    """
+
+    _logger = logging.getLogger(__name__)
+    base = ctx.obj
+    root_dir = UPath(base.root_dir)
+
+    # Discover scenes
+    scenes = _discover_scannetpp_scenes(root_dir)
+    if not scenes:
+        if (root_dir / "dslr" / "colmap").is_dir():
+            scenes = [root_dir]
+        else:
+            raise click.ClickException(f"No ScanNet++ scenes found in {root_dir}")
+
+    _logger.info(f"Found {len(scenes)} ScanNet++ scene(s)")
+
+    for scene_path in scenes:
+        scene_id = scene_path.name
+
+        # Check has_masks from train_test_lists.json
+        train_test_path = scene_path / "dslr" / "train_test_lists.json"
+        has_masks = False
+        if train_test_path.exists():
+            with train_test_path.open("r") as f:
+                has_masks = json.load(f).get("has_masks", False)
+
+        masks_dir: Optional[str] = "dslr/resized_anon_masks" if has_masks else None
+
+        # ScanNet++ DSLR has exactly 1 COLMAP camera -> NCore ID "dslr1"
+        camera_prefix = "dslr"
+        images_dir = "dslr/resized_images"
+        primary_image_dir = scene_path / images_dir
+        primary_image_names = sorted(f.name for f in primary_image_dir.iterdir() if f.is_file())
+
+        generic_meta_data = _build_scannetpp_split_metadata(
+            scene_path=scene_path,
+            image_names=primary_image_names,
+            camera_id=f"{camera_prefix}1",
+            start_time_sec=kwargs.get("start_time_sec", 0.0),
+        )
+
+        config = ColmapConverter4Config(
+            root_dir=str(scene_path),
+            output_dir=base.output_dir,
+            verbose=base.verbose,
+            debug=base.debug,
+            debug_port=base.debug_port,
+            no_cameras=base.no_cameras,
+            camera_ids=base.camera_ids,
+            no_lidars=base.no_lidars,
+            lidar_ids=base.lidar_ids,
+            no_radars=base.no_radars,
+            radar_ids=base.radar_ids,
+            colmap_dir="dslr/colmap",
+            images_dir=images_dir,
+            masks_dir=masks_dir,
+            camera_prefix=camera_prefix,
+            include_downsampled_images=False,
+            generic_meta_data=generic_meta_data,
+            **kwargs,
+        )
+
+        _logger.info(f"Converting scene: {scene_id}")
+        ColmapDataConverter.convert(config)
 
 
 if __name__ == "__main__":

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -194,10 +194,9 @@ class ColmapDataConverter(FileBasedDataConverter):
 
         bin_path = self.sequence_path / "sparse" / "0"
 
-        self.scene_manager = pycolmap.SceneManager(str(bin_path))
-        self.scene_manager.load_cameras()
-        self.scene_manager.load_images()
-        self.scene_manager.load_points3D()
+        image_path = self.sequence_path / self.images_dir
+        self.scene_manager = pycolmap.SceneManager(str(bin_path), image_path=str(image_path))
+        self.scene_manager.load()
 
         self.cameras = self.populate_camera_data(
             parent_dir=self.sequence_path,


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the COLMAP data conversion pipeline, with a focus on supporting ScanNet++ DSLR scenes, enhancing documentation, and ensuring compatibility with Python 3. The most significant changes include the addition of a reusable COLMAP converter library, improved handling of COLMAP fisheye camera models, expanded CLI and documentation for ScanNet++ conversion, and a patch to fix Python 3 incompatibility in the `pycolmap` dependency.

**ScanNet++ and COLMAP Conversion Enhancements:**

* Added a reusable `py_library` Bazel target for the COLMAP converter, enabling other converters (such as ScanNet++) to import and use its functionality (`tools/data_converter/colmap/BUILD.bazel`).
* Expanded CLI and documentation to support a new `scannetpp-v4` subcommand for converting ScanNet++ DSLR scenes, including support for the COLMAP `OPENCV_FISHEYE` camera model and handling of train/test splits (`tools/data_converter/colmap/README.md`, `docs/conversions/colmap/colmap.rst`, `docs/conversions/index.rst`) [[1]](diffhunk://#diff-ba10af088b19c24fdf4e21f15177d5320124e9758fc1fa8cae798a8730b83b6bR104-R142) [[2]](diffhunk://#diff-2fb04e0f931f2bbf5f230c68fa02498fd11fc576bf7238ab8eb54eeb223f33ccL189-R246) [[3]](diffhunk://#diff-5a11ff37d6a53fef7ba2030ea05c117a06d72bacef8265227051d4fa608c484aL8-R9).
* Added new CLI options for specifying COLMAP, images, and masks directories, and updated documentation to describe these options (`tools/data_converter/colmap/README.md`, `docs/conversions/colmap/colmap.rst`) [[1]](diffhunk://#diff-ba10af088b19c24fdf4e21f15177d5320124e9758fc1fa8cae798a8730b83b6bR68-R70) [[2]](diffhunk://#diff-2fb04e0f931f2bbf5f230c68fa02498fd11fc576bf7238ab8eb54eeb223f33ccR167-R177).

**Camera Model and Testing Improvements:**

* Implemented `OpenCVFisheyeCameraModel.compute_max_angle`, a static method to estimate the maximum field-of-view angle for fisheye cameras, and added comprehensive unit tests to ensure correctness and round-trip serialization (`ncore/impl/sensors/camera.py`, `ncore/impl/sensors/camera_test.py`) [[1]](diffhunk://#diff-c8fd3899733116e1bc59f76ec6bb29fab3f8e7a9450f155a3aee35c0bb3fc88dR1677-R1742) [[2]](diffhunk://#diff-9f16de99019245db8defc797444cb5d762e5af591f1b53f128efd932eb43f8a2R1711-R1804).

**Dependency and Compatibility Fixes:**

* Added a patch to the `pycolmap` dependency to fix Python 3 incompatibility with `map()` usage, ensuring correct loading of COLMAP text-format files; updated Bazel build files to apply this patch (`deps/pycolmap/BUILD.bazel`, `deps/pycolmap/fix-python3-map.patch`, `MODULE.bazel`) [[1]](diffhunk://#diff-6efa2eaa7782bb9b5b01dad0d6d34db628290ffec19f4c4538c50dcab2c3e413R1-R72) [[2]](diffhunk://#diff-7959239fee8981471382bb99c9a43455ad5349771a04b10c70a5b510429ae029R15-R16) [[3]](diffhunk://#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdcL112-R120).

**Documentation and Usability Improvements:**

* Clarified camera model documentation, mask file conventions, and conversion process for both COLMAP and ScanNet++ datasets (`docs/conversions/colmap/colmap.rst`, `tools/data_converter/colmap/README.md`) [[1]](diffhunk://#diff-2fb04e0f931f2bbf5f230c68fa02498fd11fc576bf7238ab8eb54eeb223f33ccL50-R59) [[2]](diffhunk://#diff-2fb04e0f931f2bbf5f230c68fa02498fd11fc576bf7238ab8eb54eeb223f33ccL76-R81) [[3]](diffhunk://#diff-2fb04e0f931f2bbf5f230c68fa02498fd11fc576bf7238ab8eb54eeb223f33ccR167-R177) [[4]](diffhunk://#diff-ba10af088b19c24fdf4e21f15177d5320124e9758fc1fa8cae798a8730b83b6bR104-R142).

**Minor Fixes:**

* Improved description of point cloud storage in the README and updated type imports in the converter for better type checking (`tools/data_converter/colmap/README.md`, `tools/data_converter/colmap/converter.py`) [[1]](diffhunk://#diff-ba10af088b19c24fdf4e21f15177d5320124e9758fc1fa8cae798a8730b83b6bL18-R18) [[2]](diffhunk://#diff-5906fa03d0ccd479ab829602209fa02387b0db56598c06ead3b1289129ab64f5L22-R22).