### PR TITLE
[Perf] Optimize IndexedTarStore open with single-read

### DIFF
--- a/ncore/impl/data/stores.py
+++ b/ncore/impl/data/stores.py
@@ -78,7 +78,14 @@ class IndexedTarStore(Store):
 
         records: Dict[str, IndexedTarStore.TarRecord] = field(default_factory=dict)
 
-    def __init__(self, itar_path: Union[str, Path, UPath], mode: Literal["r", "w"] = "r"):
+    def __init__(
+        self,
+        itar_path: Union[str, Path, UPath],
+        mode: Literal["r", "w"] = "r",
+        # Maximum bytes read from the tail of the file in a single I/O call to load the tar index.
+        # Covers both the small index header and (ideally) the compressed index payload.
+        index_tail_read_size: int = 1 << 20,  # 1 MiB by default
+    ):
         if mode not in ["r", "w"]:
             raise ValueError("TarRecordIndex: only r/w modes supported")
 
@@ -114,7 +121,7 @@ class IndexedTarStore(Store):
 
         # init / load index table
         if self.mode == "r":
-            self.index = self._load_tar_index(self.tar_file_object)
+            self.index = self._load_tar_index(self.tar_file_object, index_tail_read_size)
         else:
             self.index = self.TarRecordIndex()
 
@@ -236,7 +243,7 @@ class IndexedTarStore(Store):
     # Methods / constants for storing index header and payload
     INDEX_HEADER_MAGIC = b"itar"
 
-    # Index header binary format
+    # Index header binary format (20-bytes)
     #
     # <little-endian
     # IndexMagic  - 4s - 4xchar             - 4bytes
@@ -259,51 +266,52 @@ class IndexedTarStore(Store):
 
         CBOR_LZMA_XZ_V1 = auto()
 
-    # Maximum bytes read from the tail of the file in a single I/O call.
-    # Covers both the 20-byte header block and the compressed index payload.
-    _INDEX_TAIL_READ_SIZE = 1 << 20  # 1 MiB
-
     @classmethod
-    def _load_tar_index(cls, tar_file_object: IO[Any]) -> TarRecordIndex:
+    def _load_tar_index(cls, tar_file_object: IO[Any], index_tail_read_size: int) -> TarRecordIndex:
         """Loads a tar record index from the end of a tar file object.
 
-        Reads up to 1 MiB from the tail of the file in one ``fobj.read()``
-        call.  Extracts both the 20-byte header (in the last 512-byte block)
+        Reads up to index_tail_read_size from the tail of the file in one ``fobj.read()``
+        call.  Extracts both the index header (in the last 512-byte block)
         and the compressed index payload from that same buffer.  Only falls
-        back to a second read if the compressed index is larger than 1 MiB.
+        back to a second read if the compressed index is larger than the tail read size.
         """
+        assert index_tail_read_size >= tarfile.BLOCKSIZE, "Tail read size needs to be at least one tar block size"
+
         original_file_position = tar_file_object.tell()
 
         # Determine file size
         tar_file_object.seek(0, os.SEEK_END)
         file_size = tar_file_object.tell()
 
-        # Read up to 1 MiB from the tail in one call
-        tail_size = min(file_size, cls._INDEX_TAIL_READ_SIZE)
-        tar_file_object.seek(file_size - tail_size)
-        tail_buffer = tar_file_object.read(tail_size)
+        # Read up to index_tail_read_size from the tail in one read call
+        tail_buffer_size = min(file_size, index_tail_read_size)
+        tar_file_object.seek(file_size - tail_buffer_size)
+        tail_buffer = tar_file_object.read(tail_buffer_size)
 
-        # Extract the 20-byte header from the last 512-byte block
-        header_fmt_size = struct.calcsize(cls.INDEX_HEADER_FORMAT)
-        header_offset_in_buf = tail_size - tarfile.BLOCKSIZE
+        # Extract the header from the last 512-byte block
+        header_binary_size = struct.calcsize(cls.INDEX_HEADER_FORMAT)
+        assert header_binary_size <= index_tail_read_size, (
+            "Index header larger than tail read size, increase index_tail_read_size"
+        )
+        header_offset_in_tail_buffer = tail_buffer_size - tarfile.BLOCKSIZE
         header = cls.IndexHeader._make(
             struct.unpack(
                 cls.INDEX_HEADER_FORMAT,
-                tail_buffer[header_offset_in_buf : header_offset_in_buf + header_fmt_size],
+                tail_buffer[header_offset_in_tail_buffer : header_offset_in_tail_buffer + header_binary_size],
             )
         )
 
         if header.magic != cls.INDEX_HEADER_MAGIC:
             raise ValueError("IndexedTarStore: invalid index header, can't load indexed tar file")
 
