### PR TITLE
fix(ncore_vis): default cuboid source filter to first available source

### DIFF
--- a/tools/ncore_vis/components/camera.py
+++ b/tools/ncore_vis/components/camera.py
@@ -213,7 +213,10 @@ class CameraComponent(VisualizationComponent):
 
         # Shared overlay settings (single values applied to all cameras)
         self._overlay_cuboids: bool = False
-        self._cuboid_source: str = LabelSource.AUTOLABEL.name
+        cuboid_label_source_names = self.data_loader.get_cuboid_label_source_names()
+        self._cuboid_label_source_name: str = (
+            cuboid_label_source_names[0] if cuboid_label_source_names else LabelSource.AUTOLABEL.name
+        )
         self._project_lidar: bool = False
         self._project_lidar_id: str = ""
         self._project_mode: str = "rolling-shutter"
@@ -296,8 +299,8 @@ class CameraComponent(VisualizationComponent):
                 )
                 source_dropdown = self.client.gui.add_dropdown(
                     "Cuboid Source",
-                    options=[s.name for s in LabelSource],
-                    initial_value=self._cuboid_source,
+                    options=cuboid_label_source_names if cuboid_label_source_names else [LabelSource.AUTOLABEL.name],
+                    initial_value=self._cuboid_label_source_name,
                     hint="Label source for cuboid overlays on all cameras",
                 )
                 self._bind_overlay_settings(
@@ -583,7 +586,7 @@ class CameraComponent(VisualizationComponent):
 
         @source_dropdown.on_update
         def _(_: viser.GuiEvent) -> None:  # type: ignore[no-redef]
-            self._cuboid_source = source_dropdown.value
+            self._cuboid_label_source_name = source_dropdown.value
             self._refresh_all_cameras()
 
     def _bind_lidar_projection_settings(
@@ -1327,7 +1330,7 @@ class CameraComponent(VisualizationComponent):
         # Iterate over all tracks; interpolate each to the mid-frame time.
         for track in self.data_loader.get_cuboid_tracks():
             # Filter by label source
-            if track.source.name != self._cuboid_source:
+            if track.source.name != self._cuboid_label_source_name:
                 continue
 
             if (obs := track.interpolate_at(mid_timestamp_us, max_clamp_us=max_clamp_us)) is None:

--- a/tools/ncore_vis/components/cuboids.py
+++ b/tools/ncore_vis/components/cuboids.py
@@ -45,11 +45,17 @@ class CuboidsComponent(VisualizationComponent):
         self._enabled: bool = True
         self._show_labels: bool = False
 
-        default_source = LabelSource.AUTOLABEL.name
-
         # Don't create the tab if there are no cuboid observations.
         if not self.data_loader.get_cuboid_tracks():
             return
+
+        # Determine available sources from the actual data
+        available_cuboid_label_source_names = self.data_loader.get_cuboid_label_source_names()
+        if not available_cuboid_label_source_names:
+            return
+
+        default_cuboid_label_source_name = available_cuboid_label_source_names[0]
+        self._cuboid_source = default_cuboid_label_source_name
 
         with tab_group.add_tab("Cuboids"):
             cuboid_checkbox = self.client.gui.add_checkbox(
@@ -57,8 +63,8 @@ class CuboidsComponent(VisualizationComponent):
             )
             source_dropdown = self.client.gui.add_dropdown(
                 "Cuboid Source",
-                options=[s.name for s in LabelSource],
-                initial_value=default_source,
+                options=available_cuboid_label_source_names,
+                initial_value=default_cuboid_label_source_name,
                 hint="Label source for cuboid observations",
             )
             label_checkbox = self.client.gui.add_checkbox(

--- a/tools/ncore_vis/data_loader.py
+++ b/tools/ncore_vis/data_loader.py
@@ -406,3 +406,9 @@ class DataLoader:
             no cuboid observations are available.
         """
         return self._cuboid_tracks
+
+    def get_cuboid_label_source_names(self) -> List[str]:
+        """Return sorted list of unique label source names present in cuboid observations."""
+        if self._cuboid_df.empty:
+            return []
+        return sorted(self._cuboid_df["source"].unique().tolist())


### PR DESCRIPTION
## Summary

- Derive cuboid label source dropdown options from actual data instead of listing all `LabelSource` enum values
- Default to the first source found, so cuboids show up without manual selection
- Applies to both the 3D cuboids panel and the camera cuboid overlay dropdown
- Add `DataLoader.get_cuboid_sources()` for clean access to available sources

## Motivation

The cuboid source dropdown previously listed all `LabelSource` enum values (`AUTOLABEL`, `EXTERNAL`, `GT_SYNTHETIC`, `GT_ANNOTATION`, `UNKNOWN`) and defaulted to `AUTOLABEL`. For datasets that only have `EXTERNAL` labels (e.g., KITTI tracklets), cuboids would not render until the user manually switched the dropdown.

## Changes

| File | Description |
|------|-------------|
| `tools/ncore_vis/data_loader.py` | Add `get_cuboid_sources()` method |
| `tools/ncore_vis/components/cuboids.py` | Use available sources for dropdown, default to first |
| `tools/ncore_vis/components/camera.py` | Same fix for camera cuboid overlay dropdown |