### PR TITLE
build: Specify wheel version via embed label

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,6 +32,9 @@ test --test_output=errors
 # Config for running tests without GPU (e.g., CPU-only CI runners)
 test:no-gpu --test_env=NCORE_NO_GPU_TESTS=1
 
+# Wheel versioning
+build --embed_label=19.0.0
+
 # Mypy aspect registration + enable by default
 build --aspects //bazel/typing:aspects.bzl%mypy_aspect
 build --output_groups=+mypy

--- a/.cog.toml
+++ b/.cog.toml
@@ -15,12 +15,12 @@ tag_prefix = "v"
 # "HEAD" allows usage from jj's detached HEAD mode
 branch_whitelist = ["main", "HEAD"]
 
-# Update the Python wheel version in the Bazel build file before the bump commit.
+# Update the Python wheel version / embed_label in the bazel.rc file before the bump commit
 pre_bump_hooks = [
-    """sed -i 's/version = "[0-9]*\\.[0-9]*\\.[0-9]*"/version = "{{version}}"/g' ncore/BUILD.bazel""",
+    """sed -i 's/embed_label="[0-9]*\\.[0-9]*\\.[0-9]*"/embed_label="{{version}}"/g' .bazelrc""",
 ]
 
-# Remove the local tag created by cog bump; tagging is handled by GH releases / CI.
+# Remove the local tag created by cog bump; tagging is handled by GH releases / CI
 post_bump_hooks = [
     "git tag --delete {{version_tag}}",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: bazelisk run //ncore:ncore_wheel.publish -- --repository pypi --verbose --skip-existing --non-interactive
+        run: bazelisk run //ncore:ncore_wheel.publish -- --stamp --repository pypi --verbose --skip-existing --non-interactive
 
       - name: Print installation instructions
         run: |

--- a/ncore/BUILD.bazel
+++ b/ncore/BUILD.bazel
@@ -67,7 +67,12 @@ py_wheel(
         "universal_pathlib",
     ],
     summary = "A unified data format and library for AV / robotics",
-    version = "19.0.0",
+    # Build / deploy wheels:
+    # - bazel build //ncore:ncore_wheel.dist --stamp --embed_label=<VERSION>
+    # - bazel run //ncore:ncore_wheel.publish -- --stamp --embed_label=<VERSION> --repository pypi --verbose --skip-existing --non-interactive
+    #
+    # Version is set via --embed_label and requires calling targets with `--stamp`, default is set in .bazelrc
+    version = "{BUILD_EMBED_LABEL}",
     deps = [
         ":ncore_pkg",
     ],


### PR DESCRIPTION
Allows to overwrite version on demand

---

This pull request updates the versioning and build process for the Python wheel, shifting from hardcoded version numbers in Bazel build files to using Bazel's `embed_label` mechanism. This change centralizes version management, improves automation for releases, and ensures consistent versioning across builds and CI. The most important changes are:

**Build and Versioning Improvements:**

* Updated `.bazelrc` to set a default `embed_label` for builds, enabling Bazel to embed the version label (wheel version) during the build process.
* Modified `ncore/BUILD.bazel` to use `{BUILD_EMBED_LABEL}` as the wheel version, so the version is now injected via Bazel's stamping mechanism instead of being hardcoded. Includes comments explaining the new build and deployment process.

**Release Automation:**

* Changed `.cog.toml` pre-bump hooks to update the `embed_label` in `.bazelrc` instead of the version in `ncore/BUILD.bazel`, aligning automated version bumps with the new versioning approach.

**Continuous Integration:**

* Updated the PyPI publish step in `.github/workflows/ci.yml` to always use the `--stamp` flag, ensuring the correct version label is embedded in published wheels.
