### PR TITLE
fix(ty): Fix ty-reported static type issues

### DIFF
--- a/ncore/impl/data/types.py
+++ b/ncore/impl/data/types.py
@@ -319,7 +319,7 @@ class FThetaCameraModelParameters(CameraModelParameters, dataclasses_json.DataCl
         # (backwards polynomial is a pixel-distance to angle map, so the domain needs to be scaled).
         # Potentially anisotropic scaling is handled by the linear term.
         scaled_pixel_map = np.polynomial.Polynomial([0.0, 1.0 / image_domain_scale_factors[1]])
-        pixeldist_to_angle_poly = np.polynomial.Polynomial(self.pixeldist_to_angle_poly)(scaled_pixel_map).coef.astype(  # type: ignore
+        pixeldist_to_angle_poly = np.polynomial.Polynomial(self.pixeldist_to_angle_poly)(scaled_pixel_map).coef.astype(
             np.float32
         )
 

--- a/ncore/impl/data/v4/components.py
+++ b/ncore/impl/data/v4/components.py
@@ -1006,7 +1006,7 @@ class BaseSensorComponentWriter(ComponentWriter):
         """Returns the group of a frame, initializing it if required"""
 
         if isinstance(timestamps_us, np.ndarray):
-            frame_id = timestamps_us[1].item()  # end-of-frame timestamp is frame ID
+            frame_id = cast(np.ndarray, timestamps_us)[1].item()  # end-of-frame timestamp is frame ID
         else:
             frame_id = timestamps_us
 
@@ -1081,7 +1081,7 @@ class BaseSensorComponentReader(ComponentReader):
         """Returns the group of a frame"""
 
         if isinstance(timestamps_us, np.ndarray):
-            frame_id = timestamps_us[1].item()  # end-of-frame timestamp is frame ID
+            frame_id = cast(np.ndarray, timestamps_us)[1].item()  # end-of-frame timestamp is frame ID
         else:
             frame_id = timestamps_us
 
@@ -1251,7 +1251,7 @@ class BaseRayBundleSensorComponentReader(BaseSensorComponentReader):
     def get_frame_ray_bundle_return_data_names(self, timestamp_us: int) -> List[str]:
         """List of all ray bundle return data names for a frame"""
 
-        return list(cast(zarr.Group, self._get_ray_bundle_returns_group(timestamp_us)).keys())
+        return list(self._get_ray_bundle_returns_group(timestamp_us).keys())
 
     def has_frame_ray_bundle_return_data(self, timestamp_us: int, name: str) -> bool:
         """Signals if named ray bundle return data exists for a frame"""

--- a/ncore/impl/data/v4/components_test.py
+++ b/ncore/impl/data/v4/components_test.py
@@ -18,7 +18,7 @@ import io
 import tempfile
 import unittest
 
-from typing import Dict, Literal, Tuple
+from typing import Dict, Literal, Tuple, cast
 
 import numpy as np
 import PIL.Image as PILImage
@@ -87,7 +87,7 @@ class TestData4Reload(unittest.TestCase):
                 ref_sequence_timestamp_interval_us := HalfClosedInterval(int(0 * 1e6), int(1 * 1e6) + 1)
             ),
             store_type=store_type,
-            generic_meta_data=(ref_generic_sequence_meta_data := {"some": 1, "key": 1.2}),
+            generic_meta_data=cast(Dict[str, JsonLike], ref_generic_sequence_meta_data := {"some": 1, "key": 1.2}),
         )
 
         # Store pose / extrinsics
@@ -166,7 +166,7 @@ class TestData4Reload(unittest.TestCase):
             PosesComponent.Writer,
             ref_poses_id := "some_poses_type",
             group_name=None,  # use default component group
