### PR TITLE
feat: Allow optional itar index_tail_read_size optional

### DIFF
--- a/ncore/impl/data/stores.py
+++ b/ncore/impl/data/stores.py
@@ -47,9 +47,18 @@ class IndexedTarStore(Store):
     ----------
     itar_path : string
         Location of the tar file (needs to end with '.itar').
-    mode : string, optional
+    mode : string, optional, default 'r'
         One of 'r' to read an existing file, or 'w' to truncate and write a new
         file.
+    index_tail_read_size : int or None, optional, default 1 << 20 (1 MiB)
+        Maximum bytes read from the tail of the file in a single I/O call to load the tar index.
+        Covers both the small index header and (ideally) the compressed index payload.
+        If not specified, perform separate reads for header and payload,
+        which is more robust for large indices, but requires two I/O calls.
+        Will be increased to at least one tar block size if specified smaller,
+        since the header is located in the last block.
+        Default 1 MiB size fits typical use cases, but may be increased if the compressed
+        index size is expected to be larger or decreased if remote access chunk sizes are smaller.
 
     After modifying a IndexedTarStore, the ``close()`` method must be called, otherwise
     essential data will not be written to the underlying files. The IndexedTarStore
@@ -82,9 +91,7 @@ class IndexedTarStore(Store):
         self,
         itar_path: Union[str, Path, UPath],
         mode: Literal["r", "w"] = "r",
-        # Maximum bytes read from the tail of the file in a single I/O call to load the tar index.
-        # Covers both the small index header and (ideally) the compressed index payload.
-        index_tail_read_size: int = 1 << 20,  # 1 MiB by default
+        index_tail_read_size: Optional[int] = 1 << 20,  # 1 MiB by default
     ):
         if mode not in ["r", "w"]:
             raise ValueError("TarRecordIndex: only r/w modes supported")
@@ -267,15 +274,11 @@ class IndexedTarStore(Store):
         CBOR_LZMA_XZ_V1 = auto()
 
     @classmethod
-    def _load_tar_index(cls, tar_file_object: IO[Any], index_tail_read_size: int) -> TarRecordIndex:
-        """Loads a tar record index from the end of a tar file object.
-
-        Reads up to index_tail_read_size from the tail of the file in one ``fobj.read()``
-        call.  Extracts both the index header (in the last 512-byte block)
-        and the compressed index payload from that same buffer.  Only falls
-        back to a second read if the compressed index is larger than the tail read size.
-        """
-        assert index_tail_read_size >= tarfile.BLOCKSIZE, "Tail read size needs to be at least one tar block size"
+    def _load_tar_index(cls, tar_file_object: IO[Any], index_tail_read_size: Optional[int]) -> TarRecordIndex:
+        """Loads a tar record index from the end of a tar file object."""
+        # Determine tail read size
+        if index_tail_read_size is None or index_tail_read_size < tarfile.BLOCKSIZE:
+            index_tail_read_size = tarfile.BLOCKSIZE  # explicit separate reads
 
         original_file_position = tar_file_object.tell()
 
@@ -288,11 +291,8 @@ class IndexedTarStore(Store):
         tar_file_object.seek(file_size - tail_buffer_size)
         tail_buffer = tar_file_object.read(tail_buffer_size)
 
-        # Extract the header from the last 512-byte block
+        # Extract the header from the last 512-byte block (it's guaranteed that the header fits into a single block)
         header_binary_size = struct.calcsize(cls.INDEX_HEADER_FORMAT)
