### PR TITLE
feat(converters): add --world-global-mode option for optional world_global pose storage

### DIFF
--- a/docs/conversions/colmap/colmap.rst
+++ b/docs/conversions/colmap/colmap.rst
@@ -175,6 +175,11 @@ subdirectory is treated as a separate sequence.
      - (auto-detect)
      - Explicit masks directory relative to each sequence root. When set,
        looks for ``<masks_dir>/<stem>.png``
+   * - ``--world-global-mode {none,identity}``
+     - ``none``
+     - Controls whether a ``("world", "world_global")`` static pose is stored.
+       ``none`` omits it (default); ``identity`` stores an identity matrix
+       for downstream consumers that require it
 
 For the complete implementation, see
 ``tools/data_converter/colmap/converter.py``.

--- a/docs/conversions/waymo/waymo.rst
+++ b/docs/conversions/waymo/waymo.rst
@@ -123,6 +123,13 @@ Run the converter with Bazel from the repository root:
    * - ``--sequence-meta`` / ``--no-sequence-meta``
      - enabled
      - Whether to write a JSON metadata file alongside each converted sequence
+   * - ``--world-global-mode {none,identity,localized}``
+     - ``none``
+     - Controls whether a ``("world", "world_global")`` static pose is stored.
+       ``none`` omits it (default); ``identity`` stores an identity matrix;
+       ``localized`` rebases poses relative to the first frame (matching,
+       e.g., the PAI converter pattern) and stores the original first pose
+       as ``world_global`` in float64
 
 For the complete implementation, see
 ``tools/data_converter/waymo/converter.py``.

--- a/tools/data_converter/colmap/README.md
+++ b/tools/data_converter/colmap/README.md
@@ -68,6 +68,7 @@ bazel run //tools/data_converter/colmap -- \
 | `--colmap-dir` | Relative path to COLMAP reconstruction directory | `sparse/0` |
 | `--images-dir` | Relative path to images directory | `images` |
 | `--masks-dir` | Explicit masks directory (auto-detect if not set) | None |
+| `--world-global-mode` | Controls `("world", "world_global")` static pose storage: `none` (omit), `identity` (store identity matrix) | `none` |
 
 ### Examples
 

--- a/tools/data_converter/colmap/converter.py
+++ b/tools/data_converter/colmap/converter.py
@@ -67,6 +67,7 @@ class ColmapConverter4Config(FileBasedDataConverterConfig):
     images_dir: str = "images"
     masks_dir: Optional[str] = None
     generic_meta_data: dict[str, JsonLike] = field(default_factory=dict)
+    world_global_mode: Literal["none", "identity"] = "none"
 
 
 @dataclass(kw_only=True, slots=True)
@@ -190,6 +191,7 @@ class ColmapDataConverter(FileBasedDataConverter):
         self.images_dir = config.images_dir
         self.masks_dir = config.masks_dir
         self.generic_meta_data: dict[str, JsonLike] = config.generic_meta_data
+        self.world_global_mode: Literal["none", "identity"] = config.world_global_mode
         self.logger = logging.getLogger(__name__)
 
     @staticmethod
@@ -297,6 +299,14 @@ class ColmapDataConverter(FileBasedDataConverter):
 
         ## Decode and store camera frames
         self.decode_cameras()
+
+        ## Store world->world_global static pose if requested
+        if self.world_global_mode == "identity":
+            self.poses_writer.store_static_pose(
+                source_frame_id="world",
+                target_frame_id="world_global",
+                pose=np.eye(4, dtype=np.float64),
+            )
 
         # Store per-shard meta data / final success state / close file
         ncore_4_paths = self.store_writer.finalize()
@@ -594,6 +604,15 @@ class ColmapDataConverter(FileBasedDataConverter):
     type=str,
     default=None,
     help="Path to the masks directory (relative to sequence root). If not set, masks are discovered via conventions.",
+)
+@click.option(
+    "--world-global-mode",
+    type=click.Choice(["none", "identity"], case_sensitive=False),
+    default="none",
+    show_default=True,
+    help="""Controls whether a ("world", "world_global") static pose is stored:
+        - "none": No world_global pose (default).
+        - "identity": Store an identity world_global pose for downstream consumers that require it.""",
 )
 @click.pass_context
 def colmap_v4(ctx, *_, **kwargs):

--- a/tools/data_converter/waymo/README.md
+++ b/tools/data_converter/waymo/README.md
@@ -42,6 +42,7 @@ bazel run //tools/data_converter/waymo -- \
 | `--store-type` | Output store type (`itar` or `directory`) | `itar` |
 | `--profile` | Component group profile (`default`, `separate-sensors`, `separate-all`) | `separate-sensors` |
 | `--sequence-meta` / `--no-sequence-meta` | Generate sequence meta-data file | True |
+| `--world-global-mode` | Controls `("world", "world_global")` static pose storage: `none` (omit), `identity` (store identity matrix), `localized` (rebase poses relative to the first frame, matching, e.g., the PAI converter pattern) | `none` |
 
 ### Examples
 

