### PR TITLE
docs: add project site link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ SPDX-License-Identifier: Apache-2.0
 
 NCore provides data representations, APIs, and tools to support data-driven neural reconstructions with a focus on robotics and autonomous vehicle data.
 
+**Project Site:** [research.nvidia.com/labs/sil/projects/ncore](https://research.nvidia.com/labs/sil/projects/ncore)
+
 ## Key Features
 
 - **Neural Reconstruction** - Designed for data-driven neural 3D reconstruction and simulation applications


### PR DESCRIPTION
## Summary
- Adds a link to the project site (https://research.nvidia.com/labs/sil/projects/ncore) in the README, right below the description.