### PR TITLE
ci: add copy-pr-bot configuration for self-hosted runner

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for the copy-pr-bot GitHub App.
+# This bot creates pull-request/<number> branches from external PRs,
+# enabling CI workflows on NVIDIA self-hosted runners (which do not
+# allow pull_request-triggered workflows for security reasons).
+#
+# See: https://docs.gha-runners.nvidia.com/platform/apps/copy-pr-bot/
+
+enabled: true
+auto_sync_draft: false
+auto_sync_ready: true


### PR DESCRIPTION
## Summary

Add the `.github/copy-pr-bot.yaml` configuration file to enable the [copy-pr-bot](https://github.com/apps/copy-pr-bot) GitHub App on this repository.

### Why

NVIDIA self-hosted runners block `pull_request`-triggered workflows for security reasons. The copy-pr-bot works around this by mirroring PR content to `pull-request/<number>` branches inside the repo, which trigger `push` events instead.

This is a prerequisite for switching CI to self-hosted GPU runners (see #80).

### What it does

When a trusted NVIDIA employee opens a PR (with signed commits), the bot automatically creates a `pull-request/N` branch. For external contributors, a repo member can approve with `/ok to test <SHA>`.

### Configuration

- `enabled: true` -- activate the bot
- `auto_sync_draft: false` -- don't sync draft PRs (saves runner capacity)
- `auto_sync_ready: true` -- auto-sync when PR is marked ready for review