### PR TITLE
fix(docs): update ncore_docs_data to v0.6 to fix missing camera.jpg image

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -92,8 +92,8 @@ http_archive(
 # documentation binary data
 http_archive(
     name = "ncore_docs_data",
-    sha256 = "8ca36f8944d99a7612a46c163e3d200b51620abc689e4ab0e467439831cd3779",
-    urls = ["https://maven.pkg.github.com/NVIDIA/ncore/com/nvidia/ncore/ncore-docs-data/0.5/ncore-docs-data.tar.gz"],
+    sha256 = "bd0b4f487832df4db3bc360aa8d58392b09aa578be165ebd690b9857bd94c986",
+    urls = ["https://maven.pkg.github.com/NVIDIA/ncore/com/nvidia/ncore/ncore-docs-data/0.6/ncore-docs-data.tar.gz"],
 )
 
 # Waymo Open Dataset (http_archive for proto definitions)


### PR DESCRIPTION
## Summary

- Updates the `ncore_docs_data` external archive from v0.5 to v0.6
- The `camera.jpg` in the v0.5 archive was a Git LFS pointer file (130 bytes) instead of the actual JPEG image (28KB), causing a broken image in the **Camera and Image Coordinate System** section of the rendered documentation
- Verified the docs build succeeds and `camera.jpg` is now a valid JPEG in the output