### PR TITLE
chore(version): v19.1.1

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,7 +33,7 @@ test --test_output=errors
 test:no-gpu --test_env=NCORE_NO_GPU_TESTS=1
 
 # Wheel versioning
-build --embed_label=19.1.0
+build --embed_label=19.1.1
 
 # Mypy aspect registration + enable by default
 build --aspects //bazel/typing:aspects.bzl%mypy_aspect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ All notable changes to the NCore project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - - -
+## [v19.1.1](https://github.com/NVIDIA/ncore/compare/5a278ff4d250f0ee6c1a2a81bdeb7c40367c2f90..v19.1.1) - 2026-05-08
+
+This is a bugfix release to allow using the V4 compat APIs in `PYTHONOPTIMIZE=1` settings.
+
+#### 🪲 Fixed
+- (**data**) extract walrus-operator assignments from assert statements - ([5a278ff](https://github.com/NVIDIA/ncore/commit/5a278ff4d250f0ee6c1a2a81bdeb7c40367c2f90)) - Janick Martinez Esturo
+
+- - -
+
 ## [v19.1.0](https://github.com/NVIDIA/ncore/compare/bb21e4a5ed5eb686be50ee29498eac84ce785574..v19.1.0) - 2026-05-07
 
 ### Highlights


### PR DESCRIPTION
This pull request is a bugfix release updating the project to version 19.1.1. The primary focus is to address a compatibility issue with the V4 APIs when running under optimized Python settings (`PYTHONOPTIMIZE=1`). The release also includes a specific fix for handling walrus-operator assignments in assert statements.

Version update and bugfix:

* Updated the build label in `.bazelrc` from `19.1.0` to `19.1.1` to reflect the new release version.
* Added a new changelog entry for v19.1.1 in `CHANGELOG.md`, documenting the bugfix for extracting walrus-operator assignments from assert statements and improved compatibility with `PYTHONOPTIMIZE=1`.