### PR TITLE
feat(pai): add radar sensor support to PAI converter and ncore_vis

### DIFF
--- a/tools/data_converter/pai/converter.py
+++ b/tools/data_converter/pai/converter.py
@@ -22,6 +22,7 @@ FEATURES:
   - Egomotion poses from sensor data
   - 7 cameras (120° FOV front/cross, 70° FOV rear, 30° FOV tele)
   - 1 top lidar (360° FOV, DRACO compressed)
+  - Up to 19 radar sensors (spherical coordinates, per-detection Doppler/RCS/SNR)
   - Cuboid obstacle labels
 
 LIMITATIONS:
@@ -55,6 +56,7 @@ from ncore.data.v4 import (
     LidarSensorComponent,
     MasksComponent,
     PosesComponent,
+    RadarSensorComponent,
     SequenceComponentGroupsReader,
     SequenceComponentGroupsWriter,
 )
@@ -150,6 +152,7 @@ class _PaiConversionMixin:
     # Methods from BaseDataConverter that the mixin calls
     get_active_camera_ids: Callable[..., list[str]]
     get_active_lidar_ids: Callable[..., list[str]]
+    get_active_radar_ids: Callable[..., list[str]]
 
     # Camera sensor mapping
     CAMERA_SENSORS = [
@@ -200,6 +203,8 @@ class _PaiConversionMixin:
         all_lidar_ids = [s for s in self.sensor_extrinsics.keys() if "lidar" in s]
         active_camera_ids = self.get_active_camera_ids(all_camera_ids)
         active_lidar_ids = self.get_active_lidar_ids(all_lidar_ids)
+        all_radar_ids = [s for s in self.sensor_extrinsics.keys() if s.startswith("radar_")]
+        active_radar_ids = self.get_active_radar_ids(all_radar_ids)
 
         # Load egomotion (timestamps are shifted to be positive)
         ego_df = self.provider.load_parquet("egomotion")
@@ -239,7 +244,7 @@ class _PaiConversionMixin:
         self.component_groups = ComponentGroupAssignments.create(
             camera_ids=active_camera_ids,
             lidar_ids=active_lidar_ids,
-            radar_ids=[],
+            radar_ids=active_radar_ids,
             profile=self.component_group_profile,
         )
 
@@ -319,6 +324,7 @@ class _PaiConversionMixin:
         # Decode all sensors and store data in components
         self.decode_cameras(active_camera_ids)
         self.decode_lidars(active_lidar_ids)
+        self.decode_radars(active_radar_ids)
 
         # Create and store cuboids component
         self.store_writer.register_component_writer(
@@ -422,12 +428,28 @@ class _PaiConversionMixin:
         extrinsics_df = self.provider.load_parquet("sensor_extrinsics")
         self.sensor_extrinsics = parse_sensor_extrinsics(extrinsics_df, self.clip_id, self.sensor_presence)
 
+        # The .offline extrinsics may only contain cameras + lidar.  If radar
+        # sensors are present according to feature_presence but missing from the
+        # loaded extrinsics, fall back to the non-offline extrinsics for those.
+        radar_present = [s for s in self.sensor_presence.index if s.startswith("radar_") and self.sensor_presence[s]]
+        radar_missing = [s for s in radar_present if s not in self.sensor_extrinsics]
+        if radar_missing and self.provider.has_file("sensor_extrinsics_online"):
+            self.logger.info(
+                f"Loading online extrinsics for {len(radar_missing)} radar sensors missing from offline calibration"
+            )
+            online_extrinsics_df = self.provider.load_parquet("sensor_extrinsics_online")
+            online_extrinsics = parse_sensor_extrinsics(online_extrinsics_df, self.clip_id, self.sensor_presence)
+            for radar_id in radar_missing:
+                if radar_id in online_extrinsics:
+                    self.sensor_extrinsics[radar_id] = online_extrinsics[radar_id]
+
         dimensions_df = self.provider.load_parquet("vehicle_dimensions")
         self.vehicle_dimensions = parse_vehicle_dimensions(dimensions_df, self.clip_id)
 
         self.logger.info(
             f"Loaded metadata: {len(self.camera_intrinsics)} cameras, "
-            f"{len([k for k in self.sensor_extrinsics if 'lidar' in k])} lidars"
+            f"{len([k for k in self.sensor_extrinsics if 'lidar' in k])} lidars, "
+            f"{len([k for k in self.sensor_extrinsics if k.startswith('radar_')])} radars"
         )
 
         # Platform details
@@ -547,6 +569,131 @@ class _PaiConversionMixin:
                     frame_timestamps_us=timestamps_us,
                     generic_data={},
                     generic_meta_data={},
+                )
+
+    def decode_radars(self, active_radar_ids: list[str]) -> None:
+        logger = self.logger.getChild("decode_radars")
+
+        for radar_id in active_radar_ids:
+            logger.info(f"Decoding radar data from {radar_id}")
+            if not self.provider.has_file(radar_id):
+                logger.warning(f"Radar file not found for {radar_id}")
+                continue
+
+            # Load radar parquet
+            radar_df = self.provider.load_parquet(radar_id)
+
+            # Get sensor transform
+            T_sensor_rig = self.sensor_extrinsics[radar_id]
+
+            # Store extrinsics
+            self.poses_writer.store_static_pose(
+                source_frame_id=radar_id,
+                target_frame_id="rig",
+                pose=T_sensor_rig.astype(np.float32),
+            )
+
+            # Create radar writer
+            radar_writer = self.store_writer.register_component_writer(
+                RadarSensorComponent.Writer,
+                component_instance_name=radar_id,
+                group_name=self.component_groups.radar_component_groups.get(radar_id),
+            )
+
+            # Group detections by scan_index (stored as the DataFrame index)
+            for scan_index, scan_df in tqdm.tqdm(radar_df.groupby(level=0), desc=f"Radar {radar_id}"):
+                # Infer frame timestamps from per-detection timestamps
+                timestamp_us = cast(np.ndarray, scan_df["sensor_timestamp"].values.astype(np.int64))
+
+                frame_start_us = int(timestamp_us.min())
+                frame_end_us = int(timestamp_us.max())
+
+                # Skip scans with non-positive timestamps (before time origin)
+                if frame_end_us < 0:
+                    continue
+
+                # Skip frames outside sequence time interval
+                if frame_start_us < self.sequence_timestamp_interval_us.start:
+                    continue
+                if frame_end_us >= self.sequence_timestamp_interval_us.stop:
+                    break
+
+                # Filter out negative timestamps
+                valid = timestamp_us >= 0
+                if not valid.all():
+                    scan_df = scan_df[valid]
+                    timestamp_us = timestamp_us[valid]
+
+                # Convert spherical to unit direction vectors
+                azimuth = scan_df["azimuth"].values.astype(np.float64)
+                elevation = scan_df["elevation"].values.astype(np.float64)
+
+                cos_el = np.cos(elevation)
+                direction = np.stack(
+                    [
+                        cos_el * np.cos(azimuth),
+                        cos_el * np.sin(azimuth),
+                        np.sin(elevation),
+                    ],
+                    axis=-1,
+                ).astype(np.float32)
+
+                # Distance (metric, single return)
+                distance_m = cast(np.ndarray, scan_df["distance"].values.astype(np.float32))
+
+                # Filter out zero/negative distances
+                valid_mask = distance_m > 0
+                direction = direction[valid_mask]
+                timestamp_us = timestamp_us[valid_mask]
+                distance_m = distance_m[np.newaxis, valid_mask]  # [1, N]
+
+                # Frame timestamps
+                frame_timestamps_us = np.array([frame_start_us, frame_end_us], dtype=np.uint64)
+
+                # Generic data: per-detection radar signals
+                generic_data: dict[str, np.ndarray] = {}
+
+                if "radial_velocity" in scan_df.columns:
+                    # Units: m/s (meters per second), positive away from the sensor
+                    generic_data["radial_velocity_m_s"] = cast(
+                        np.ndarray, scan_df["radial_velocity"].values[valid_mask].astype(np.float32)
+                    )
+                if "rcs" in scan_df.columns:
+                    # Units: dBsm (decibels relative to square meter)
+                    generic_data["rcs_dBsm"] = cast(np.ndarray, scan_df["rcs"].values[valid_mask].astype(np.float32))
+                if "snr" in scan_df.columns:
+                    # Units: dB (decibels), higher ~ more reliable detection
+                    generic_data["snr_dB"] = cast(np.ndarray, scan_df["snr"].values[valid_mask].astype(np.float32))
+                if "exist_probb" in scan_df.columns:
+                    # Normalize uint8 (0-100) to float32 (0-1)
+                    generic_data["exist_probb"] = (
+                        cast(np.ndarray, scan_df["exist_probb"].values[valid_mask].astype(np.float32)) / 100.0
+                    )
+
+                # Generic metadata: scan-level scalars
+                generic_meta_data: dict[str, JsonLike] = {
+                    "scan_index": cast(int, scan_index),
+                }
+                for col, meta_key, conv in [
+                    ("doppler_ambiguity", "doppler_ambiguity", float),
+                    ("radar_model", "radar_model", int),
+                    ("num_returns", "num_returns", int),
+                ]:
+                    if col in scan_df.columns:
+                        val = scan_df[col].iloc[0]
+                        try:
+                            if not np.isnan(float(val)):
+                                generic_meta_data[meta_key] = conv(val)
+                        except (ValueError, TypeError):
+                            pass
+
+                radar_writer.store_frame(
+                    direction=direction,
+                    timestamp_us=timestamp_us.astype(np.uint64),
+                    distance_m=distance_m,
+                    frame_timestamps_us=frame_timestamps_us,
+                    generic_data=generic_data,
+                    generic_meta_data=generic_meta_data,
                 )
 
     def decode_cameras(self, active_camera_ids: list[str]):

--- a/tools/data_converter/pai/data_provider.py
+++ b/tools/data_converter/pai/data_provider.py
@@ -294,6 +294,10 @@ class StreamingClipDataProvider:
         if key in ("camera_intrinsics", "sensor_extrinsics", "vehicle_dimensions", "lidar_intrinsics"):
             return self._prefer_offline_feature(key), None
 
+        # Explicit non-offline (online) extrinsics (for radar calibration fallback)
+        if key == "sensor_extrinsics_online":
+            return "sensor_extrinsics", None
+
         # Label features
         if key == "egomotion":
             feat_name = self._prefer_offline_feature("egomotion")
@@ -324,6 +328,13 @@ class StreamingClipDataProvider:
             clip_files = feat.clip_filenames(self._clip_id)
             filename = next(iter(clip_files.values()))
             return "lidar_top_360fov", filename
+
+        # Radar sensors: key is the sensor name directly (e.g. "radar_front_center_srr_0")
+        if key.startswith("radar_"):
+            feat = self._index.get_feature(key)
+            clip_files = feat.clip_filenames(self._clip_id)
+            filename = next(iter(clip_files.values()))
+            return key, filename
 
         raise KeyError(f"Unknown data key: {key!r}")
 

--- a/tools/data_converter/pai/utils.py
+++ b/tools/data_converter/pai/utils.py
@@ -97,6 +97,8 @@ def find_clip_files(clip_dir: UPath, clip_id: str) -> Dict[str, UPath]:
                 <clip_id>.<camera_name>.blurred_boxes.parquet
             lidar/
                 <clip_id>.lidar_top_360fov.parquet
+            radar/
+                <clip_id>.radar_*.parquet  (per-radar sensor, dynamically discovered)
             metadata/
                 feature_presence.parquet
                 data_collection.parquet
@@ -123,6 +125,11 @@ def find_clip_files(clip_dir: UPath, clip_id: str) -> Dict[str, UPath]:
         "sensor_extrinsics": _prefer_offline(calibration_dir / "sensor_extrinsics.parquet"),
         "vehicle_dimensions": _prefer_offline(calibration_dir / "vehicle_dimensions.parquet"),
     }