-        # Try to extract the compressed index payload from the same buffer
-        buffer_start_in_file = file_size - tail_size
-        if header.offset >= buffer_start_in_file:
+        # Try to extract the compressed index payload from the tail buffer
+        index_start_in_file = file_size - tail_buffer_size
+        if header.offset >= index_start_in_file:
             # Payload is fully within the buffer we already read
-            payload_start = header.offset - buffer_start_in_file
-            index_binary = tail_buffer[payload_start : payload_start + header.size]
+            index_start_in_tail_buffer = header.offset - index_start_in_file
+            index_binary = tail_buffer[index_start_in_tail_buffer : index_start_in_tail_buffer + header.size]
         else:
-            # Rare: compressed index > 1 MiB — fall back to a second read
+            # Rare: compressed index > index_tail_read_size — fall back to a second read
             tar_file_object.seek(header.offset)
             index_binary = tar_file_object.read(header.size)
 
@@ -371,8 +379,7 @@ class IndexedTarStore(Store):
             index_offset,
             index_size,
         )
-        header_size = len(header_binary)
-        _logger.debug(f"IndexedTarStore: header store size={header_size}")
+        _logger.debug(f"IndexedTarStore: header store size={len(header_binary)}")
 
         # Append index header to tar file
         tar_file_object.write(header_binary)

--- a/ncore/impl/data/stores.py
+++ b/ncore/impl/data/stores.py
@@ -40,6 +40,21 @@ from zarr.util import json_loads
 _logger = logging.getLogger(__name__)
 
 
+class _NullTarFile:
+    """Stub replacing tarfile.TarFile when no tar-level I/O is needed.
+
+    The stock TarFile(fileobj=fobj) reads tar headers from the beginning of
+    the file, which is wasted I/O since all reads go through
+    __getitem__ -> fobj.seek() + fobj.read() using the index offsets.
+    """
+
+    def __init__(self):
+        self.fileobj = None
+
+    def close(self):
+        pass
+
+
 class IndexedTarStore(Store):
     """A zarr store over *indexed* tar files
 
@@ -98,7 +113,7 @@ class IndexedTarStore(Store):
 
         self.itar_upath = itar_upath.absolute()
 
-        # open file object and tar file (require file to be both writeable and readable when writing)
+        # open file object (require file to be both writeable and readable when writing)
         self.tar_file_object: IO[Any]
         if self.mode == "r":
             self.tar_file_object = self.itar_upath.open("rb")
@@ -108,7 +123,9 @@ class IndexedTarStore(Store):
             # if the FS supports it, so ignore type-checker here
             self.tar_file_object = self.itar_upath.open("wb+")  # type: ignore[call-overload]
 
-        self.tar_file = tarfile.TarFile(fileobj=self.tar_file_object, mode=self.mode)
+        # Use a lightweight stub instead of tarfile.TarFile — the real TarFile
+        # is only created lazily on the first __setitem__ call (write mode).
+        self.tar_file: Union[tarfile.TarFile, _NullTarFile] = _NullTarFile()
 
         # init / load index table
         if self.mode == "r":
@@ -158,6 +175,10 @@ class IndexedTarStore(Store):
 
             value_bytes: bytes = compat.ensure_bytes(value)
             value_size: int = len(value_bytes)
+
+            # Lazily create TarFile on first write
+            if not isinstance(self.tar_file, tarfile.TarFile):
+                self.tar_file = tarfile.TarFile(fileobj=self.tar_file_object, mode="w")
 
             # Remember current tar file position, which is the start of the header
             header_start_position = self.tar_file_object.tell()
@@ -255,32 +276,61 @@ class IndexedTarStore(Store):
 
         CBOR_LZMA_XZ_V1 = auto()
 
+    # Maximum bytes read from the tail of the file in a single I/O call.
+    # Covers both the 20-byte header block and the compressed index payload.
+    _INDEX_TAIL_READ_SIZE = 1 << 20  # 1 MiB
+
     @classmethod
     def _load_tar_index(cls, tar_file_object: IO[Any]) -> TarRecordIndex:
-        """Loads a tar record index from the end of a tar file object"""
+        """Loads a tar record index from the end of a tar file object.
 
