### PR TITLE
refactor(v4-components): use module-level logger for ncore/impl/data/v4/components.py

### DIFF
--- a/ncore/impl/data/v4/components.py
+++ b/ncore/impl/data/v4/components.py
@@ -66,6 +66,8 @@ if sys.version_info >= (3, 11):
     # - alias these globally as a workaround
     from typing import Self
 
+_logger = logging.getLogger(__name__)
+
 VERSION = "v4"
 
 
@@ -370,7 +372,7 @@ class SequenceComponentGroupsReader:
                 # Make sure paths are absolute at this point
                 component_store_upath = component_store_upath.absolute()
 
-                logging.info(f"SequenceStoreReader: Loading component store {component_store_upath}")
+                _logger.info(f"SequenceStoreReader: Loading component store {component_store_upath}")
 
                 component_store: Store
                 if component_store_upath.is_file():


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description
Switch the lone `logging.info` call in `ncore/impl/data/v4/components.py` to a module-level `_logger = logging.getLogger(__name__)`, matching the convention already used in `ncore/impl/data/stores.py`. This routes log records under the module's logger so callers can filter/configure them per-module instead of through the root logger.

## Type of Change

<!-- Check the relevant option(s): -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] My commits are GPG-signed
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally (`bazel test //...`)
- [ ] Code is formatted (`bazel run //:format`)
- [ ] I have updated documentation as needed
- [ ] My changes include SPDX license headers on all new files