+
+    # Non-offline (online) extrinsics (radar calibration may only be in the online variant)
+    online_extrinsics_path = calibration_dir / "sensor_extrinsics.parquet"
+    if online_extrinsics_path.exists():
+        files["sensor_extrinsics_online"] = online_extrinsics_path
 
     # Obstacle labels
     obstacle_path = _prefer_offline(clip_dir / "labels" / f"{clip_id}.obstacle.parquet")
@@ -157,6 +164,14 @@ def find_clip_files(clip_dir: UPath, clip_id: str) -> Dict[str, UPath]:
     lidar_path = clip_dir / "lidar" / f"{clip_id}.lidar_top_360fov.parquet"
     if lidar_path.exists():
         files["lidar_top_360fov"] = lidar_path
+
+    # Radar files are flat in radar/ -- discover dynamically based on available files
+    radar_dir = clip_dir / "radar"
+    if radar_dir.exists():
+        for parquet_path in sorted(radar_dir.glob(f"{clip_id}.radar_*.parquet")):
+            # Extract sensor name: "{clip_id}.{sensor_name}.parquet" -> "{sensor_name}"
+            sensor_name = parquet_path.stem.removeprefix(f"{clip_id}.")
+            files[sensor_name] = parquet_path
 
     return files
 

--- a/tools/ncore_project_pc_to_img.py
+++ b/tools/ncore_project_pc_to_img.py
@@ -23,6 +23,8 @@ from typing import Optional, Tuple
 import click
 import matplotlib
 