-        assert header_binary_size <= index_tail_read_size, (
-            "Index header larger than tail read size, increase index_tail_read_size"
-        )
         header_offset_in_tail_buffer = tail_buffer_size - tarfile.BLOCKSIZE
         header = cls.IndexHeader._make(
             struct.unpack(

--- a/ncore/impl/data/stores_test.py
+++ b/ncore/impl/data/stores_test.py
@@ -17,6 +17,8 @@ import itertools
 import tempfile
 import unittest
 
+from typing import Optional
+
 import numpy as np
 import parameterized
 import zarr
@@ -25,7 +27,14 @@ from .stores import IndexedTarStore, consolidate_compressed_metadata, open_compr
 
 
 COMPRESSED_CONSOLIDATED_VALUES = [False, True]
-INDEX_TAIL_READ_SIZES = [1 << 20, 512]  # 1 MiB (default) and 512 bytes (edge case of single tar block size)
+INDEX_TAIL_READ_SIZES = [
+    None,
+    1 << 10,
+    1 << 20,
+    1,
+    512,
+    513,
+]  # None (explicit separate reads), 0.5 MiB, 1 MiB (default), 1 byte / 512 / 513 bytes (edge cases resulting in separate reads)
 
 
 class TestIndexedTarStore(unittest.TestCase):
@@ -51,7 +60,7 @@ class TestIndexedTarStore(unittest.TestCase):
             INDEX_TAIL_READ_SIZES,
         )
     )
-    def test_reserialization(self, index_tail_read_size: int):
+    def test_reserialization(self, index_tail_read_size: Optional[int]):
         """Make sure storing / loading of regular zarr data to .itar files works correctly"""
 
         # re-serialize to .itar archive
@@ -75,7 +84,7 @@ class TestIndexedTarStore(unittest.TestCase):
             INDEX_TAIL_READ_SIZES,
         )
     )
-    def test_compressed_consolidated(self, index_tail_read_size: int):
+    def test_compressed_consolidated(self, index_tail_read_size: Optional[int]):
         """Make sure compressed consolidated meta data is stored/loaded correctly"""
 
         # serialize to .itar archive (will also serialize compressed-consolidated meta-data)
@@ -103,7 +112,7 @@ class TestIndexedTarStore(unittest.TestCase):
             INDEX_TAIL_READ_SIZES,
         )
     )
-    def test_empty(self, compressed_consolidate: bool, index_tail_read_size: int):
+    def test_empty(self, compressed_consolidate: bool, index_tail_read_size: Optional[int]):
         """Verify edge case of serialization of empty store is possible without errors"""
         with tempfile.NamedTemporaryFile(suffix=".itar") as f:
             with IndexedTarStore(f.name, mode="w") as s_itar_out:  # closes file on exit


### PR DESCRIPTION
This pull request enhances the flexibility and robustness of the `IndexedTarStore` tar index loading logic and its associated tests. The main improvements include allowing the `index_tail_read_size` parameter to be `None` (to force separate reads for the index header and payload), expanding test coverage for edge cases, and simplifying related code and assertions.

**Enhancements to tar index loading:**
* The `index_tail_read_size` parameter in `IndexedTarStore` and `IndexType._load_tar_index` can now be `None`, which triggers a more robust two-read fallback for large or unusual tar indices. The parameter also defaults to 1 MiB but can be set to smaller values, including edge cases. [[1]](diffhunk://#diff-8bb43fd511fbd197a01be1aacddc1039ce65c6793ae2fd9640830b8c91fa7990L50-R61) [[2]](diffhunk://#diff-8bb43fd511fbd197a01be1aacddc1039ce65c6793ae2fd9640830b8c91fa7990L87-R96) [[3]](diffhunk://#diff-8bb43fd511fbd197a01be1aacddc1039ce65c6793ae2fd9640830b8c91fa7990L270-R283)
* Simplified and clarified the logic for extracting the index header, removing redundant assertions and comments.

**Test coverage improvements:**
* The test suite now covers a wider range of `index_tail_read_size` values, including `None`, very small, and slightly larger-than-block-size values, to ensure robust handling of all supported cases.
* Updated test signatures and parameterization to support `Optional[int]` for `index_tail_read_size`, reflecting the new logic and improving test clarity. [[1]](diffhunk://#diff-666b4491bab6850da678e0d1f4642b12d8292ce1b8ea5cfa7c7744ed2ec05d56R20-R21) [[2]](diffhunk://#diff-666b4491bab6850da678e0d1f4642b12d8292ce1b8ea5cfa7c7744ed2ec05d56L54-R63) [[3]](diffhunk://#diff-666b4491bab6850da678e0d1f4642b12d8292ce1b8ea5cfa7c7744ed2ec05d56L78-R87) [[4]](diffhunk://#diff-666b4491bab6850da678e0d1f4642b12d8292ce1b8ea5cfa7c7744ed2ec05d56L106-R115)