### PR TITLE
fix(unit-tests): Prevent relative imports in tests

### DIFF
--- a/bazel/pytest/defs.bzl
+++ b/bazel/pytest/defs.bzl
@@ -36,6 +36,7 @@ def pytest_test(name, srcs, python_versions = ["3.11", "3.8"], deps = [], args =
                 "--capture=no",
             ] + args + ["$(location :%s)" % x for x in srcs],
             srcs_version = "PY3",
+            legacy_create_init = 0,
             deps = deps + [
                 requirement("pytest"),
             ],

--- a/ncore/impl/data/stores_test.py
+++ b/ncore/impl/data/stores_test.py
@@ -24,7 +24,7 @@ import numpy as np
 import parameterized
 import zarr
 
-from .stores import IndexedTarStore, consolidate_compressed_metadata, open_compressed_consolidated
+from ncore.impl.data.stores import IndexedTarStore, consolidate_compressed_metadata, open_compressed_consolidated
 
 
 COMPRESSED_CONSOLIDATED_VALUES = [False, True]

--- a/ncore/impl/data/types_test.py
+++ b/ncore/impl/data/types_test.py
@@ -21,8 +21,7 @@ import numpy as np
 import numpy.testing as npt
 
 from ncore.impl.common.transformations import PoseGraphInterpolator
-
-from .types import PointCloud
+from ncore.impl.data.types import PointCloud
 
 
 class TestPointCloud(unittest.TestCase):

--- a/ncore/impl/data/util_test.py
+++ b/ncore/impl/data/util_test.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from .util import closest_index_sorted
+from ncore.impl.data.util import closest_index_sorted
 
 
 class TestClosestIndexSorted(unittest.TestCase):

--- a/ncore/impl/data/v4/compat_test.py
+++ b/ncore/impl/data/v4/compat_test.py
@@ -26,11 +26,9 @@ from upath import UPath
 
 from ncore.impl.common.transformations import HalfClosedInterval
 from ncore.impl.common.util import unpack_optional
-from ncore.impl.data.compat import RayBundleSensorPointCloudsSourceAdapter
 from ncore.impl.data.types import PointCloud, RowOffsetStructuredSpinningLidarModelParameters
-
-from .compat import SequenceLoaderV4
-from .components import (
+from ncore.impl.data.v4.compat import SequenceLoaderV4
+from ncore.impl.data.v4.components import (
     IntrinsicsComponent,
     LidarSensorComponent,
     PointCloudsComponent,

--- a/ncore/impl/data/v4/components_test.py
+++ b/ncore/impl/data/v4/components_test.py
@@ -41,8 +41,7 @@ from ncore.impl.data.types import (
     RowOffsetStructuredSpinningLidarModelParameters,
     ShutterType,
 )
-
-from .components import (
+from ncore.impl.data.v4.components import (
     CameraSensorComponent,
     ComponentReader,
     ComponentWriter,


### PR DESCRIPTION
Previously ncore/data/__init__.py was deleted after test execution due to bazel overwriting the package init file - disallow this in test targets and fix all relative imports to be absolute.

This pull request primarily updates import statements in various test files to use absolute imports instead of relative imports, improving code clarity and maintainability. Additionally, a minor Bazel configuration change is included.

**Test Import Refactoring:**

* Updated all test files in `ncore/impl/data` and subdirectories to use absolute imports for modules under `ncore.impl.data` and `ncore.impl.data.v4`, replacing relative imports. This change helps avoid import errors and improves test robustness and readability. [[1]](diffhunk://#diff-666b4491bab6850da678e0d1f4642b12d8292ce1b8ea5cfa7c7744ed2ec05d56L27-R27) [[2]](diffhunk://#diff-fedfac25004771694878ea321c186da7d9dcd98ab09903b361aed9ef3ea58774L24-R24) [[3]](diffhunk://#diff-cd7029751bfc1bd7d6ddfc46166f96a54214c9ef71758d5a6b880f7910efccf6L18-R18) [[4]](diffhunk://#diff-2aa99ccef4e0d5a6beade37c3fe6c238f08dbb291296feea2ec2fb2e9e9759f0L29-R31) [[5]](diffhunk://#diff-683efb941f9303c1b2580f492191a760aa17ca2a38c2cee06cc0ee1ee6bdd570L44-R44)
