### PR TITLE
feat(ncore_vis): Add option to recenter world coordinates near the origin

### DIFF
--- a/docs/tools/ncore_vis.rst
+++ b/docs/tools/ncore_vis.rst
@@ -60,6 +60,9 @@ Global Options
    * - ``--world-frame-id``
      - ``world``
      - Pose graph frame ID for the world/map reference
+   * - ``--recenter-world/--no-recenter-world``
+     - on
+     - Whether to recenter the viewer world frame to the rig's initial pose
    * - ``--debug``
      - off
      - Start a debugpy remote debugging session

--- a/tools/ncore_vis/cli.py
+++ b/tools/ncore_vis/cli.py
@@ -47,6 +47,7 @@ class CLIBaseParams:
     port: int
     rig_frame_id: str
     world_frame_id: str
+    recenter_world: bool
     debug: bool
     debug_port: int
 
@@ -56,6 +57,12 @@ class CLIBaseParams:
 @click.option("--port", type=int, default=8080, help="Server port")
 @click.option("--rig-frame-id", type=str, default="rig", help="Pose graph frame ID for the rig/vehicle body")
 @click.option("--world-frame-id", type=str, default="world", help="Pose graph frame ID for the world/map reference")
+@click.option(
+    "--recenter-world/--no-recenter-world",
+    default=True,
+    help="Recenter the scene near the origin by subtracting the first rig pose translation. "
+    "Prevents rendering artifacts caused by large world-frame offsets.",
+)
 @click.option("--debug", is_flag=True, default=False, help="Start a debugpy remote debugging session")
 @click.option("--debug-port", type=int, default=5678, help="Port on which debugpy will wait for a client to connect")
 @click.pass_context
@@ -133,6 +140,7 @@ def run(params: CLIBaseParams, loader: SequenceLoaderProtocol) -> None:
         port=params.port,
         rig_frame_id=params.rig_frame_id,
         world_frame_id=params.world_frame_id,
+        recenter_world=params.recenter_world,
     )
     server.start()
 

--- a/tools/ncore_vis/components/camera.py
+++ b/tools/ncore_vis/components/camera.py
@@ -583,6 +583,7 @@ class CameraComponent(VisualizationComponent):
             T_camera_world = cam.get_frames_T_sensor_target(
                 self.data_loader.world_frame_id, frame_idx, FrameTimepoint.END
             )
+            T_camera_world = self.data_loader.rebase_world_se3(T_camera_world)
             position, wxyz = se3_to_position_wxyz(T_camera_world)
 
             # Pose frame

--- a/tools/ncore_vis/components/cuboids.py
+++ b/tools/ncore_vis/components/cuboids.py
@@ -124,6 +124,7 @@ class CuboidsComponent(VisualizationComponent):
             for i, obs in enumerate(observations):
                 bbox = obs.bbox3
                 T_bbox_world = se3_from_centroid_euler(bbox.centroid, bbox.rot)
+                T_bbox_world = self.data_loader.rebase_world_se3(T_bbox_world)
                 position, wxyz = se3_to_position_wxyz(T_bbox_world)
                 color = self.renderer.get_class_color(obs.class_id)
 

--- a/tools/ncore_vis/components/lidar.py
+++ b/tools/ncore_vis/components/lidar.py
@@ -416,7 +416,8 @@ class LidarComponent(VisualizationComponent):
         T_sensor_world = sensor.get_frames_T_sensor_target(
             self.data_loader.world_frame_id, frame_idx, FrameTimepoint.END
         )
-        return transform_point_cloud(points_sensor, T_sensor_world)
+        points_world = transform_point_cloud(points_sensor, T_sensor_world)
+        return self.data_loader.rebase_world_points(points_world)
 
     def _get_fused_point_cloud(
         self,

--- a/tools/ncore_vis/components/point_clouds.py
+++ b/tools/ncore_vis/components/point_clouds.py
@@ -273,6 +273,7 @@ class PointCloudsComponent(VisualizationComponent):
                 target_frame_timestamp_us=pc.reference_frame_timestamp_us,
                 pose_graph=self.data_loader.pose_graph,
             ).xyz
+            points_world = self.data_loader.rebase_world_points(points_world)
 
             colors = self._colorize_points(source_id, pc, points_world)
 

--- a/tools/ncore_vis/components/radar.py
+++ b/tools/ncore_vis/components/radar.py
@@ -414,7 +414,8 @@ class RadarComponent(VisualizationComponent):
         T_sensor_world = sensor.get_frames_T_sensor_target(
             self.data_loader.world_frame_id, frame_idx, FrameTimepoint.END
         )
