### PR TITLE
fix(ncore_vis): handle grayscale camera images

### DIFF
--- a/tools/ncore_vis/components/camera.py
+++ b/tools/ncore_vis/components/camera.py
@@ -787,8 +787,11 @@ class CameraComponent(VisualizationComponent):
             )
             self._poses[camera_id] = pose_handle
 
-            # Image (with optional overlays)
-            image = cam.get_frame_image_array(frame_idx)
+            # Image (with optional overlays) — convert to RGB for viser compatibility
+            pil_img = cam.get_frame_image(frame_idx)
+            if pil_img.mode != "RGB":
+                pil_img = pil_img.convert("RGB")
+            image = np.asarray(pil_img)
 
             if self._project_lidar:
                 try:


### PR DESCRIPTION
## Summary

Use `get_frame_image()` (PIL) instead of `get_frame_image_array()` (numpy) in the camera visualizer, converting to RGB before passing to viser. This fixes an `IndexError` on grayscale cameras (e.g., KITTI image_00/image_01) where viser expects a 3-channel array but gets a 2D `(H, W)` array.

## Changes

| File | Description |
|------|-------------|
| `tools/ncore_vis/components/camera.py` | Convert PIL image to RGB before `np.asarray()` |

Single-line logic change, no API modifications.