-        # Load header
+        Reads up to 1 MiB from the tail of the file in one ``fobj.read()``
+        call.  Extracts both the 20-byte header (in the last 512-byte block)
+        and the compressed index payload from that same buffer.  Only falls
+        back to a second read if the compressed index is larger than 1 MiB.
+        """
         original_file_position = tar_file_object.tell()
-        tar_file_object.seek(-tarfile.BLOCKSIZE, os.SEEK_END)
-        header_binary = tar_file_object.read(struct.calcsize(cls.INDEX_HEADER_FORMAT))
 
-        # Decode header
-        header = cls.IndexHeader._make(struct.unpack(cls.INDEX_HEADER_FORMAT, header_binary))
+        # Determine file size
+        tar_file_object.seek(0, os.SEEK_END)
+        file_size = tar_file_object.tell()
 
-        # Check magic bytes
+        # Read up to 1 MiB from the tail in one call
+        tail_size = min(file_size, cls._INDEX_TAIL_READ_SIZE)
+        tar_file_object.seek(file_size - tail_size)
+        tail_buffer = tar_file_object.read(tail_size)
+
+        # Extract the 20-byte header from the last 512-byte block
+        header_fmt_size = struct.calcsize(cls.INDEX_HEADER_FORMAT)
+        header_offset_in_buf = tail_size - tarfile.BLOCKSIZE
+        header = cls.IndexHeader._make(
+            struct.unpack(
+                cls.INDEX_HEADER_FORMAT,
+                tail_buffer[header_offset_in_buf : header_offset_in_buf + header_fmt_size],
+            )
+        )
+
         if header.magic != cls.INDEX_HEADER_MAGIC:
             raise ValueError("IndexedTarStore: invalid index header, can't load indexed tar file")
 
-        # Load index based on type
-        tar_file_object.seek(header.offset)
-        header_binary = tar_file_object.read(header.size)
+        # Try to extract the compressed index payload from the same buffer
+        buffer_start_in_file = file_size - tail_size
+        if header.offset >= buffer_start_in_file:
+            # Payload is fully within the buffer we already read
+            payload_start = header.offset - buffer_start_in_file
+            index_binary = tail_buffer[payload_start : payload_start + header.size]
+        else:
+            # Rare: compressed index > 1 MiB — fall back to a second read
+            tar_file_object.seek(header.offset)
+            index_binary = tar_file_object.read(header.size)
+
         tar_file_object.seek(original_file_position)
 
         if header.type == cls.IndexType.CBOR_LZMA_XZ_V1.value:
-            _logger.debug(f"IndexedTarStore: lzma-compressed (xz archive format) index load size={len(header_binary)}")
+            _logger.debug(f"IndexedTarStore: lzma-compressed (xz archive format) index load size={len(index_binary)}")
 
             # load table (SOA)
-            table = cbor2.loads(lzma.LZMADecompressor().decompress(header_binary))
+            table = cbor2.loads(lzma.LZMADecompressor().decompress(index_binary))
             items = table["items"]
             offset_datas = table["offset_datas"]
             sizes = table["sizes"]

--- a/ncore/impl/data/stores.py
+++ b/ncore/impl/data/stores.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from enum import IntEnum, auto, unique
 from pathlib import Path
 from threading import RLock
-from typing import IO, Any, Dict, Iterator, Literal, NamedTuple, Union
+from typing import IO, Any, Dict, Iterator, Literal, NamedTuple, Optional, Union, cast
 
 import cbor2
 import zarr
@@ -38,21 +38,6 @@ from zarr.util import json_loads
 
 
 _logger = logging.getLogger(__name__)
-
-
-class _NullTarFile:
-    """Stub replacing tarfile.TarFile when no tar-level I/O is needed.
-
-    The stock TarFile(fileobj=fobj) reads tar headers from the beginning of
-    the file, which is wasted I/O since all reads go through
-    __getitem__ -> fobj.seek() + fobj.read() using the index offsets.
-    """
-
-    def __init__(self):
-        self.fileobj = None
-
-    def close(self):
-        pass
 
 
 class IndexedTarStore(Store):
@@ -113,8 +98,10 @@ class IndexedTarStore(Store):
 
         self.itar_upath = itar_upath.absolute()
 
-        # open file object (require file to be both writeable and readable when writing)
+        # open file object (require file to be both writeable and readable when writing) and
+        # tar file (only required for write mode, read mode directly uses file object)
         self.tar_file_object: IO[Any]
+        self.tar_file: Optional[tarfile.TarFile] = None
         if self.mode == "r":
             self.tar_file_object = self.itar_upath.open("rb")
         else:
@@ -123,9 +110,7 @@ class IndexedTarStore(Store):
             # if the FS supports it, so ignore type-checker here
             self.tar_file_object = self.itar_upath.open("wb+")  # type: ignore[call-overload]
 
-        # Use a lightweight stub instead of tarfile.TarFile — the real TarFile
-        # is only created lazily on the first __setitem__ call (write mode).
-        self.tar_file: Union[tarfile.TarFile, _NullTarFile] = _NullTarFile()
+            self.tar_file = tarfile.TarFile(fileobj=self.tar_file_object, mode="w")
 
         # init / load index table
         if self.mode == "r":
@@ -176,10 +161,6 @@ class IndexedTarStore(Store):
             value_bytes: bytes = compat.ensure_bytes(value)
             value_size: int = len(value_bytes)
 
-            # Lazily create TarFile on first write
-            if not isinstance(self.tar_file, tarfile.TarFile):
-                self.tar_file = tarfile.TarFile(fileobj=self.tar_file_object, mode="w")
-
             # Remember current tar file position, which is the start of the header
             header_start_position = self.tar_file_object.tell()
 
@@ -187,7 +168,7 @@ class IndexedTarStore(Store):
             tarinfo = tarfile.TarInfo(item)
             tarinfo.size = value_size
 
-            self.tar_file.addfile(tarinfo, fileobj=io.BytesIO(value_bytes))
+            cast(tarfile.TarFile, self.tar_file).addfile(tarinfo, fileobj=io.BytesIO(value_bytes))
 
             # End position after writing both header and payload
             end_position = self.tar_file_object.tell()
@@ -219,11 +200,11 @@ class IndexedTarStore(Store):
     def close(self):
         """Needs to be called after finishing updating the store"""
         with self.mutex:
-            # Closing the tar file appends two finishing blocks to the end of the file
-            # if in write mode, but doesn't close the internal file object yet
-            self.tar_file.close()
-
             if self.mode == "w":
+                # Closing the tar file appends two finishing blocks to the end of the file
+                # if in write mode, but doesn't close the internal file object yet
+                cast(tarfile.TarFile, self.tar_file).close()
+
                 # Add index if writing
                 self._save_tar_index(self.tar_file_object, self.index)
 
@@ -245,7 +226,9 @@ class IndexedTarStore(Store):
                 # if the FS supports it, so ignore type-checker here
                 self.tar_file_object = self.itar_upath.open("wb+")  # type: ignore[call-overload]
 
-            self.tar_file.fileobj = self.tar_file_object
+            if self.mode == "w":
+                # assign the new file object to the tar file (only required for write mode)
+                cast(tarfile.TarFile, self.tar_file).fileobj = self.tar_file_object
 
             # seek to previous position
             self.tar_file_object.seek(current_position)

--- a/ncore/impl/data/stores_test.py
+++ b/ncore/impl/data/stores_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import tempfile
 import unittest
 
@@ -21,6 +22,10 @@ import parameterized
 import zarr
 
 from .stores import IndexedTarStore, consolidate_compressed_metadata, open_compressed_consolidated
+
+
+COMPRESSED_CONSOLIDATED_VALUES = [False, True]
+INDEX_TAIL_READ_SIZES = [1 << 20, 512]  # 1 MiB (default) and 512 bytes (edge case of single tar block size)
 
 
 class TestIndexedTarStore(unittest.TestCase):
@@ -41,7 +46,12 @@ class TestIndexedTarStore(unittest.TestCase):
         )
         self.assertDictEqual(self.g_ref.attrs.asdict(), group.attrs.asdict())
 
-    def test_reserialization(self):
+    @parameterized.parameterized.expand(
+        itertools.product(
+            INDEX_TAIL_READ_SIZES,
+        )
+    )
+    def test_reserialization(self, index_tail_read_size: int):
         """Make sure storing / loading of regular zarr data to .itar files works correctly"""
 
         # re-serialize to .itar archive
@@ -50,7 +60,7 @@ class TestIndexedTarStore(unittest.TestCase):
                 zarr.copy_store(self.g_ref.store, s_itar_out)
 
             # reload store from file
-            store = IndexedTarStore(f.name)
+            store = IndexedTarStore(f.name, index_tail_read_size=index_tail_read_size)
             g_reload = zarr.open(store=store, mode="r")
 
             # check all data was correctly serialized / deserialized
@@ -60,7 +70,12 @@ class TestIndexedTarStore(unittest.TestCase):
             store.reload_resources()
             self.check_with_reference(g_reload)
 
-    def test_compressed_consolidated(self):
+    @parameterized.parameterized.expand(
+        itertools.product(
+            INDEX_TAIL_READ_SIZES,
+        )
+    )
+    def test_compressed_consolidated(self, index_tail_read_size: int):
         """Make sure compressed consolidated meta data is stored/loaded correctly"""
 
         # serialize to .itar archive (will also serialize compressed-consolidated meta-data)
@@ -72,7 +87,7 @@ class TestIndexedTarStore(unittest.TestCase):
                 consolidate_compressed_metadata(s_itar_out)
 
             # reload store from file with compressed consolidated meta-data
-            store = IndexedTarStore(f.name)
+            store = IndexedTarStore(f.name, index_tail_read_size=index_tail_read_size)
             g_reload = open_compressed_consolidated(store=store, mode="r")
 
             # check all data was correctly serialized / deserialized
@@ -83,18 +98,12 @@ class TestIndexedTarStore(unittest.TestCase):
             self.check_with_reference(g_reload)
 
     @parameterized.parameterized.expand(
-        [
-            (
-                "not-compressed_consolidate",
-                False,
-            ),
-            (
-                "compressed_consolidate",
-                True,
-            ),
-        ]
+        itertools.product(
+            COMPRESSED_CONSOLIDATED_VALUES,
+            INDEX_TAIL_READ_SIZES,
+        )
     )
-    def test_empty(self, _, compressed_consolidate: bool):
+    def test_empty(self, compressed_consolidate: bool, index_tail_read_size: int):
         """Verify edge case of serialization of empty store is possible without errors"""
         with tempfile.NamedTemporaryFile(suffix=".itar") as f:
             with IndexedTarStore(f.name, mode="w") as s_itar_out:  # closes file on exit
@@ -103,7 +112,7 @@ class TestIndexedTarStore(unittest.TestCase):
                 if compressed_consolidate:
                     consolidate_compressed_metadata(s_itar_out)
 
-            with IndexedTarStore(f.name) as s_itar_in:
+            with IndexedTarStore(f.name, index_tail_read_size=index_tail_read_size) as s_itar_in:
                 # Loading store should work without errors
 
                 # But loading a non-existing group should then fail

--- a/ncore/impl/data/v4/components.py
+++ b/ncore/impl/data/v4/components.py
@@ -319,6 +319,7 @@ class SequenceComponentGroupsReader:
         self,
         component_group_paths: List[UPath] | List[Path],
         open_consolidated: bool = True,
+        itar_index_tail_read_size: int = 1 << 20,  # 1 MiB default
         max_threads: int | None = None,
     ):
         """Initialize a SequenceComponentReader for a virtual sequence represented by a list of components.