-        return transform_point_cloud(points_sensor, T_sensor_world)
+        points_world = transform_point_cloud(points_sensor, T_sensor_world)
+        return self.data_loader.rebase_world_points(points_world)
 
     def _get_fused_point_cloud(
         self,

--- a/tools/ncore_vis/components/trajectory.py
+++ b/tools/ncore_vis/components/trajectory.py
@@ -109,6 +109,8 @@ class TrajectoryComponent(VisualizationComponent):
         if poses.shape[0] == 0:
             return
 
+        poses = self.data_loader.rebase_world_se3(poses)
+
         with self.client.atomic():
             for i in range(poses.shape[0]):
                 T = poses[i]
@@ -178,6 +180,7 @@ class TrajectoryComponent(VisualizationComponent):
                 self._rig_frame_handle.visible = False
             return
 
+        pose = self.data_loader.rebase_world_se3(pose)
         position, wxyz = se3_to_position_wxyz(pose)
 
         if self._rig_frame_handle is None:

--- a/tools/ncore_vis/data_loader.py
+++ b/tools/ncore_vis/data_loader.py
@@ -54,10 +54,12 @@ class DataLoader:
         loader: SequenceLoaderProtocol,
         rig_frame_id: Optional[str] = "rig",
         world_frame_id: str = "world",
+        recenter_world: bool = True,
     ) -> None:
         self._loader: SequenceLoaderProtocol = loader
         self._rig_frame_id: Optional[str] = rig_frame_id
         self._world_frame_id: str = world_frame_id
+        self._recenter_world: bool = recenter_world
         self._warned_pose_paths: set = set()
 
         # Build cuboid DataFrame and tracks eagerly (thread-safe: done once at init)
@@ -99,6 +101,69 @@ class DataLoader:
     def world_frame_id(self) -> str:
         """Pose graph frame ID for the world/map reference."""
         return self._world_frame_id
+
+    # ------------------------------------------------------------------
+    # World recentering
+    # ------------------------------------------------------------------
+
+    @functools.cached_property
+    def world_origin_offset(self) -> np.ndarray:
+        """Translation offset subtracted from world coordinates to place the scene near the origin.
+
+        When ``recenter_world`` is enabled, returns the translation component of the
+        first rig-to-world pose (i.e. the rig position at t=0).  This ensures that all
+        rendered geometry is close to the coordinate origin, preventing floating-point
+        precision issues in the WebGL renderer.
+
+        Returns ``[0, 0, 0]`` when recentering is disabled or trajectory data is unavailable.
+        """
+        if not self._recenter_world:
+            return np.zeros(3, dtype=np.float64)
+
+        if self._rig_frame_id is None:
+            return np.zeros(3, dtype=np.float64)
+
+        interval = self._loader.sequence_timestamp_interval_us
+        try:
+            poses = self.pose_graph.evaluate_poses(
+                self._rig_frame_id, self._world_frame_id, np.array([interval.start], dtype=np.uint64)
+            )
+        except KeyError:
+            return np.zeros(3, dtype=np.float64)
+
+        offset = poses[0, :3, 3].astype(np.float64).copy()
+        logger.info("World origin offset (recenter): [%.2f, %.2f, %.2f]", offset[0], offset[1], offset[2])
+        return offset
+
+    def rebase_world_se3(self, T: np.ndarray) -> np.ndarray:
+        """Subtract :attr:`world_origin_offset` from the translation of SE3 matrix/matrices.
+
+        Args:
+            T: SE3 matrix of shape ``[4, 4]`` or batch ``[N, 4, 4]``.
+
+        Returns:
+            *T* with the translation column adjusted.
+        """
+        offset = self.world_origin_offset
+        if not offset.any():
+            return T
+        T[..., :3, 3] -= offset
+        return T
+
+    def rebase_world_points(self, points: np.ndarray) -> np.ndarray:
+        """Subtract :attr:`world_origin_offset` from XYZ point coordinates.
+
+        Args:
+            points: Array of shape ``[N, 3]`` or ``[N, 3+]``.
+
+        Returns:
+            *points* with XYZ columns adjusted.
+        """
+        offset = self.world_origin_offset
+        if not offset.any():
+            return points
+        points[:, :3] -= offset
+        return points
 
     @functools.lru_cache(maxsize=None)
     def get_camera_sensor(self, camera_id: str) -> CameraSensorProtocol:

