### PR TITLE
fix(converters): remove superfluous identity world_global pose from waymo and colmap converters

### DIFF
--- a/docs/data/formats.rst
+++ b/docs/data/formats.rst
@@ -110,8 +110,8 @@ The poses component stores both static (time-invariant) and dynamic
 
 For ego-vehicle trajectories, the rig-to-world transformation is typically
 stored as a dynamic pose under the key ``("rig", "world")``. Transformations
-from local world to global world frames (like ECEF) are represented by the
-``("world", "world_global")`` record.
+from local world to global world frames (like ECEF) are represented by a
+``("world", "world_global")`` record, if applicable.
 
 Static poses are used for sensor extrinsic calibrations. For example, a
 camera-to-rig transformation would be stored under the key

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -270,13 +270,6 @@ class ColmapDataConverter(FileBasedDataConverter):
             group_name=self.component_groups.poses_component_group,
         )
 
-        # Store static world->world_global pose
-        self.poses_writer.store_static_pose(
-            source_frame_id="world",
-            target_frame_id="world_global",
-            pose=np.eye(4, dtype="float64"),
-        )
-
         # Create intrinsics component
         self.intrinsics_writer = self.store_writer.register_component_writer(
             IntrinsicsComponent.Writer,

--- a/tools/data_converter/waymo/converter.py
+++ b/tools/data_converter/waymo/converter.py
@@ -300,14 +300,7 @@ class WaymoConverter4(FileBasedDataConverter):
         )
         T_rig_worlds = np.concatenate((T_rig_worlds_array, T_rig_worlds_array_extrapolated))[unique_indices]
 
-        # Use identity base pose as waymo data is already shifted
-        self.T_world_world_global = np.eye(4, dtype="float64")
-
         self.pose_interpolator = PoseInterpolator(T_rig_worlds, T_rig_world_timestamps_us)
-
-        # Log base pose to share it more easily with downstream teams (it is serialized also explicitly)
-        with np.printoptions(floatmode="unique", linewidth=200):  # print in highest precision
-            self.logger.info(f"> processed {len(T_rig_worlds)} poses, using base pose:\n{self.T_world_world_global}")
 
     def store_poses(self) -> None:
         """Stores the processed egomotion poses into the poses component."""
@@ -317,13 +310,6 @@ class WaymoConverter4(FileBasedDataConverter):
             target_frame_id="world",
             poses=self.pose_interpolator.poses.astype(np.float32),
             timestamps_us=self.pose_interpolator.timestamps,
-        )
-
-        # Store static world->world_global pose (float64 for high precision)
-        self.poses_writer.store_static_pose(
-            source_frame_id="world",
-            target_frame_id="world_global",
-            pose=self.T_world_world_global.astype(np.float64),
         )
 
     # Label IDs to label type strings


### PR DESCRIPTION
## Summary

- Remove the identity `("world", "world_global")` static pose that was unnecessarily stored by the **Waymo** and **COLMAP** converters. These converters have no ECEF / global frame information — the stored identity matrix carried no semantic content.
- Update `docs/data/formats.rst` to clarify that the `("world", "world_global")` record is optional (only applicable when a meaningful global frame transform exists, as in the PAI converter).

## Details

The `("world", "world_global")` static pose is intended to map between a sequence-local `world` frame and an earth-centered (ECEF) `world_global` frame. The **PAI converter** stores a meaningful non-identity transform here (the first ego pose, used to rebase all other poses to a local origin). However, the **Waymo** and **COLMAP** converters both hardcoded `np.eye(4)` — an identity matrix that adds no information.

### Changes

| File | Change |
|------|--------|
| `tools/data_converter/waymo/converter.py` | Remove `self.T_world_world_global` attribute, its log line, and the `store_static_pose` call |
| `tools/data_converter/colmap/converter.py` | Remove the `store_static_pose("world", "world_global", ...)` call |
| `docs/data/formats.rst` | Clarify that the `("world", "world_global")` record is stored "if applicable" |

No production code reads or depends on the `("world", "world_global")` pose from waymo/colmap-converted datasets.