+from ncore.impl.data.compat import LidarSensorProtocol, RayBundleSensorProtocol
+
 
 def _select_matplotlib_backend() -> None:
     """Select the best available matplotlib backend.
@@ -288,7 +290,13 @@ def v4(
 
 
 def run(params: CLIBaseParams, loader: SequenceLoaderProtocol) -> None:
-    lidar_sensor = loader.get_lidar_sensor(params.sensor_id)
+    # Auto-detect sensor type from available sensor IDs
+    ray_sensor: RayBundleSensorProtocol
+    if params.sensor_id in loader.radar_ids:
+        ray_sensor = loader.get_radar_sensor(params.sensor_id)
+    else:
+        ray_sensor = loader.get_lidar_sensor(params.sensor_id)
+
     cam_sensor = loader.get_camera_sensor(params.camera_id)
 
     # Get the camera frame indices from the index range
@@ -310,12 +318,12 @@ def run(params: CLIBaseParams, loader: SequenceLoaderProtocol) -> None:
     cam_model = CameraModel.from_parameters(cam_model_params, device=params.device)
 
     # Initialize motion compensator, and the lidar model if requested
-    motion_compensator = MotionCompensator(lidar_sensor.pose_graph)
+    motion_compensator = MotionCompensator(ray_sensor.pose_graph)
     lidar_model: Optional[StructuredLidarModel] = None
-    if params.enable_lidar_model:
-        lidar_model = StructuredLidarModel.maybe_from_parameters(lidar_sensor.model_parameters, device=params.device)
+    if params.enable_lidar_model and isinstance(ray_sensor, LidarSensorProtocol):
+        lidar_model = StructuredLidarModel.maybe_from_parameters(ray_sensor.model_parameters, device=params.device)
 
-        assert lidar_model is not None, f"No structured lidar model available for lidar sensor {params.sensor_id}"
+        assert lidar_model is not None, f"No structured lidar model available for sensor {params.sensor_id}"
 
         msg += " | with structured lidar model"
 
@@ -323,7 +331,7 @@ def run(params: CLIBaseParams, loader: SequenceLoaderProtocol) -> None:
         # Get the camera timestamp and find the closes lidar frame (relative to center of camera frame timestamps)
         cam_timestamp_start_us = cam_sensor.get_frame_timestamp_us(frame_index, types.FrameTimepoint.START)
         cam_timestamp_end_us = cam_sensor.get_frame_timestamp_us(frame_index, types.FrameTimepoint.END)
-        pc_frame_index = lidar_sensor.get_closest_frame_index(
+        pc_frame_index = ray_sensor.get_closest_frame_index(
             cam_timestamp_start_us + (cam_timestamp_end_us - cam_timestamp_start_us) // 2,
             relative_frame_time=0.5,
         )
@@ -331,15 +339,15 @@ def run(params: CLIBaseParams, loader: SequenceLoaderProtocol) -> None:
         # Load the camera image and the point cloud
         img_frame = cam_sensor.get_frame_image_array(frame_index)
 
-        if lidar_model is not None:
+        if isinstance(ray_sensor, LidarSensorProtocol) and lidar_model is not None:
             ## Generate sensor points from model elements with length of the source data
             sensor_pc = (
                 lidar_model.elements_to_sensor_points(
                     unpack_optional(
-                        lidar_sensor.get_frame_ray_bundle_model_element(pc_frame_index),
+                        ray_sensor.get_frame_ray_bundle_model_element(pc_frame_index),
                         msg=f"Lidar model elements not available for frame {pc_frame_index}",
                     ),
-                    lidar_sensor.get_frame_ray_bundle_return_distance_m(
+                    ray_sensor.get_frame_ray_bundle_return_distance_m(
                         pc_frame_index, return_index=params.sensor_return_index
                     ),
                 )
@@ -351,14 +359,12 @@ def run(params: CLIBaseParams, loader: SequenceLoaderProtocol) -> None:
             pc = motion_compensator.motion_compensate_points(
                 sensor_id=params.sensor_id,
                 xyz_pointtime=sensor_pc,
-                timestamp_us=lidar_sensor.get_frame_ray_bundle_timestamp_us(pc_frame_index),
-                frame_start_timestamp_us=lidar_sensor.get_frame_timestamp_us(
-                    pc_frame_index, types.FrameTimepoint.START
-                ),
-                frame_end_timestamp_us=lidar_sensor.get_frame_timestamp_us(pc_frame_index, types.FrameTimepoint.END),
+                timestamp_us=ray_sensor.get_frame_ray_bundle_timestamp_us(pc_frame_index),
+                frame_start_timestamp_us=ray_sensor.get_frame_timestamp_us(pc_frame_index, types.FrameTimepoint.START),
+                frame_end_timestamp_us=ray_sensor.get_frame_timestamp_us(pc_frame_index, types.FrameTimepoint.END),
             ).xyz_e_sensorend
         else:
-            pc = lidar_sensor.get_frame_point_cloud(
+            pc = ray_sensor.get_frame_point_cloud(
                 pc_frame_index,
                 motion_compensation=True,
                 with_start_points=False,
@@ -367,7 +373,7 @@ def run(params: CLIBaseParams, loader: SequenceLoaderProtocol) -> None:
 
         # Transform the point cloud to the world coordinate frame
         pc = transform_point_cloud(
-            pc, lidar_sensor.get_frames_T_sensor_target("world", pc_frame_index, types.FrameTimepoint.END)
+            pc, ray_sensor.get_frames_T_sensor_target("world", pc_frame_index, types.FrameTimepoint.END)
         )
 
         T_world_camera_start = se3_inverse(
@@ -403,6 +409,9 @@ def run(params: CLIBaseParams, loader: SequenceLoaderProtocol) -> None:
                 world_point_projections = cam_model.world_points_to_image_points_static_pose(
                     pc, T_world_camera_end, return_valid_indices=True, return_T_world_sensors=True
                 )
+
+            case _:
+                raise ValueError(f"Unsupported pose option: {params.pose}")
 
         image_point_coords = world_point_projections.image_points.cpu().numpy()
         trans_matrices = world_point_projections.T_world_sensors.cpu().numpy()  # type: ignore

--- a/tools/ncore_vis/BUILD.bazel
+++ b/tools/ncore_vis/BUILD.bazel
@@ -77,6 +77,7 @@ py_library(
         "components/camera.py",
         "components/cuboids.py",
         "components/lidar.py",
+        "components/radar.py",
         "components/trajectory.py",
     ],
     deps = [

--- a/tools/ncore_vis/components/__init__.py
+++ b/tools/ncore_vis/components/__init__.py
@@ -30,6 +30,7 @@ from tools.ncore_vis.components import (
     camera,  # noqa: F401
     cuboids,  # noqa: F401
     lidar,  # noqa: F401
+    radar,  # noqa: F401
     trajectory,  # noqa: F401
 )
 from tools.ncore_vis.components.base import VisualizationComponent, get_registered_components, register_component

--- a/tools/ncore_vis/components/camera.py
+++ b/tools/ncore_vis/components/camera.py
@@ -110,6 +110,8 @@ class CameraComponent(VisualizationComponent):
         self._project_mode: str = "rolling-shutter"
         self._project_point_size: int = 1
         self._project_range_cycle: float = 50.0
+        self._project_radar: bool = False
+        self._project_radar_id: str = "All"
         self._show_mask: bool = False
         self._mask_name: str = ""
         self._mask_opacity: float = 0.3
@@ -143,6 +145,8 @@ class CameraComponent(VisualizationComponent):
         lidar_ids = self.data_loader.lidar_ids
         if lidar_ids:
             self._project_lidar_id = lidar_ids[0]
+
+        radar_ids = self.data_loader.radar_ids
 
         for camera_id in self.data_loader.camera_ids:
             self._visible[camera_id] = True
@@ -217,6 +221,22 @@ class CameraComponent(VisualizationComponent):
                         proj_mode_dropdown=proj_mode_dropdown,
                         proj_point_size_slider=proj_point_size_slider,
                         proj_range_cycle_slider=proj_range_cycle_slider,
+                    )
+
+                # -- Radar projection --
+                if radar_ids:
+                    project_radar_checkbox = self.client.gui.add_checkbox(
+                        "Project Radar", initial_value=False, hint="Project radar points onto all cameras"
+                    )
+                    proj_radar_dropdown = self.client.gui.add_dropdown(
+                        "Radar Sensor",
+                        options=["All"] + radar_ids,
+                        initial_value="All",
+                        hint="Radar sensor to project (or 'All' for every radar)",
+                    )
+                    self._bind_radar_projection_settings(
+                        project_radar_checkbox=project_radar_checkbox,
+                        proj_radar_dropdown=proj_radar_dropdown,
                     )
 
                 # -- Mask overlay --
@@ -376,6 +396,23 @@ class CameraComponent(VisualizationComponent):
             self._project_range_cycle = proj_range_cycle_slider.value
             self._refresh_all_cameras()
 
+    def _bind_radar_projection_settings(
+        self,
+        project_radar_checkbox: viser.GuiInputHandle[bool],
+        proj_radar_dropdown: viser.GuiInputHandle[str],
+    ) -> None:
+        """Wire up radar projection shared-setting callbacks."""
+
+        @project_radar_checkbox.on_update
+        def _(_: viser.GuiEvent) -> None:
+            self._project_radar = project_radar_checkbox.value
+            self._refresh_all_cameras()
+
+        @proj_radar_dropdown.on_update
+        def _(_: viser.GuiEvent) -> None:  # type: ignore[no-redef]
+            self._project_radar_id = proj_radar_dropdown.value
+            self._refresh_all_cameras()
+
     def _bind_mask_settings(
         self,
         show_mask_checkbox: viser.GuiInputHandle[bool],
@@ -471,6 +508,12 @@ class CameraComponent(VisualizationComponent):
                     image = self._overlay_lidar_projection(camera_id, frame_idx, image)
                 except Exception:
                     logger.debug("Lidar projection overlay failed for %s frame %d", camera_id, frame_idx, exc_info=True)
+
+            if self._project_radar:
+                try:
+                    image = self._overlay_radar_projection(camera_id, frame_idx, image)
+                except Exception:
+                    logger.debug("Radar projection overlay failed for %s frame %d", camera_id, frame_idx, exc_info=True)
 
             if self._overlay_cuboids:
                 try:
@@ -631,6 +674,90 @@ class CameraComponent(VisualizationComponent):
             cv2.circle(output_image, (px, py), point_radius, color, thickness=-1, lineType=cv2.LINE_AA)
 
         return output_image
+
+    # ------------------------------------------------------------------
+    # Radar projection overlay
+    # ------------------------------------------------------------------
+
+    def _overlay_radar_projection(self, camera_id: str, frame_idx: int, image: np.ndarray) -> np.ndarray:
+        """Project radar point clouds onto the camera image with range-based coloring.
+
+        When ``self._project_radar_id`` is ``"All"``, every radar sensor is projected.
+
+        Args:
+            camera_id: Camera sensor to project onto.
+            frame_idx: Camera frame index.
+            image: RGB image array (H, W, 3), uint8.
+
+        Returns:
+            Copy of the image with projected radar points drawn.
+        """
+        if self._project_radar_id == "All":
+            radar_ids = self.data_loader.radar_ids
+        else:
+            radar_ids = [self._project_radar_id]
+
+        output_image = image.copy()
+        for radar_id in radar_ids:
+            output_image = self._project_single_radar(camera_id, frame_idx, radar_id, output_image)
+        return output_image
+
+    def _project_single_radar(self, camera_id: str, frame_idx: int, radar_id: str, image: np.ndarray) -> np.ndarray:
+        """Project a single radar sensor's point cloud onto *image* (mutates in-place)."""
+        cam = self.data_loader.get_camera_sensor(camera_id)
+        radar_sensor = self.data_loader.get_radar_sensor(radar_id)
+        camera_model = self._camera_models[camera_id]
+
+        # Find closest radar frame to the camera frame (by center-of-frame timestamp)
+        cam_interval = self.data_loader.get_sensor_frame_interval_us(camera_id, frame_idx)
+        cam_center_us = cam_interval.start + (cam_interval.end - cam_interval.start) // 2
+        radar_frame_idx = radar_sensor.get_closest_frame_index(cam_center_us, relative_frame_time=0.5)
+
+        # Load point cloud and transform to world coordinates
+        pc_sensor = radar_sensor.get_frame_point_cloud(
+            radar_frame_idx, motion_compensation=True, with_start_points=False
+        )
+        world_id = self.data_loader.world_frame_id
+        T_radar_world = radar_sensor.get_frames_T_sensor_target(world_id, radar_frame_idx, FrameTimepoint.END)
+        pc_world = transform_point_cloud(pc_sensor.xyz_m_end, T_radar_world)
+
+        # Get camera world-to-sensor transforms (T_world_camera)
+        T_world_camera_start = cam.get_frames_T_source_sensor(world_id, frame_idx, FrameTimepoint.START)
+        T_world_camera_end = cam.get_frames_T_source_sensor(world_id, frame_idx, FrameTimepoint.END)
+
+        # Project world points to image coordinates
+        mode = self._project_mode
+        projection = self._project_points(camera_model, pc_world, T_world_camera_start, T_world_camera_end, mode)
+
+        if projection.valid_indices is None or projection.image_points.shape[0] == 0:
+            return image
+
+        image_coords = projection.image_points.cpu().numpy()
+        valid_idx = projection.valid_indices.cpu().numpy()
+
+        # Compute per-point range (distance from camera origin in camera frame)
+        if projection.T_world_sensors is not None:
+            T_w2c = projection.T_world_sensors.cpu().numpy()
+            transformed = transform_point_cloud(pc_world[valid_idx, None, :], T_w2c).squeeze(1)
+            ranges = np.linalg.norm(transformed, axis=1)
+        else:
+            ranges = np.linalg.norm(pc_sensor.xyz_m_end[valid_idx], axis=1)
+
+        # Draw range-colored points (slightly larger than lidar to distinguish)
+        cycle = max(1.0, self._project_range_cycle)
+        point_radius = max(2, self._project_point_size + 1)
+
+        normalized = (ranges % cycle) / cycle
+        rgba = _JET_CMAP(normalized)
+        colors_bgr = (rgba[:, [2, 1, 0]] * 255.0).astype(np.uint8)
+
+        for i in range(image_coords.shape[0]):
+            px = int(round(image_coords[i, 0]))
+            py = int(round(image_coords[i, 1]))
+            color = (int(colors_bgr[i, 0]), int(colors_bgr[i, 1]), int(colors_bgr[i, 2]))
+            cv2.circle(image, (px, py), point_radius, color, thickness=-1, lineType=cv2.LINE_AA)
+
+        return image
 
     def _project_points(
         self,

--- a/tools/ncore_vis/components/radar.py
+++ b/tools/ncore_vis/components/radar.py
@@ -1,0 +1,566 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Radar point cloud visualization component with fusing and motion compensation.
+
+Unlike the lidar component which duplicates settings per sensor, the radar component
+uses a single set of shared visualization settings (color style, point size, fusing,
+motion compensation) applied to all radar sensors.  Each sensor only has its own
+frame slider and show/hide toggle.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+
+from typing import Any, Dict, List, Tuple
+
+import matplotlib
+import numpy as np
+import viser
+
+from ncore.impl.common.transformations import HalfClosedInterval, transform_point_cloud
+from ncore.impl.data.types import FrameTimepoint
+from tools.ncore_vis.components.base import VisualizationComponent, register_component
+
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_POINT_COLOR: np.ndarray = np.array([0, 255, 0], dtype=np.uint8)
+
+# Pre-fetch colormaps once at module level.
+_JET_CMAP: matplotlib.colors.Colormap = matplotlib.colormaps["jet"]
+_TURBO_CMAP: matplotlib.colors.Colormap = matplotlib.colormaps["turbo"]
+
+# Supported color styles (no intensity or model element styles for radar).
+_COLOR_STYLES: List[str] = [
+    "Range (jet)",
+    "Height (turbo)",
+    "Timestamp",
+]
+
+# Color styles that require per-frame data (cannot be computed from positions alone).
+_PER_FRAME_COLOR_STYLES: frozenset[str] = frozenset(
+    [
+        "Timestamp",
+    ]
+)
+
+
+@register_component
+class RadarComponent(VisualizationComponent):
+    """Radar point cloud visualization with shared settings, fusing, and motion compensation.
+
+    A single set of visualization controls (color style, point size, fusing, motion
+    compensation) is shared across all radar sensors.  Each sensor only exposes a
+    frame slider and a show/hide toggle.
+    """
+
+    def __init__(self, client: Any, data_loader: Any, renderer: Any) -> None:
+        super().__init__(client, data_loader, renderer)
+
+        # Scan for per-sensor generic_data fields that can drive point color.
+        self._metadata_color_fields: Dict[str, List[str]] = {
+            radar_id: self._scan_metadata_color_fields(radar_id) for radar_id in self.data_loader.radar_ids
+        }
+
+        # Build the union of all metadata color fields across sensors.
+        seen: dict[str, None] = {}
+        for fields in self._metadata_color_fields.values():
+            for f in fields:
+                seen.setdefault(f, None)
+        self._all_metadata_color_fields: List[str] = list(seen)
+
+    # ------------------------------------------------------------------
+    # GUI
+    # ------------------------------------------------------------------
+
+    def create_gui(self, tab_group: viser.GuiTabGroupHandle) -> None:  # noqa: C901
+        self._enabled: bool = True
+        self._point_clouds: Dict[str, viser.PointCloudHandle] = {}
+
+        # Per-sensor state (only frame index and visibility).
+        self._frame_sliders: Dict[str, viser.GuiInputHandle[int]] = {}
+        self._show_pc: Dict[str, bool] = {}
+
+        # Shared visualization settings (single values applied to all radars).
+        default_color = "radial_velocity" if "radial_velocity" in self._all_metadata_color_fields else "Range (jet)"
+        self._color_style: str = default_color
+        self._point_size: float = 0.05
+        self._is_fused: bool = False
+        self._fused_frame_step: int = 0
+        self._fused_range: Tuple[int, int] = (0, 0)
+        self._motion_comp: bool = True
+        self._range_cycle: float = 50.0
+        self._height_range: Tuple[float, float] = (-5.0, 15.0)
+
+        # Early return if no radar sensors available (no empty tab).
+        if not self.data_loader.radar_ids:
+            return
+
+        # Determine global max frame across all radars (for fusing sliders).
+        global_max_frame = 0
+        for radar_id in self.data_loader.radar_ids:
+            sensor = self.data_loader.get_radar_sensor(radar_id)
+            global_max_frame = max(global_max_frame, max(0, sensor.frames_count - 1))
+
+        self._fused_range = (0, global_max_frame)
+        self._fused_frame_step = min(40, global_max_frame) if global_max_frame > 0 else 0
+
+        with tab_group.add_tab("Radars"):
+            enabled_checkbox = self.client.gui.add_checkbox(
+                "Enabled", initial_value=True, hint="Enable radar point cloud visualization"
+            )
+
+            @enabled_checkbox.on_update
+            def _(_: viser.GuiEvent) -> None:
+                self._enabled = enabled_checkbox.value
+                for rid in self._point_clouds:
+                    self._point_clouds[rid].visible = enabled_checkbox.value and self._show_pc.get(rid, True)
+
+            # -- Shared settings folder --
+            with self.client.gui.add_folder("Settings"):
+                color_dropdown = self.client.gui.add_dropdown(
+                    "Color Style",
+                    options=_COLOR_STYLES + self._all_metadata_color_fields,
+                    initial_value=default_color,
+                )
+                point_size_slider = self.client.gui.add_slider(
+                    "Point Size Radius (cm)",
+                    min=0,
+                    max=100,
+                    step=1,
+                    initial_value=50,
+                )
+                range_cycle_slider = self.client.gui.add_slider(
+                    "Range Cycle (m)",
+                    min=5.0,
+                    max=200.0,
+                    step=1.0,
+                    initial_value=50.0,
+                )
+                height_range_slider = self.client.gui.add_multi_slider(
+                    "Height Range (m)",
+                    min=-50.0,
+                    max=100.0,
+                    step=0.5,
+                    initial_value=(-5.0, 15.0),
+                )
+                motion_comp_checkbox = self.client.gui.add_checkbox(
+                    "Motion Compensation",
+                    initial_value=True,
+                )
+                fused_checkbox = self.client.gui.add_checkbox("Fuse", initial_value=False)
+                fused_frame_step_slider = self.client.gui.add_slider(
+                    "Frame Step (Fused)",
+                    min=min(1, global_max_frame),
+                    max=max(1, global_max_frame),
+                    step=1,
+                    initial_value=self._fused_frame_step,
+                )
+                fused_range_slider = self.client.gui.add_multi_slider(
+                    "Fused Range",
+                    min=0,
+                    max=global_max_frame,
+                    step=1,
+                    initial_value=(0, global_max_frame),
+                )
+
+            self._bind_shared_settings(
+                color_dropdown=color_dropdown,
+                point_size_slider=point_size_slider,
+                range_cycle_slider=range_cycle_slider,
+                height_range_slider=height_range_slider,
+                motion_comp_checkbox=motion_comp_checkbox,
+                fused_checkbox=fused_checkbox,
+                fused_frame_step_slider=fused_frame_step_slider,
+                fused_range_slider=fused_range_slider,
+            )
+
+            # -- Per-radar sensor folders (frame slider + show/hide only) --
+            for radar_id in self.data_loader.radar_ids:
+                sensor = self.data_loader.get_radar_sensor(radar_id)
+                max_frame = max(0, sensor.frames_count - 1)
+                self._show_pc[radar_id] = True
+
+                with self.client.gui.add_folder(radar_id):
+                    frame_slider = self.client.gui.add_slider("Frame", min=0, max=max_frame, step=1, initial_value=0)
+                    self._frame_sliders[radar_id] = frame_slider
+
+                    show_checkbox = self.client.gui.add_checkbox(
+                        "Show", initial_value=True, hint=f"Show point cloud for {radar_id}"
+                    )
+
+                self._bind_per_radar_callbacks(radar_id, frame_slider, show_checkbox)
+
+    def get_frame_sliders(self) -> Dict[str, viser.GuiInputHandle[int]]:
+        return dict(self._frame_sliders)
+
+    def populate_scene(self) -> None:
+        if not self._enabled:
+            return
+        futures = [self.renderer._executor.submit(self._update_radar, rid) for rid in self.data_loader.radar_ids]
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                future.result()
+            except Exception:
+                logger.exception("Error populating radar scene")
+
+    def on_reference_frame_change(self, interval_us: HalfClosedInterval) -> None:
+        if not self._enabled:
+            return
+        center_us = interval_us.start + (interval_us.end - interval_us.start) // 2
+        for radar_id in self.data_loader.radar_ids:
+            if not self._show_pc.get(radar_id, True):
+                continue
+            if radar_id not in self._frame_sliders:
+                continue
+            sensor = self.data_loader.get_radar_sensor(radar_id)
+            self._frame_sliders[radar_id].value = sensor.get_closest_frame_index(center_us, relative_frame_time=0.5)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _scan_metadata_color_fields(self, radar_id: str) -> List[str]:
+        """Return generic_data field names from frame 0 whose shape qualifies for coloring."""
+        sensor = self.data_loader.get_radar_sensor(radar_id)
+
+        if sensor.frames_count == 0:
+            return []
+
+        n_points = sensor.get_frame_ray_bundle_count(0)
+        if n_points == 0:
+            return []
+
+        color_metadata_fields: List[str] = []
+        for name in sensor.get_frame_generic_data_names(0):
+            data = np.asarray(sensor.get_frame_generic_data(0, name))
+            if data.ndim == 1 and data.shape[0] == n_points:
+                color_metadata_fields.append(name)
+            elif data.ndim == 2 and data.shape[0] == n_points and data.shape[1] in [1, 3, 4]:
+                color_metadata_fields.append(name)
+        return color_metadata_fields
+
+    def _bind_shared_settings(
+        self,
+        color_dropdown: viser.GuiDropdownHandle,
+        point_size_slider: viser.GuiInputHandle[int],
+        range_cycle_slider: viser.GuiInputHandle[float],
+        height_range_slider: Any,
+        motion_comp_checkbox: viser.GuiInputHandle[bool],
+        fused_checkbox: viser.GuiInputHandle[bool],
+        fused_frame_step_slider: viser.GuiInputHandle[int],
+        fused_range_slider: Any,
+    ) -> None:
+        """Wire up shared visualization setting callbacks — each triggers a refresh of all radars."""
+
+        @color_dropdown.on_update
+        def _(_: viser.GuiEvent) -> None:
+            self._color_style = color_dropdown.value
+            self._refresh_all()
+
+        @point_size_slider.on_update
+        def _(_: viser.GuiEvent) -> None:
+            self._point_size = point_size_slider.value / 1000.0
+            self._refresh_all()
+
+        @range_cycle_slider.on_update
+        def _(_: viser.GuiEvent) -> None:
+            self._range_cycle = range_cycle_slider.value
+            if self._color_style == "Range (jet)":
+                self._refresh_all()
+
+        @height_range_slider.on_update
+        def _(_: viser.GuiEvent) -> None:
+            self._height_range = height_range_slider.value
+            if self._color_style == "Height (turbo)":
+                self._refresh_all()
+
+        @motion_comp_checkbox.on_update
+        def _(_: viser.GuiEvent) -> None:
+            self._motion_comp = motion_comp_checkbox.value
+            self._refresh_all()
+
+        @fused_checkbox.on_update
+        def _(_: viser.GuiEvent) -> None:
+            self._is_fused = fused_checkbox.value
+            self._refresh_all()
+
+        @fused_frame_step_slider.on_update
+        def _(_: viser.GuiEvent) -> None:
+            self._fused_frame_step = fused_frame_step_slider.value
+            if self._is_fused:
+                self._refresh_all()
+
+        @fused_range_slider.on_update
+        def _(_: viser.GuiEvent) -> None:
+            self._fused_range = fused_range_slider.value
+            if self._is_fused:
+                self._refresh_all()
+
+    def _bind_per_radar_callbacks(
+        self,
+        radar_id: str,
+        frame_slider: viser.GuiInputHandle[int],
+        show_checkbox: viser.GuiInputHandle[bool],
+    ) -> None:
+        """Wire up per-radar callbacks (frame change, show/hide)."""
+
+        @frame_slider.on_update
+        def _(_: viser.GuiEvent, _rid: str = radar_id) -> None:
+            if not self._is_fused:
+                self._update_radar(_rid)
+
+        @show_checkbox.on_update
+        def _(_: viser.GuiEvent, _rid: str = radar_id) -> None:
+            was_hidden = not self._show_pc.get(_rid, True)
+            self._show_pc[_rid] = show_checkbox.value
+            if show_checkbox.value and was_hidden:
+                self._update_radar(_rid)
+            elif _rid in self._point_clouds:
+                self._point_clouds[_rid].visible = show_checkbox.value and self._enabled
+
+    def _refresh_all(self) -> None:
+        """Re-render all visible radar point clouds."""
+        for radar_id in self.data_loader.radar_ids:
+            if self._show_pc.get(radar_id, True):
+                self._update_radar(radar_id)
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+
+    def _update_radar(self, radar_id: str) -> None:
+        """Re-render point cloud for *radar_id* using current GUI state."""
+        if not self._enabled:
+            return
+        if not self._show_pc.get(radar_id, True):
+            return
+        with self.client.atomic():
+            if point_cloud := self._point_clouds.pop(radar_id, None):
+                point_cloud.remove()
+
+            frame_idx = self._frame_sliders[radar_id].value
+            visible = self._show_pc[radar_id]
+
+            pc_handle = self._create_point_cloud(radar_id, frame_idx, visible)
+            self._point_clouds[radar_id] = pc_handle
+        self.client.flush()
+
+    def _create_point_cloud(
+        self,
+        radar_id: str,
+        frame_idx: int,
+        visible: bool,
+    ) -> viser.PointCloudHandle:
+        """Create a single viser point cloud node."""
+        color_style = self._color_style
+        is_metadata_style = color_style in self._metadata_color_fields.get(radar_id, [])
+
+        if self._is_fused:
+            handle_name = f"/radars/{radar_id}/fused_point_cloud"
+            needs_per_frame = color_style in _PER_FRAME_COLOR_STYLES or is_metadata_style
+            if needs_per_frame:
+                points_world, colors = self._get_fused_point_cloud_with_colors(
+                    radar_id, self._fused_range[0], self._fused_range[1], self._fused_frame_step
+                )
+            else:
+                points_world, points_sensor = self._get_fused_point_cloud(
+                    radar_id, self._fused_range[0], self._fused_range[1], self._fused_frame_step
+                )
+                colors = self._colorize_points(radar_id, frame_idx, points_sensor, points_world)
+        else:
+            handle_name = f"/radars/{radar_id}/point_cloud"
+            points_sensor = self._get_point_cloud_sensor(radar_id, frame_idx)
+            points_world = self._transform_to_world(radar_id, frame_idx, points_sensor)
+            colors = self._colorize_points(radar_id, frame_idx, points_sensor, points_world)
+
+        return self.client.scene.add_point_cloud(
+            handle_name,
+            points=points_world,
+            colors=colors,
+            point_size=self._point_size,
+            point_shape="circle",
+            visible=visible,
+        )
+
+    # ------------------------------------------------------------------
+    # Point cloud loading
+    # ------------------------------------------------------------------
+
+    def _get_point_cloud_sensor(self, radar_id: str, frame_idx: int) -> np.ndarray:
+        """Load a single-frame point cloud in sensor coordinates."""
+        sensor = self.data_loader.get_radar_sensor(radar_id)
+        pc = sensor.get_frame_point_cloud(frame_idx, motion_compensation=self._motion_comp, with_start_points=False)
+        return pc.xyz_m_end
+
+    def _transform_to_world(self, radar_id: str, frame_idx: int, points_sensor: np.ndarray) -> np.ndarray:
+        """Transform sensor-frame points to world coordinates."""
+        sensor = self.data_loader.get_radar_sensor(radar_id)
+        T_sensor_world = sensor.get_frames_T_sensor_target(
+            self.data_loader.world_frame_id, frame_idx, FrameTimepoint.END
+        )
+        return transform_point_cloud(points_sensor, T_sensor_world)
+
+    def _get_fused_point_cloud(
+        self,
+        radar_id: str,
+        start_frame_idx: int,
+        end_frame_idx: int,
+        step: int,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Accumulate point clouds over a frame range.
+
+        Returns:
+            Tuple of (world-frame points, sensor-frame points).
+        """
+        sensor = self.data_loader.get_radar_sensor(radar_id)
+        max_frame = max(0, sensor.frames_count - 1)
+        # Clamp range to this sensor's actual frame count.
+        end = min(end_frame_idx, max_frame)
+        frame_idxs = list(range(start_frame_idx, end + 1, max(1, step)))
+
+        def _load(frame_idx: int) -> Tuple[np.ndarray, np.ndarray]:
+            pts_sensor = self._get_point_cloud_sensor(radar_id, frame_idx)
+            pts_world = self._transform_to_world(radar_id, frame_idx, pts_sensor)
+            return pts_world, pts_sensor
+
+        results = list(self.renderer._executor.map(_load, frame_idxs))
+        all_world = [r[0] for r in results]
+        all_sensor = [r[1] for r in results]
+        return np.concatenate(all_world), np.concatenate(all_sensor)
+
+    def _get_fused_point_cloud_with_colors(
+        self,
+        radar_id: str,
+        start_frame_idx: int,
+        end_frame_idx: int,
+        step: int,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Accumulate point clouds with per-frame coloring over a frame range.
+
+        Returns:
+            Tuple of (world-frame points, colors).
+        """
+        sensor = self.data_loader.get_radar_sensor(radar_id)
+        max_frame = max(0, sensor.frames_count - 1)
+        end = min(end_frame_idx, max_frame)
+        frame_idxs = list(range(start_frame_idx, end + 1, max(1, step)))
+
+        def _load_and_color(frame_idx: int) -> Tuple[np.ndarray, np.ndarray]:
+            pts_sensor = self._get_point_cloud_sensor(radar_id, frame_idx)
+            pts_world = self._transform_to_world(radar_id, frame_idx, pts_sensor)
+            colors = self._colorize_points(radar_id, frame_idx, pts_sensor, pts_world)
+            return pts_world, colors
+
+        results = list(self.renderer._executor.map(_load_and_color, frame_idxs))
+        all_world = [r[0] for r in results]
+        all_colors = [r[1] for r in results]
+        return np.concatenate(all_world), np.concatenate(all_colors)
+
+    # ------------------------------------------------------------------
+    # Coloring
+    # ------------------------------------------------------------------
+
+    def _colorize_points(
+        self,
+        radar_id: str,
+        frame_idx: int,
+        points_sensor: np.ndarray,
+        points_world: np.ndarray,
+    ) -> np.ndarray:
+        """Compute per-point RGB colors based on the active color style."""
+        color_style = self._color_style
+        n_points = points_world.shape[0]
+
+        if color_style == "Range (jet)":
+            return self._color_range_jet(points_sensor)
+        if color_style == "Height (turbo)":
+            return self._color_height_turbo(points_world)
+        if color_style == "Timestamp":
+            return self._color_timestamp(radar_id, frame_idx, n_points)
+        if color_style in self._metadata_color_fields.get(radar_id, []):
+            return self._color_metadata_field(radar_id, frame_idx, color_style, n_points)
+
+        return np.tile(_DEFAULT_POINT_COLOR, (n_points, 1))
+
+    def _color_range_jet(self, points_sensor: np.ndarray) -> np.ndarray:
+        """Color by range from sensor origin using the jet colormap."""
+        cycle = max(1.0, self._range_cycle)
+        ranges = np.linalg.norm(points_sensor, axis=1)
+        normalized = (ranges % cycle) / cycle
+        rgba = _JET_CMAP(normalized)
+        return (rgba[:, :3] * 255.0).astype(np.uint8)
+
+    def _color_height_turbo(self, points_world: np.ndarray) -> np.ndarray:
+        """Color by world-frame Z height using the turbo colormap."""
+        z_min, z_max = self._height_range
+        z_range = max(z_max - z_min, 0.01)
+        z = points_world[:, 2]
+        normalized = np.clip((z - z_min) / z_range, 0.0, 1.0)
+        rgba = _TURBO_CMAP(normalized)
+        return (rgba[:, :3] * 255.0).astype(np.uint8)
+
+    def _color_timestamp(self, radar_id: str, frame_idx: int, n_points: int) -> np.ndarray:
+        """Color by per-point timestamp within the frame using the turbo colormap."""
+        sensor = self.data_loader.get_radar_sensor(radar_id)
+        try:
+            timestamps = sensor.get_frame_ray_bundle_timestamp_us(frame_idx)
+        except Exception:
+            return np.tile(_DEFAULT_POINT_COLOR, (n_points, 1))
+
+        ts_min = float(timestamps.min())
+        ts_max = float(timestamps.max())
+        ts_range = max(ts_max - ts_min, 1.0)
+        normalized = (timestamps.astype(np.float64) - ts_min) / ts_range
+        rgba = _TURBO_CMAP(normalized)
+        return (rgba[:, :3] * 255.0).astype(np.uint8)
+
+    def _color_metadata_field(self, radar_id: str, frame_idx: int, field_name: str, n_points: int) -> np.ndarray:
+        """Color by a generic_data metadata field.
+
+        Single-channel fields use turbo colormap (better for Doppler, RCS, etc.).
+        """
+        try:
+            sensor = self.data_loader.get_radar_sensor(radar_id)
+            data = np.asarray(sensor.get_frame_generic_data(frame_idx, field_name))
+        except (KeyError, IndexError):
+            return np.tile(_DEFAULT_POINT_COLOR, (n_points, 1))
+
+        # Single-channel: use turbo colormap.
+        if data.ndim == 1 or (data.ndim == 2 and data.shape[1] == 1):
+            values = data.ravel().astype(np.float64)
+            v_min = float(values.min())
+            v_max = float(values.max())
+            v_range = max(v_max - v_min, 1e-9)
+            normalized = (values - v_min) / v_range
+            rgba = _TURBO_CMAP(normalized)
+            return (rgba[:, :3] * 255.0).astype(np.uint8)
+
+        # Multi-channel uint8: return as-is.
+        if data.dtype == np.uint8:
+            return data[:, :3] if data.shape[1] >= 3 else np.tile(_DEFAULT_POINT_COLOR, (n_points, 1))
+
+        # Multi-channel float: normalize and convert.
+        if not np.issubdtype(data.dtype, np.floating):
+            data = data.astype(np.float32)
+        min_val = data.min()
+        max_val = data.max()
+        drange = max_val - min_val
+        if drange == 0.0:
+            return np.tile(_DEFAULT_POINT_COLOR, (n_points, 1))
+        return ((data[:, :3] - min_val) / drange * 255.0).astype(np.uint8)

--- a/tools/ncore_vis/data_loader.py
+++ b/tools/ncore_vis/data_loader.py
@@ -27,7 +27,13 @@ import numpy as np
 import pandas as pd
 
 from ncore.impl.common.transformations import HalfClosedInterval, PoseGraphInterpolator
-from ncore.impl.data.compat import CameraSensorProtocol, LidarSensorProtocol, SensorProtocol, SequenceLoaderProtocol
+from ncore.impl.data.compat import (
+    CameraSensorProtocol,
+    LidarSensorProtocol,
+    RadarSensorProtocol,
+    SensorProtocol,
+    SequenceLoaderProtocol,
+)
 from ncore.impl.data.types import CuboidTrackObservation, FrameTimepoint, LabelSource
 from tools.ncore_vis.tracks import CuboidTrack
 
@@ -102,15 +108,27 @@ class DataLoader:
         """Return a lidar sensor by ID (cached)."""
         return self._loader.get_lidar_sensor(lidar_id)
 
+    @property
+    def radar_ids(self) -> List[str]:
+        """All radar sensor IDs in the sequence."""
+        return self._loader.radar_ids
+
+    @functools.lru_cache(maxsize=None)
+    def get_radar_sensor(self, radar_id: str) -> RadarSensorProtocol:
+        """Return a radar sensor by ID (cached)."""
+        return self._loader.get_radar_sensor(radar_id)
+
     # ------------------------------------------------------------------
     # Cross-sensor frame synchronization
     # ------------------------------------------------------------------
 
     def _get_sensor(self, sensor_id: str) -> SensorProtocol:
-        """Return a sensor by ID, looking up cameras first then lidars."""
+        """Return a sensor by ID, looking up cameras first, then lidars, then radars."""
         if sensor_id in self.camera_ids:
             return self.get_camera_sensor(sensor_id)
-        return self.get_lidar_sensor(sensor_id)
+        if sensor_id in self.lidar_ids:
+            return self.get_lidar_sensor(sensor_id)
+        return self.get_radar_sensor(sensor_id)
 
     def get_sensor_frame_interval_us(self, sensor_id: str, frame_index: int) -> HalfClosedInterval:
         """Return the ``[start, stop)`` timestamp interval in microseconds for a sensor frame.

--- a/tools/ncore_vis/renderer.py
+++ b/tools/ncore_vis/renderer.py
@@ -153,7 +153,7 @@ class NCoreVisRenderer:
     def _create_sequence_tab(self, tab_group: viser.GuiTabGroupHandle) -> viser.GuiTabHandle:
         """Build the Sequence tab with reference sensor controls and playback."""
         # Prefer lidars as default reference sensor (better temporal coverage).
-        all_sensor_ids = self.data_loader.lidar_ids + self.data_loader.camera_ids
+        all_sensor_ids = self.data_loader.lidar_ids + self.data_loader.radar_ids + self.data_loader.camera_ids
         if not all_sensor_ids:
             all_sensor_ids = ["(none)"]
         self.reference_sensor = all_sensor_ids[0]
@@ -288,4 +288,6 @@ class NCoreVisRenderer:
             return max(0, self.data_loader.get_camera_sensor(sensor_id).frames_count - 1)
         if sensor_id in self.data_loader.lidar_ids:
             return max(0, self.data_loader.get_lidar_sensor(sensor_id).frames_count - 1)
+        if sensor_id in self.data_loader.radar_ids:
+            return max(0, self.data_loader.get_radar_sensor(sensor_id).frames_count - 1)
         return 0


### PR DESCRIPTION
## Summary

- Extend the PAI data converter to discover and convert up to 19 radar sensors per clip into NCore V4 `RadarSensorComponent` format
- Add radar visualization to `ncore_vis` (3D point cloud component with fusing, motion compensation, and radar-specific color styles including radial velocity, RCS, SNR)
- Add radar projection overlay to the camera component in `ncore_vis`
- Generalize `ncore_project_pc_to_img.py` to auto-detect and support radar sensors via `RayBundleSensorProtocol`

![radar-6x-half-short](https://github.com/user-attachments/assets/95a94c04-7934-4196-bc81-7cae0beaab24)

## Data Signal Mapping

Per-detection radar signals from the PAI parquet are mapped as follows:

| PAI Column | NCore Field | Notes |
|---|---|---|
| azimuth + elevation | `direction` (float32 [N,3]) | Spherical → unit Cartesian |
| distance | `distance_m` (float32 [1,N]) | Single return |
| radial_velocity | `generic_data["radial_velocity"]` | Doppler velocity (m/s) |
| rcs | `generic_data["rcs"]` | Radar Cross Section (dBsm) |
| snr | `generic_data["snr"]` | Signal-to-Noise Ratio (dB) |
| exist_probb | `generic_data["exist_probb"]` | Normalized uint8→float [0,1] |
| doppler_ambiguity, radar_model | `generic_meta_data` | Scan-level scalars |

## Key Implementation Details

- Radar extrinsics are only present in the non-offline `sensor_extrinsics` parquet (the `.offline` variant only contains cameras + lidar). The converter falls back to the raw variant automatically.
- Radar scans are grouped by `scan_index` (DataFrame index level 0), with each scan becoming one `store_frame()` call.
- The `ncore_vis` radar component auto-discovers `generic_data` fields and offers them as color styles, defaulting to `radial_velocity` when available.

## Test

Verified end-to-end with streaming conversion of clip `0683f871-7d49-4bf9-8201-6227af1221bc`:

```
Loaded metadata: 7 cameras, 1 lidars, 9 radars
Loading non-offline extrinsics for 9 radar sensors missing from offline calibration
Radar radar_front_center_srr_0: 12 frames converted
...
(9 radar sensors total, each producing ~12 frames per second of data)
```