--- a/tools/ncore_vis/server.py
+++ b/tools/ncore_vis/server.py
@@ -45,17 +45,22 @@ class NCoreVisServer:
         port: int,
         rig_frame_id: Optional[str] = "rig",
         world_frame_id: str = "world",
+        recenter_world: bool = True,
     ) -> None:
         self._loader: SequenceLoaderProtocol = loader
         self._host: str = host
         self._port: int = port
         self._rig_frame_id: Optional[str] = rig_frame_id
         self._world_frame_id: str = world_frame_id
+        self._recenter_world: bool = recenter_world
 
     def start(self) -> None:
         """Create the data loader, start the viser server, and block forever."""
         self._data_loader = DataLoader(
-            self._loader, rig_frame_id=self._rig_frame_id, world_frame_id=self._world_frame_id
+            self._loader,
+            rig_frame_id=self._rig_frame_id,
+            world_frame_id=self._world_frame_id,
+            recenter_world=self._recenter_world,
         )
         self._renderers: Dict[int, NCoreVisRenderer] = {}
 


### PR DESCRIPTION
Some datasets (like waymo) might have large local world offsets that can cause rendering artifacts in WebGL due to floating-point precision issues and requires explicitl initial recentering to the scene in the viewer. This change avoids both issues by allowing to recenter to the first pose (if available) to the viewers origin.

Example of waymo data rendered correctly

<img width="838" height="704" alt="image" src="https://github.com/user-attachments/assets/aee57ae1-c0a9-4705-b478-62b15afd3877" />

This pull request adds a new "recenter world" feature to the visualization tool, allowing users to shift the entire scene so that it is centered near the origin. This helps prevent rendering artifacts caused by large world-frame offsets. The feature is exposed as a CLI option and is implemented throughout the data loading and rendering pipeline to adjust all relevant world-coordinate data.

**New feature: World recentering**

* Added a `--recenter-world/--no-recenter-world` CLI option (default: enabled) to control whether the scene is shifted to the origin by subtracting the first rig pose translation. This is reflected in the `CLIBaseParams` dataclass and passed through the CLI, server, and data loader layers. [[1]](diffhunk://#diff-045ad5f6bb8bf0c8e1cb570086f9fe58bde5a4a2451b72cdc36af4d91c54b22cR50) [[2]](diffhunk://#diff-045ad5f6bb8bf0c8e1cb570086f9fe58bde5a4a2451b72cdc36af4d91c54b22cR60-R65) [[3]](diffhunk://#diff-045ad5f6bb8bf0c8e1cb570086f9fe58bde5a4a2451b72cdc36af4d91c54b22cR143) [[4]](diffhunk://#diff-9ca2279f918cea3562f7d6388b5fd652d85e9aacb78f1c6e01df1ff78b720edcR48-R63) [[5]](diffhunk://#diff-5af85b1b63ea1575bb1968bd2bff382d5e72f3d13be5be426fa8458a220c7720R57-R62)
* Implemented `world_origin_offset`, `rebase_world_se3`, and `rebase_world_points` methods in `DataLoader` to compute and apply the translation offset for recentering world coordinates.

**Integration into rendering pipeline**

* Updated camera, cuboid, lidar, radar, and trajectory components to use the new recentering logic by calling `rebase_world_se3` or `rebase_world_points` before rendering world-coordinate data. This ensures all rendered geometry is consistently shifted. [[1]](diffhunk://#diff-e701576bcdf48a208f5af48973d1cf57031b4038f56056daf563a56534b79126R586) [[2]](diffhunk://#diff-7607ce975b7aa967650e986a0c3b6e70671ca8cf2a273c7c7dbee5463442e273R127) [[3]](diffhunk://#diff-c52af9467ef85a11cc21466ef8502a565313f89e1e6c015d58f28523057d4247L419-R420) [[4]](diffhunk://#diff-76738faa1ef2cfe797073408c8638c854514e7c775c9b1a078d59ab57ad38fbeR276) [[5]](diffhunk://#diff-c97493804f44c90d10324df6ad1a32805e8b250ccd05921b36a873d7f3d95fa9L417-R418) [[6]](diffhunk://#diff-6480b7c8c34f0a424df40d0fbb9fb8123481cc1bb7cd212abbb1f77d453dde53R112-R113) [[7]](diffhunk://#diff-6480b7c8c34f0a424df40d0fbb9fb8123481cc1bb7cd212abbb1f77d453dde53R183)
