### PR TITLE
fix(bazel): patch protobuf for NixOS PATH compatibility

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,6 +33,18 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 
+## protobuf
+# Patch protobuf to add use_default_shell_env=True to embed_edition_defaults.
+# Without this, ctx.actions.run_shell runs with an empty PATH, which breaks on
+# NixOS where tools like sed/cp live in /nix/store and are not at /usr/bin.
+single_version_override(
+    module_name = "protobuf",
+    patch_strip = 1,
+    patches = [
+        "//bazel/protobuf:protobuf_use_default_shell_env.patch",
+    ],
+)
+
 ## rules_python
 bazel_dep(name = "rules_python", version = "1.2.0")
 

--- a/bazel/protobuf/BUILD.bazel
+++ b/bazel/protobuf/BUILD.bazel
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exports_files(["protobuf_use_default_shell_env.patch"])

--- a/bazel/protobuf/protobuf_use_default_shell_env.patch
+++ b/bazel/protobuf/protobuf_use_default_shell_env.patch
@@ -1,0 +1,10 @@
+--- a/editions/defaults.bzl
++++ b/editions/defaults.bzl
+@@ -70,6 +70,7 @@ def _embed_edition_defaults_impl(ctx):
+         fail("Unknown encoding %s" % ctx.attr.encoding)
+     ctx.actions.run_shell(
+         outputs = [ctx.outputs.output],
++        use_default_shell_env = True,
+         inputs = [ctx.file.defaults, ctx.file.template],
+         tools = [ctx.executable._escape],
+         command = """


### PR DESCRIPTION
## Summary

- Patches protobuf@29.1 `embed_edition_defaults` rule to add `use_default_shell_env = True` to its `ctx.actions.run_shell()` call
- Without this, the action runs with an empty `PATH`, causing `sed`/`cp` not found errors on NixOS (where tools live in `/nix/store`, not `/usr/bin`)

## Root Cause

Protobuf's `_embed_edition_defaults_impl` in `editions/defaults.bzl` uses `ctx.actions.run_shell()` without `use_default_shell_env = True`. In Bazel 8, this creates a hermetic action environment with no `PATH` at all — `--action_env=PATH` and `--noincompatible_strict_action_env` only apply to actions that opt in via `use_default_shell_env`. On NixOS there are no tools at standard FHS paths like `/usr/bin/sed`, so the build fails.

## Changes

| File | Description |
|------|-------------|
| `MODULE.bazel` | `single_version_override` for protobuf with the patch |
| `bazel/protobuf/BUILD.bazel` | Exports the patch file |
| `bazel/protobuf/protobuf_use_default_shell_env.patch` | One-line patch adding `use_default_shell_env = True` |

## Testing

- `bazel build //...` — passes (912 actions)
- `bazel test --config=no-gpu //...` — 25/28 pass (3 failures are pre-existing Python 3.8 + PyTorch `libtorch_cpu.so` incompatibility, unrelated)