@@ -331,6 +332,10 @@ class SequenceComponentGroupsReader:
                                storage to prevent latencies introduced when accessing the data.
                                If the component data is available on fast *local* storage, disabling
                                this option can speed up initial load times.
+            itar_index_tail_read_size: When loading component groups from .itar files, the size of the tail buffer to read in a
+                               single I/O call to initialize the tar file index to minimize reads.
+                               Default 1 MiB size fits typical use cases, but may be increased if the compressed
+                               index size is expected to be larger or decreased if remote access chunk sizes are smaller.
             max_threads:       The maximum number of threads used to load the different components (if None,
                                use interpreter-default number of threads for a ThreadPoolExecutor)
         """
@@ -360,7 +365,9 @@ class SequenceComponentGroupsReader:
                             f"Unsupported file-based store format {component_store_upath}, expected .zarr.itar"
                         )
 
-                    component_store = stores.IndexedTarStore(component_store_upath, mode="r")
+                    component_store = stores.IndexedTarStore(
+                        component_store_upath, mode="r", index_tail_read_size=itar_index_tail_read_size
+                    )
                 else:
                     component_store = zarr.storage.DirectoryStore(component_store_upath)
 


### PR DESCRIPTION
Reduce I/O during IndexedTarStore read-mode open from 3 seeks + 2 reads down to 1 seek + 1 read in the common case:

- Single-read tar index: _load_tar_index now reads 1 MiB from the tail of the file in one fobj.read() call, extracting both the 20-byte header and the compressed index payload from the same buffer. Only falls back to a second read when the index exceeds 1 MiB.

<!--
SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe what this PR does and why. Link to any related issues. -->

## Type of Change

<!-- Check the relevant option(s): -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] My commits are GPG-signed
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally (`bazel test //...`)
- [ ] Code is formatted (`bazel run //:format`)
- [ ] I have updated documentation as needed
- [ ] My changes include SPDX license headers on all new files
