### PR TITLE
build: Suppress rules_py warning on RECORD file changes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,7 +43,10 @@ bazel_dep(name = "rules_python", version = "1.2.0")
 single_version_override(
     module_name = "rules_python",
     patch_strip = 1,
-    patches = ["//bazel/rules_python:rules_python_repo_contents_cache.patch"],
+    patches = [
+        "//bazel/rules_python:rules_python_repo_contents_cache.patch",
+        "//bazel/rules_python:rules_python_suppress_record_warning.patch",
+    ],
 )
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/bazel/rules_python/rules_python_suppress_record_warning.patch
+++ b/bazel/rules_python/rules_python_suppress_record_warning.patch
@@ -1,0 +1,40 @@
+Suppress noisy RECORD-file-differs warning when patching wheels
+
+When we intentionally patch a wheel via pip.override() (e.g. our torch
+CUDA-preload patch), rules_python regenerates the RECORD file with
+updated hashes. It then compares the new RECORD against the original
+and prints a large WARNING telling the user to also supply a RECORD
+patch. This warning is misleading and noisy in our case -- the RECORD
+*should* differ because we intentionally modified a file, and the
+repackaged wheel already contains the correct RECORD.
+
+The warning was originally added for a Windows line-ending edge case
+(bazelbuild/rules_python#1639) and as a supply-chain awareness nudge,
+neither of which applies to intentional pip.override() patching.
+
+This is fixed properly in rules_python >=1.9.0 but we cannot upgrade
+past 1.2.0 because 1.8.0+ drops built-in Python 3.8 toolchain support
+which we still require.
+
+--- a/python/private/pypi/patch_whl.bzl
++++ b/python/private/pypi/patch_whl.bzl
+@@ -119,19 +119,4 @@
+         **kwargs
+     )
+ 
+-    if record_patch.exists:
+-        record_patch_contents = rctx.read(record_patch)
+-        warning_msg = """WARNING: the resultant RECORD file of the patch wheel is different
+-
+-    If you are patching on Windows, you may see this warning because of
+-    a known issue (bazelbuild/rules_python#1639) with file endings.
+-
+-    If you would like to silence the warning, you can apply the patch that is stored in
+-      {record_patch}. The contents of the file are below:
+-{record_patch_contents}""".format(
+-            record_patch = record_patch,
+-            record_patch_contents = record_patch_contents,
+-        )
+-        print(warning_msg)  # buildifier: disable=print
+-
+     return rctx.path(whl_patched)


### PR DESCRIPTION
This pull request updates our Bazel configuration to suppress a noisy and misleading warning from `rules_python` when intentionally patching Python wheels. This is achieved by adding a custom patch that disables the warning, which is not relevant for our use case and is fixed only in later versions of `rules_python` that we cannot upgrade to yet.

Dependency configuration update:

* Added a new patch, `rules_python_suppress_record_warning.patch`, to the `rules_python` dependency in `MODULE.bazel` to suppress unnecessary RECORD file warnings when patching wheels.

Patch details:

* Introduced `bazel/rules_python/rules_python_suppress_record_warning.patch`, which removes the code that prints a large warning about RECORD file differences when patching wheels via `pip.override()`. This prevents misleading output in our builds.