### PR TITLE
fix(ci): move --stamp before -- so Bazel processes it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: bazelisk run //ncore:ncore_wheel.publish -- --stamp --repository pypi --verbose --skip-existing --non-interactive
+        run: bazelisk run //ncore:ncore_wheel.publish --stamp -- --repository pypi --verbose --skip-existing --non-interactive
 
       - name: Print installation instructions
         run: |

--- a/ncore/BUILD.bazel
+++ b/ncore/BUILD.bazel
@@ -69,7 +69,7 @@ py_wheel(
     summary = "A unified data format and library for AV / robotics",
     # Build / deploy wheels:
     # - bazel build //ncore:ncore_wheel.dist --stamp --embed_label=<VERSION>
-    # - bazel run //ncore:ncore_wheel.publish -- --stamp --embed_label=<VERSION> --repository pypi --verbose --skip-existing --non-interactive
+    # - bazel run //ncore:ncore_wheel.publish --stamp --embed_label=<VERSION> -- --repository pypi --verbose --skip-existing --non-interactive
     #
     # Version is set via --embed_label and requires calling targets with `--stamp`, default is set in .bazelrc
     version = "{BUILD_EMBED_LABEL}",


### PR DESCRIPTION
## Summary

Fixes the PyPI publish failure introduced in #95.

`--stamp` was placed after `--` in the `bazelisk run` command, so it was passed to twine (the publish script) instead of to Bazel. Without `--stamp`, Bazel doesn't resolve `{BUILD_EMBED_LABEL}` — the wheel gets a literal invalid version string that PyPI rejects (exit code 2).

## Changes

- Move `--stamp` before `--` in the CI publish step
- Fix the corresponding documentation comment in `ncore/BUILD.bazel`