-            generic_meta_data=(ref_pose_generic_meta_data := {"some": "thing"}),
+            generic_meta_data=cast(Dict[str, JsonLike], ref_pose_generic_meta_data := {"some": "thing"}),
         ).store_dynamic_pose(
             source_frame_id="rig",
             target_frame_id="world",
@@ -364,7 +364,9 @@ class TestData4Reload(unittest.TestCase):
                 "png",
                 ref_camera_timestamps_us0 := np.array([0 * 1e6, 0.1 * 1e6], dtype=np.uint64),
                 ref_camera_generic_data0 := {"some-frame-data": np.random.rand(6, 2)},
-                ref_camera_generic_metadata0 := {"some-frame-meta-data": {"something": 1, "else": 2}},
+                ref_camera_generic_metadata0 := cast(
+                    Dict[str, JsonLike], {"some-frame-meta-data": {"something": 1, "else": 2}}
+                ),
             )
 
         with io.BytesIO() as buffer:
@@ -377,7 +379,9 @@ class TestData4Reload(unittest.TestCase):
                 "png",
                 ref_camera_timestamps_us1 := np.array([0.1 * 1e6, 0.2 * 1e6], dtype=np.uint64),
                 ref_camera_generic_data1 := {"some-frame-data": np.random.rand(6, 2)},
-                ref_camera_generic_metadata1 := {"some-more-frame-meta-data": {"even": True, "more": None}},
+                ref_camera_generic_metadata1 := cast(
+                    Dict[str, JsonLike], {"some-more-frame-meta-data": {"even": True, "more": None}}
+                ),
             )
 
         # Store lidar data
@@ -402,7 +406,9 @@ class TestData4Reload(unittest.TestCase):
             ref_lidar_intensity0 := np.random.rand(1, 5).astype(np.float32),
             ref_lidar_timestamps_us0 := np.array([0 * 1e6, 0.5 * 1e6], dtype=np.uint64),
             ref_lidar_generic_data0 := {"some-other-frame-data": np.random.rand(6, 2)},
-            ref_lidar_generic_metadata0 := {"some-more-meta-data": {"yes": None, "no": True}},
+            ref_lidar_generic_metadata0 := cast(
+                Dict[str, JsonLike], {"some-more-meta-data": {"yes": None, "no": True}}
+            ),
         )
 
         ref_lidar_valid_mask0 = np.ones((1, 5), dtype=bool)
@@ -432,7 +438,7 @@ class TestData4Reload(unittest.TestCase):
             ref_lidar_intensity1,
             ref_lidar_timestamps_us1 := np.array([0.5 * 1e6, 1 * 1e6], dtype=np.uint64),
             ref_lidar_generic_data1 := {"some-other-frame-data": np.random.rand(2, 2)},
-            ref_lidar_generic_metadata1 := {"even-more-meta-data": {"yesno": None}},
+            ref_lidar_generic_metadata1 := cast(Dict[str, JsonLike], {"even-more-meta-data": {"yesno": None}}),
         )
 
         # Store radar data
@@ -451,7 +457,9 @@ class TestData4Reload(unittest.TestCase):
             ref_radar_distance_m0 := radar_distance_m0[np.newaxis, :],
             ref_radar_timestamps_us0 := np.array([0.1 * 1e6, 0.1 * 1e6], dtype=np.uint64),
             ref_radar_generic_data0 := {"some-other-frame-data": np.random.rand(6, 2)},
-            ref_radar_generic_metadata0 := {"some-more-meta-data": {"funny": "yes", "no": True}},
+            ref_radar_generic_metadata0 := cast(
+                Dict[str, JsonLike], {"some-more-meta-data": {"funny": "yes", "no": True}}
+            ),
         )
 
         ref_radar_direction_m1, radar_distance_m1 = normalize_points(np.random.rand(8, 3).astype(np.float32) + 0.2)
@@ -462,7 +470,7 @@ class TestData4Reload(unittest.TestCase):
             ref_radar_distance_m1 := np.stack((radar_distance_m1, radar_distance_m1 + 0.2)),
             ref_radar_timestamps_us1 := np.array([0.2 * 1e6, 0.2 * 1e6], dtype=np.uint64),
             ref_radar_generic_data1 := {"some-radar-frame-data": np.random.rand(6, 2)},