--- a/tools/data_converter/waymo/converter.py
+++ b/tools/data_converter/waymo/converter.py
@@ -77,6 +77,7 @@ class WaymoConverter4Config(FileBasedDataConverterConfig):
     store_type: Literal["itar", "directory"] = "itar"
     component_group_profile: Literal["default", "separate-sensors", "separate-all"] = "separate-sensors"
     store_sequence_meta: bool = True
+    world_global_mode: Literal["none", "identity", "localized"] = "none"
 
 
 class WaymoConverter4(FileBasedDataConverter):
@@ -115,6 +116,7 @@ class WaymoConverter4(FileBasedDataConverter):
         )
         self.store_type: Literal["itar", "directory"] = config.store_type
         self.store_sequence_meta: bool = config.store_sequence_meta
+        self.world_global_mode: Literal["none", "identity", "localized"] = config.world_global_mode
 
         self.logger = logging.getLogger(__name__)
 
@@ -304,13 +306,39 @@ class WaymoConverter4(FileBasedDataConverter):
 
     def store_poses(self) -> None:
         """Stores the processed egomotion poses into the poses component."""
-        # Store dynamic rig->world poses (float32 for relative poses)
+        poses = self.pose_interpolator.poses  # (N, 4, 4) float64, in Waymo global coordinates
+        T_world_world_global = None
+
+        match self.world_global_mode:
+            case "none":
+                pass
+
+            case "identity":
+                T_world_world_global = np.eye(4, dtype=np.float64)
+
+            case "localized":
+                # Rebase poses relative to the first frame (matching, e.g., the PAI converter pattern).
+                # This avoids float32 precision loss for large global coordinate offsets and provides
+                # a meaningful world->world_global transform for downstream consumers.
+                T_world_world_global = poses[0].astype(np.float64).copy()
+                poses = se3_inverse(T_world_world_global)[None] @ poses
+
+            case _:
+                raise ValueError(f"Unknown world_global_mode: {self.world_global_mode!r}")
+
         self.poses_writer.store_dynamic_pose(
             source_frame_id="rig",
             target_frame_id="world",
-            poses=self.pose_interpolator.poses.astype(np.float32),
+            poses=poses.astype(np.float32),
             timestamps_us=self.pose_interpolator.timestamps,
         )
+
+        if T_world_world_global is not None:
+            self.poses_writer.store_static_pose(
+                source_frame_id="world",
+                target_frame_id="world_global",
+                pose=T_world_world_global,
+            )
 
     # Label IDs to label type strings
     LIDAR_LABEL_CLASS_ID_STRING_MAP = {
@@ -932,6 +960,17 @@ class WaymoConverter4(FileBasedDataConverter):
 )
 @click.option(
     "store_sequence_meta", "--sequence-meta/--no-sequence-meta", default=True, help="Generate sequence meta-data?"
+)
+@click.option(
+    "--world-global-mode",
+    type=click.Choice(["none", "identity", "localized"], case_sensitive=False),
+    default="none",
+    show_default=True,
+    help="""Controls whether a ("world", "world_global") static pose is stored:
+        - "none": No world_global pose (default). Poses remain in source coordinates.
+        - "identity": Store an identity world_global pose. Poses remain in source coordinates.
+        - "localized": Rebase poses relative to the first frame (matching, e.g., the PAI converter
+          pattern) and store the original first pose as world->world_global (float64).""",
 )
 @click.pass_context
 def waymo_v4(ctx, *_, **kwargs):


### PR DESCRIPTION
## Summary

Adds a `--world-global-mode` CLI option to the Waymo and COLMAP converters that controls whether a `("world", "world_global")` static pose is written. This is opt-in and disabled by default, preserving backward compatibility.

Closes #76

## Motivation

PR #67 removed the identity `("world", "world_global")` static pose from the Waymo and COLMAP converters because it carried no semantic information. However, downstream consumers like NuRec require this pose to exist to determine scene extent. This PR provides an opt-in mechanism for users who need it.

## Changes

### Waymo converter (`--world-global-mode none|identity|localized`)

- **`none`** (default): No `world_global` pose stored. Current behavior, no change.
- **`identity`**: Stores `np.eye(4, dtype=float64)` as `world->world_global`. Dynamic `rig->world` poses remain in source (Waymo global) coordinates.
- **`localized`**: Rebases all `rig->world` poses relative to the first frame and stores the original first pose as `world->world_global` in float64. This matches the PAI converter pattern, fixes float32 precision loss for large global coordinate offsets, and is recommended for NuRec.

### COLMAP converter (`--world-global-mode none|identity`)

- **`none`** (default): No `world_global` pose stored. Current behavior.
- **`identity`**: Stores `np.eye(4, dtype=float64)` as `world->world_global`. COLMAP reconstructions are already in a local coordinate frame, so `localized` mode is not applicable.

## Usage

```bash
# Waymo: recommended for NuRec compatibility
bazel run //tools/data_converter/waymo:waymo -- \
    --root-dir /path/to/waymo --output-dir /path/to/output \
    waymo-v4 --world-global-mode=localized

# COLMAP: identity mode for downstream checks
bazel run //tools/data_converter/colmap:colmap -- \
    --root-dir /path/to/colmap --output-dir /path/to/output \
    colmap-v4 --world-global-mode=identity
```