-            ref_radar_generic_metadata1 := {"some-more-meta-data": {"funny": ":("}},
+            ref_radar_generic_metadata1 := cast(Dict[str, JsonLike], {"some-more-meta-data": {"funny": ":("}}),
         )
 
         ## Finalize writers up to here
@@ -481,7 +489,7 @@ class TestData4Reload(unittest.TestCase):
             CuboidsComponent.Writer,
             ref_cuboids_id := "default",
             "cuboids",
-            ref_cuboids_generic_meta_data := {"track-set-meta-data": "some-value"},
+            ref_cuboids_generic_meta_data := cast(Dict[str, JsonLike], {"track-set-meta-data": "some-value"}),
         )
 
         ref_observation = CuboidTrackObservation(
@@ -1807,7 +1815,7 @@ class TestPointCloudsComponent(unittest.TestCase):
         # generic_meta_data
         loaded_gmd = reader.get_pc_generic_meta_data(0)
         self.assertEqual(loaded_gmd["source"], "lidar_top")
-        self.assertAlmostEqual(loaded_gmd["quality"], 0.99)
+        self.assertAlmostEqual(cast(float, loaded_gmd["quality"]), 0.99)
         self.assertEqual(loaded_gmd["tags"], ["outdoor", "sunny"])
 
         tmpdir.cleanup()


### PR DESCRIPTION
This pull request focuses on improving type safety and code clarity by adding explicit type casting, especially for generic metadata and data structures. It also includes minor type annotation cleanups and imports to ensure correctness and maintainability.

**Type safety and explicit casting improvements:**

* Added explicit `cast` calls to `Dict[str, JsonLike]` for all generic metadata arguments in `components_test.py` to clarify types and prevent type-checking errors. [[1]](diffhunk://#diff-683efb941f9303c1b2580f492191a760aa17ca2a38c2cee06cc0ee1ee6bdd570L90-R90) [[2]](diffhunk://#diff-683efb941f9303c1b2580f492191a760aa17ca2a38c2cee06cc0ee1ee6bdd570L169-R169) [[3]](diffhunk://#diff-683efb941f9303c1b2580f492191a760aa17ca2a38c2cee06cc0ee1ee6bdd570L367-R369) [[4]](diffhunk://#diff-683efb941f9303c1b2580f492191a760aa17ca2a38c2cee06cc0ee1ee6bdd570L380-R384) [[5]](diffhunk://#diff-683efb941f9303c1b2580f492191a760aa17ca2a38c2cee06cc0ee1ee6bdd570L405-R411) [[6]](diffhunk://#diff-683efb941f9303c1b2580f492191a760aa17ca2a38c2cee06cc0ee1ee6bdd570L435-R441) [[7]](diffhunk://#diff-683efb941f9303c1b2580f492191a760aa17ca2a38c2cee06cc0ee1ee6bdd570L454-R462) [[8]](diffhunk://#diff-683efb941f9303c1b2580f492191a760aa17ca2a38c2cee06cc0ee1ee6bdd570L465-R473) [[9]](diffhunk://#diff-683efb941f9303c1b2580f492191a760aa17ca2a38c2cee06cc0ee1ee6bdd570L484-R492)
* Updated the assertion in `test_generic_data_and_metadata` to cast the loaded quality value to `float` before comparison, ensuring type correctness.

**Type annotation and import cleanups:**

* Added `cast` to the test imports to support new explicit casts.
* Updated usages of `timestamps_us` in `_get_frame_group` to use `cast(np.ndarray, ...)` for better type clarity. [[1]](diffhunk://#diff-ef11fe55d5281b519967336cb48779838676ae496befaa96f04c8b4295c960c5L1009-R1009) [[2]](diffhunk://#diff-ef11fe55d5281b519967336cb48779838676ae496befaa96f04c8b4295c960c5L1084-R1084)
* Removed unnecessary `cast` to `zarr.Group` in `get_frame_ray_bundle_return_data_names`, simplifying the code.

**Minor code cleanup:**

* Removed unnecessary `# type: ignore` comment in `types.py` for a polynomial coefficient cast, as the type is now clear.