### PR TITLE
feat(data_converter): add KITTI raw dataset to NCore V4 converter

### DIFF
--- a/docs/conversions/index.rst
+++ b/docs/conversions/index.rst
@@ -5,12 +5,13 @@ Data Conversions
 ================
 
 NCore provides conversion tools for importing 3rd-party dataset formats into
-the NCore V4 component-based format. Supported formats include Waymo, COLMAP
-(including ScanNet++), and PAI.
+the NCore V4 component-based format. Supported formats include KITTI, Waymo,
+COLMAP (including ScanNet++), and PAI.
 
 .. toctree::
    :maxdepth: 1
 
+   kitti/kitti
    waymo/waymo
    colmap/colmap
    pai/pai

--- a/docs/conversions/kitti/kitti.rst
+++ b/docs/conversions/kitti/kitti.rst
@@ -1,0 +1,66 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+KITTI Dataset
+=============
+
+The NCore KITTI tool converts data from the
+`KITTI Vision Benchmark Suite <https://www.cvlibs.net/datasets/kitti/>`_
+raw data format (synced+rectified) into NCore V4 format.
+
+.. _kitti_data_conventions:
+
+Conventions
+-----------
+
+The KITTI raw dataset provides data from 6 sensors:
+
+Camera Sensors
+^^^^^^^^^^^^^^
+    1. **Left Grayscale (camera_gray_left)** -- Point Grey Flea 2, rectified
+    2. **Right Grayscale (camera_gray_right)** -- Point Grey Flea 2, rectified
+    3. **Left Color (camera_color_left)** -- Point Grey Flea 2, rectified
+    4. **Right Color (camera_color_right)** -- Point Grey Flea 2, rectified
+
+All cameras use CCD sensors (global shutter) and images are provided
+rectified with zero distortion. The camera intrinsics are stored using
+:class:`~ncore.data.OpenCVPinholeCameraModelParameters` with distortion
+coefficients set to zero.
+
+LiDAR Sensor
+^^^^^^^^^^^^^
+    1. **Top LiDAR (lidar_top)** -- Velodyne HDL-64E, 64 layers, ~100k points/frame
+
+Point clouds are stored as unstructured ray-bundle data (no structured
+spinning lidar model, no intrinsic sensor model). The original KITTI binary
+format provides only raw ``(x, y, z, reflectance)`` per point without
+row/column structure or per-beam calibration, so ``model_element`` is not
+set. Approximate per-point timestamps are reconstructed from azimuth angles
+using the known spin timing of the Velodyne HDL-64E (10 Hz,
+counter-clockwise rotation).
+
+GPS/IMU
+^^^^^^^
+The OXTS RT 3003 GPS/INS provides 30-field measurements at 10 Hz. Ego poses
+are computed via Mercator projection (first frame as origin) and stored as
+dynamic ``("rig", "world")`` poses. Raw OXTS measurements are preserved as
+component-level generic data on the poses component.
+
+3D Annotations
+^^^^^^^^^^^^^^
+Tracklet labels (``tracklet_labels.xml``) are parsed and stored as
+:class:`~ncore.data.v4.CuboidsComponent` observations in the velodyne
+coordinate frame. The viewer transforms them to world coordinates at
+runtime via the pose graph.
+
+Usage
+-----
+
+.. code-block:: bash
+
+   bazel run //tools/data_converter/kitti -- \
+       --root-dir /path/to/2011_09_26 \
+       --output-dir /path/to/output \
+       kitti-v4
+
+See ``tools/data_converter/kitti/README.md`` for full option documentation.

--- a/tools/data_converter/kitti/BUILD.bazel
+++ b/tools/data_converter/kitti/BUILD.bazel
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@ncore_pip_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel/pytest:defs.bzl", "pytest_test")
+
+# KITTI-specific utilities: calibration parsing, OXTS poses, velodyne loading, tracklets
+py_library(
+    name = "pylib_utils",
+    srcs = ["utils.py"],
+    deps = [
+        requirement("numpy"),
+        requirement("scipy"),
+        "//ncore/impl/common:pylib_transformations",
+    ],
+)
+
+# Converter library (config, converter class, CLI registration)
+py_library(
+    name = "pylib",
+    srcs = ["converter.py"],
+    deps = [
+        ":pylib_utils",
+        requirement("click"),
+        requirement("numpy"),
+        requirement("tqdm"),
+        requirement("universal_pathlib"),
+        "//ncore:pylib",
+        "//tools/data_converter:pylib_cli",
+    ],
+)
+
+# Standalone CLI binary
+py_binary(
+    name = "convert",
+    srcs = ["main.py"],
+    main = "main.py",
+    deps = [":pylib"],
+)
+
+alias(
+    name = "kitti",
+    actual = ":convert",
+)
+
+# Integration test for the KITTI converter (requires KITTI_RAW_DIR env var)
+pytest_test(
+    name = "pytest_converter",
+    srcs = ["converter_test.py"],
+    python_versions = ["3.11"],
+    tags = ["manual"],  # Only run when explicitly requested (needs external data)
+    deps = [
+        ":pylib",
+        requirement("numpy"),
+        requirement("parameterized"),
+        requirement("universal_pathlib"),
+        "//ncore:pylib",
+    ],
+)

--- a/tools/data_converter/kitti/NOTICE
+++ b/tools/data_converter/kitti/NOTICE
@@ -1,0 +1,35 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Notice
+
+This package includes code derived from
+pykitti (<https://github.com/utiasSTARS/pykitti>).
+
+## pykitti - [MIT](https://github.com/utiasSTARS/pykitti/blob/master/LICENSE)
+
+   ```text
+MIT License
+
+Copyright (c) 2017 Lee Clement
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+   ```

--- a/tools/data_converter/kitti/README.md
+++ b/tools/data_converter/kitti/README.md
@@ -1,0 +1,97 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# NCore KITTI Converter
+
+Convert KITTI Raw dataset to NCore V4 format.
+
+## Overview
+
+This module provides tooling for converting KITTI Raw synchronized+rectified data to NCore V4
+format. It is a standalone Bazel module that depends on the parent `ncore` module.
+
+Supported sensors:
+- 4 cameras (2 grayscale, 2 color) with global-shutter intrinsics
+- 1 Velodyne HDL-64E lidar with per-point azimuth-based timestamps
+- OXTS/GPS ego poses (Mercator-projected, rebased to first frame)
+- 3D tracklet annotations (cuboids in Velodyne frame)
+
+## Prerequisites
+
+- NCore build requirements (see <CONTRIBUTING.md>)
+- KITTI Raw data (download from <https://www.cvlibs.net/datasets/kitti/raw_data.php>)
+  - Synced+rectified data
+  - Calibration files
+  - Tracklet labels (optional)
+
+## Usage
+
+```bash
+bazel run //tools/data_converter/kitti -- \
+    --root-dir /path/to/kitti/2011_09_26 \
+    --output-dir /path/to/output/ncore \
+    kitti-v4
+```
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--root-dir` | Path to date directory containing calibration files and drive sequences | Required |
+| `--output-dir` | Path where converted data will be saved | Required |
+| `--verbose` | Enable debug logging | False |
+| `--no-cameras` | Disable exporting cameras | False |
+| `--camera-id` | Camera IDs to export (all if not specified) | All |
+| `--no-lidars` | Disable exporting lidars | False |
+| `--lidar-id` | Lidar IDs to export (all if not specified) | All |
+| `--store-type` | Output store type (`itar` or `directory`) | `itar` |
+| `--profile` | Component group profile (`default`, `separate-sensors`, `separate-all`) | `separate-sensors` |
+| `--sequence-meta` / `--no-sequence-meta` | Generate sequence meta-data file | True |
+
+### Examples
+
+Convert all sequences in a date directory:
+
+```bash
+bazel run //tools/data_converter/kitti -- \
+    --root-dir /data/kitti/2011_09_26 \
+    --output-dir /data/ncore/kitti \
+    kitti-v4
+```
+
+Convert only color cameras and lidar:
+
+```bash
+bazel run //tools/data_converter/kitti -- \
+    --root-dir /data/kitti/2011_09_26 \
+    --output-dir /data/ncore/kitti \
+    --camera-id camera_color_left \
+    --camera-id camera_color_right \
+    kitti-v4
+```
+
+Convert to directory format:
+
+```bash
+bazel run //tools/data_converter/kitti -- \
+    --root-dir /data/kitti/2011_09_26 \
+    --output-dir /data/ncore/kitti \
+    --store-type directory \
+    kitti-v4
+```
+
+## Sensor IDs
+
+| KITTI Directory | NCore Sensor ID |
+|----------------|-----------------|
+| `image_00` | `camera_gray_left` |
+| `image_01` | `camera_gray_right` |
+| `image_02` | `camera_color_left` |
+| `image_03` | `camera_color_right` |
+| `velodyne_points` | `lidar_top` |
+
+## License
+
+Apache 2.0 - See LICENSE file in the repository root.

--- a/tools/data_converter/kitti/converter.py
+++ b/tools/data_converter/kitti/converter.py
@@ -1,0 +1,612 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""KITTI Raw Dataset to NCore V4 converter."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from dataclasses import dataclass
+from typing import Literal
+
+import click
+import numpy as np
+import tqdm
+
+from upath import UPath
+
+from ncore.impl.common.transformations import HalfClosedInterval, se3_inverse
+from ncore.impl.data.types import (
+    BBox3,
+    CuboidTrackObservation,
+    LabelSource,
+    OpenCVPinholeCameraModelParameters,
+    ShutterType,
+)
+from ncore.impl.data.v4.components import (
+    CameraSensorComponent,
+    CuboidsComponent,
+    IntrinsicsComponent,
+    LidarSensorComponent,
+    MasksComponent,
+    PosesComponent,
+    SequenceComponentGroupsReader,
+    SequenceComponentGroupsWriter,
+)
+from ncore.impl.data.v4.types import ComponentGroupAssignments
+from ncore.impl.data_converter.base import FileBasedDataConverter, FileBasedDataConverterConfig
+from tools.data_converter.cli import cli
+from tools.data_converter.kitti.utils import (
+    OXTS_FIELD_NAMES,
+    compute_velodyne_timestamps_us,
+    load_oxts_packets,
+    load_timestamps,
+    load_velodyne_scan,
+    parse_calib_cam_to_cam,
+    parse_calib_rigid,
+    parse_tracklets,
+    poses_from_oxts,
+)
+
+
+# -----------------------------------------------------------------------------
+# Sensor IDs
+# -----------------------------------------------------------------------------
+
+CAMERA_MAP: dict[str, str] = {
+    "image_00": "camera_gray_left",
+    "image_01": "camera_gray_right",
+    "image_02": "camera_color_left",
+    "image_03": "camera_color_right",
+}
+
+LIDAR_ID = "lidar_top"
+
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+
+
+@dataclass(kw_only=True, slots=True)
+class KittiConverter4Config(FileBasedDataConverterConfig):
+    """Configuration for KITTI Raw to NCore V4 conversion."""
+
+    store_type: Literal["itar", "directory"] = "itar"
+    component_group_profile: Literal["default", "separate-sensors", "separate-all"] = "separate-sensors"
+    store_sequence_meta: bool = True
+
+
+# -----------------------------------------------------------------------------
+# Converter
+# -----------------------------------------------------------------------------
+
+
+class KittiConverter4(FileBasedDataConverter):
+    """Dataset preprocessing class for converting KITTI Raw data to NCore V4 format.
+
+    KITTI raw data can be downloaded from https://www.cvlibs.net/datasets/kitti/raw_data.php
+    in the form of synchronized+rectified data folders. Further details on the dataset
+    are available in https://www.cvlibs.net/publications/Geiger2013IJRR.pdf
+    """
+
+    def __init__(self, config: KittiConverter4Config) -> None:
+        super().__init__(config)
+
+        self.component_group_profile: Literal["default", "separate-sensors", "separate-all"] = (
+            config.component_group_profile
+        )
+        self.store_type: Literal["itar", "directory"] = config.store_type
+        self.store_sequence_meta: bool = config.store_sequence_meta
+
+        self.logger = logging.getLogger(__name__)
+
+    @staticmethod
+    def get_sequence_ids(config) -> list[str]:
+        """Discover sequence directories matching *_drive_*_sync pattern."""
+        return [str(p) for p in sorted(UPath(config.root_dir).glob("*_drive_*_sync"))]
+
+    @staticmethod
+    def from_config(config: KittiConverter4Config) -> KittiConverter4:
+        return KittiConverter4(config)
+
+    def convert_sequence(self, sequence_id: str) -> None:
+        """Runs KITTI-specific conversion for a single sequence."""
+
+        sequence_path = UPath(sequence_id)
+        sequence_name = sequence_path.name  # e.g. "2011_09_26_drive_0048_sync"
+
+        self.logger.info(f"Converting sequence: {sequence_name}")
+
+        # Date directory is the parent (contains calibration files)
+        date_dir = sequence_path.parent
+
+        # --- Parse calibration ---------------------------------------------
+        calib_cam = parse_calib_cam_to_cam(str(date_dir / "calib_cam_to_cam.txt"))
+        # Convention: T_a_b transforms points FROM frame a TO frame b
+        T_velo_cam0 = parse_calib_rigid(str(date_dir / "calib_velo_to_cam.txt"))  # velo -> cam0
+        T_rig_velo = parse_calib_rigid(str(date_dir / "calib_imu_to_velo.txt"))  # rig(=IMU) -> velo
+
+        # Derived: velo -> rig
+        T_velo_rig = se3_inverse(T_rig_velo)
+
+        # R_rect_00 extended to 4x4
+        R_rect_00 = calib_cam["R_rect_00"]
+        R_rect_00_4x4 = np.eye(4, dtype=np.float64)
+        R_rect_00_4x4[:3, :3] = R_rect_00
+
+        # --- Load OXTS (ego poses) ----------------------------------------
+        oxts_data_dir = sequence_path / "oxts" / "data"
+        packets, raw_oxts_array = load_oxts_packets(str(oxts_data_dir))
+        T_rig_world, T_world_world_global = poses_from_oxts(packets)
+
+        # Load OXTS timestamps
+        oxts_timestamps = load_timestamps(str(sequence_path / "oxts" / "timestamps.txt"))
+
+        # --- Load sensor timestamps ---------------------------------------
+        lidar_timestamps_start = load_timestamps(str(sequence_path / "velodyne_points" / "timestamps_start.txt"))
+        lidar_timestamps_end = load_timestamps(str(sequence_path / "velodyne_points" / "timestamps_end.txt"))
+        lidar_timestamps = load_timestamps(str(sequence_path / "velodyne_points" / "timestamps.txt"))
+
+        n_frames = len(oxts_timestamps)
+        assert n_frames >= 2, f"Need at least 2 frames, got {n_frames}"
+        assert len(lidar_timestamps_start) == n_frames
+        assert len(lidar_timestamps_end) == n_frames
+
+        # --- Determine active sensors -------------------------------------
+        camera_ids = self.get_active_camera_ids(list(CAMERA_MAP.values()))
+        lidar_ids = self.get_active_lidar_ids([LIDAR_ID])
+
+        # --- Create timestamp interval ------------------------------------
+        # Use the widest possible time range to encompass all sensor data.
+        # The dynamic poses must cover the full interval, so we extend the poses
+        # to match the full sensor time range.
+        pose_timestamps_us = np.array(oxts_timestamps, dtype=np.uint64)
+        all_timestamps = oxts_timestamps + lidar_timestamps_start + lidar_timestamps_end
+        seq_start_us = min(all_timestamps)
+        seq_end_us = max(all_timestamps)
+        sequence_timestamp_interval_us = HalfClosedInterval.from_start_end(
+            seq_start_us,
+            seq_end_us,
+        )
+
+        # Extend pose timestamps to cover sequence interval boundaries.
+        # Replicate boundary poses to cover the full time range.
+        if seq_start_us < int(pose_timestamps_us[0]):
+            pose_timestamps_us = np.concatenate([np.array([seq_start_us], dtype=np.uint64), pose_timestamps_us])
+            T_rig_world = np.concatenate([T_rig_world[:1], T_rig_world], axis=0)
+
+        if seq_end_us > int(pose_timestamps_us[-1]):
+            pose_timestamps_us = np.concatenate([pose_timestamps_us, np.array([seq_end_us], dtype=np.uint64)])
+            T_rig_world = np.concatenate([T_rig_world, T_rig_world[-1:]], axis=0)
+
+        # --- Component group assignments ----------------------------------
+        component_groups = ComponentGroupAssignments.create(
+            camera_ids=camera_ids,
+            lidar_ids=lidar_ids,
+            radar_ids=[],
+            point_clouds_ids=[],
+            camera_labels_ids=[],
+            profile=self.component_group_profile,
+        )
+
+        # --- Create main store writer -------------------------------------
+        store_writer = SequenceComponentGroupsWriter(
+            output_dir_path=self.output_dir / sequence_name,
+            store_base_name=sequence_name,
+            sequence_id=sequence_name,
+            sequence_timestamp_interval_us=sequence_timestamp_interval_us,
+            store_type=self.store_type,
+            generic_meta_data={},
+        )
+
+        # --- Register component writers -----------------------------------
+        poses_writer = store_writer.register_component_writer(
+            PosesComponent.Writer,
+            component_instance_name="default",
+            group_name=component_groups.poses_component_group,
+            generic_meta_data={
+                "calibration_type": "kitti:calib",
+                "egomotion_type": "kitti:oxts",
+            },
+        )
+
+        intrinsics_writer = store_writer.register_component_writer(
+            IntrinsicsComponent.Writer,
+            component_instance_name="default",
+            group_name=component_groups.intrinsics_component_group,
+        )
+
+        masks_writer = store_writer.register_component_writer(
+            MasksComponent.Writer,
+            component_instance_name="default",
+            group_name=component_groups.masks_component_group,
+        )
+
+        # --- Store ego poses ----------------------------------------------
+        poses_writer.store_dynamic_pose(
+            source_frame_id="rig",
+            target_frame_id="world",
+            poses=T_rig_world.astype(np.float32),
+            timestamps_us=pose_timestamps_us,
+        )
+
+        poses_writer.store_static_pose(
+            source_frame_id="world",
+            target_frame_id="world_global",
+            pose=T_world_world_global,
+        )
+
+        # Store raw OXTS as generic data on poses component
+        poses_writer.set_generic_data(
+            data={
+                "oxts_data": raw_oxts_array,
+                "oxts_timestamps_us": np.array(oxts_timestamps, dtype=np.uint64),
+            },
+            meta_data={"oxts_field_names": OXTS_FIELD_NAMES},
+        )
+
+        # --- Decode lidars ------------------------------------------------
+        if LIDAR_ID in lidar_ids:
+            self._decode_lidar(
+                sequence_path=sequence_path,
+                store_writer=store_writer,
+                poses_writer=poses_writer,
+                component_groups=component_groups,
+                T_velo_rig=T_velo_rig,
+                lidar_timestamps_start=lidar_timestamps_start,
+                lidar_timestamps_end=lidar_timestamps_end,
+                n_frames=n_frames,
+            )
+
+        # --- Decode cameras -----------------------------------------------
+        self._decode_cameras(
+            sequence_path=sequence_path,
+            store_writer=store_writer,
+            poses_writer=poses_writer,
+            intrinsics_writer=intrinsics_writer,
+            masks_writer=masks_writer,
+            component_groups=component_groups,
+            camera_ids=camera_ids,
+            calib_cam=calib_cam,
+            T_velo_cam0=T_velo_cam0,
+            T_rig_velo=T_rig_velo,
+            R_rect_00_4x4=R_rect_00_4x4,
+            n_frames=n_frames,
+        )
+
+        # --- Parse and store tracklets ------------------------------------
+        tracklet_path = sequence_path / "tracklet_labels.xml"
+        if tracklet_path.exists():
+            self._decode_tracklets(
+                tracklet_path=tracklet_path,
+                store_writer=store_writer,
+                component_groups=component_groups,
+                lidar_timestamps=lidar_timestamps,
+            )
+
+        # --- Finalize -----------------------------------------------------
+        ncore_4_paths = store_writer.finalize()
+
+        if self.store_sequence_meta:
+            sequence_component_reader = SequenceComponentGroupsReader(ncore_4_paths)
+            sequence_meta_path = self.output_dir / sequence_name / f"{sequence_component_reader.sequence_id}.json"
+
+            with sequence_meta_path.open("w") as f:
+                json.dump(sequence_component_reader.get_sequence_meta().to_dict(), f, indent=2)
+
+            self.logger.info(f"Wrote sequence meta data {str(sequence_meta_path)}")
+
+    def _decode_lidar(
+        self,
+        sequence_path: UPath,
+        store_writer: SequenceComponentGroupsWriter,
+        poses_writer: PosesComponent.Writer,
+        component_groups: ComponentGroupAssignments,
+        T_velo_rig: np.ndarray,
+        lidar_timestamps_start: list[int],
+        lidar_timestamps_end: list[int],
+        n_frames: int,
+    ) -> None:
+        """Decode and store all lidar frames."""
+        # Create lidar sensor writer
+        lidar_writer = store_writer.register_component_writer(
+            LidarSensorComponent.Writer,
+            component_instance_name=LIDAR_ID,
+            group_name=component_groups.lidar_component_groups.get(LIDAR_ID),
+            generic_meta_data={},
+        )
+
+        # Store lidar extrinsic (velo -> rig)
+        poses_writer.store_static_pose(
+            source_frame_id=LIDAR_ID,
+            target_frame_id="rig",
+            pose=T_velo_rig.astype(np.float32),
+        )
+
+        velodyne_data_dir = sequence_path / "velodyne_points" / "data"
+
+        for i in tqdm.tqdm(range(n_frames), desc=f"Process {LIDAR_ID}"):
+            # Load point cloud
+            bin_path = velodyne_data_dir / f"{i:010d}.bin"
+            if not bin_path.exists():
+                self.logger.warning(f"Missing velodyne file: {bin_path}")
+                continue
+
+            points = load_velodyne_scan(str(bin_path))
+
+            # Frame timestamps
+            frame_start_us = lidar_timestamps_start[i]
+            frame_end_us = lidar_timestamps_end[i]
+
+            # Compute per-point timestamps from azimuth
+            point_timestamps_us = compute_velodyne_timestamps_us(points, frame_start_us, frame_end_us)
+
+            # Compute direction and distance from raw xyz
+            xyz = points[:, :3]
+            distance_m = np.linalg.norm(xyz, axis=1, keepdims=False).astype(np.float32)
+
+            # Avoid division by zero
+            valid_mask = distance_m > 0
+            direction = np.zeros_like(xyz)
+            direction[valid_mask] = xyz[valid_mask] / distance_m[valid_mask, np.newaxis]
+
+            # Intensity (reflectance already in [0,1] range for KITTI)
+            intensity = points[:, 3:4].T  # [1, N]
+
+            # Store frame (model_element=None since KITTI velodyne has no structured model)
+            lidar_writer.store_frame(
+                direction=direction.astype(np.float32),
+                timestamp_us=point_timestamps_us,
+                model_element=None,
+                distance_m=distance_m.reshape(1, -1),  # [1, N] single return
+                intensity=intensity.astype(np.float32),
+                frame_timestamps_us=np.array([frame_start_us, frame_end_us], dtype=np.uint64),
+                generic_data={},
+                generic_meta_data={},
+            )
+
+    def _decode_cameras(
+        self,
+        sequence_path: UPath,
+        store_writer: SequenceComponentGroupsWriter,
+        poses_writer: PosesComponent.Writer,
+        intrinsics_writer: IntrinsicsComponent.Writer,
+        masks_writer: MasksComponent.Writer,
+        component_groups: ComponentGroupAssignments,
+        camera_ids: list[str],
+        calib_cam: dict[str, np.ndarray],
+        T_velo_cam0: np.ndarray,
+        T_rig_velo: np.ndarray,
+        R_rect_00_4x4: np.ndarray,
+        n_frames: int,
+    ) -> None:
+        """Decode and store all camera frames."""
+        for kitti_cam_name, ncore_cam_id in CAMERA_MAP.items():
+            if ncore_cam_id not in camera_ids:
+                continue
+
+            # Camera index (e.g., "image_02" -> "02")
+            cam_idx = kitti_cam_name.split("_")[1]
+
+            # Load camera timestamps
+            cam_timestamps = load_timestamps(str(sequence_path / kitti_cam_name / "timestamps.txt"))
+
+            # Get intrinsics from calibration
+            P_rect = calib_cam[f"P_rect_{cam_idx}"]
+            S_rect = calib_cam.get(f"S_rect_{cam_idx}")
+
+            # Extract intrinsic parameters from P_rect (3x4)
+            fu = P_rect[0, 0]
+            fv = P_rect[1, 1]
+            cu = P_rect[0, 2]
+            cv = P_rect[1, 2]
+
+            # Resolution from S_rect (rectified image size)
+            if S_rect is not None:
+                width = int(S_rect[0, 0])
+                height = int(S_rect[0, 1])
+            else:
+                # Fallback: read from first image
+                width, height = 1242, 375
+
+            # Compute camera extrinsic: T_cam_rig (cam -> rig)
+            # Chain: rig -> velo -> cam0 -> rectcam0
+            T_rig_rectcam0 = R_rect_00_4x4 @ T_velo_cam0 @ T_rig_velo
+
+            # For cameras with stereo baseline, add translation from P_rect column 4
+            # P_rect_xx[0,3] = bx * fu, so bx = P_rect_xx[0,3] / fu
+            # P_rect_xx[1,3] = by * fv (usually 0 for KITTI horizontal stereo)
+            bx = P_rect[0, 3] / fu if fu != 0 else 0.0
+            by = P_rect[1, 3] / fv if fv != 0 else 0.0
+            bz = P_rect[2, 3] if P_rect.shape[1] > 3 else 0.0
+
+            # Stereo baseline: rectcam0 -> cam_xx
+            T_rectcam0_cam = np.eye(4, dtype=np.float64)
+            T_rectcam0_cam[0, 3] = bx
+            T_rectcam0_cam[1, 3] = by
+            T_rectcam0_cam[2, 3] = bz
+
+            # Full chain rig -> cam; invert to get cam -> rig for the static pose
+            T_rig_cam = T_rectcam0_cam @ T_rig_rectcam0
+            T_cam_rig = se3_inverse(T_rig_cam)
+
+            # Create camera sensor writer
+            camera_writer = store_writer.register_component_writer(
+                CameraSensorComponent.Writer,
+                component_instance_name=ncore_cam_id,
+                group_name=component_groups.camera_component_groups.get(ncore_cam_id),
+                generic_meta_data={},
+            )
+
+            # Store frames
+            image_data_dir = sequence_path / kitti_cam_name / "data"
+            for i in tqdm.tqdm(range(n_frames), desc=f"Process {ncore_cam_id}"):
+                img_path = image_data_dir / f"{i:010d}.png"
+                if not img_path.exists():
+                    self.logger.warning(f"Missing image file: {img_path}")
+                    continue
+
+                # Read PNG as binary
+                with img_path.open("rb") as f:
+                    image_binary = f.read()
+
+                # Global shutter: start == end timestamp
+                frame_ts = cam_timestamps[i]
+
+                camera_writer.store_frame(
+                    image_binary_data=image_binary,
+                    image_format="png",
+                    frame_timestamps_us=np.array([frame_ts, frame_ts], dtype=np.uint64),
+                    generic_data={},
+                    generic_meta_data={},
+                )
+
+            # Store camera intrinsics (rectified = zero distortion)
+            intrinsics_writer.store_camera_intrinsics(
+                camera_id=ncore_cam_id,
+                camera_model_parameters=OpenCVPinholeCameraModelParameters(
+                    resolution=np.array([width, height], dtype=np.uint64),
+                    shutter_type=ShutterType.GLOBAL,
+                    external_distortion_parameters=None,
+                    principal_point=np.array([cu, cv], dtype=np.float32),
+                    focal_length=np.array([fu, fv], dtype=np.float32),
+                    radial_coeffs=np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+                    tangential_coeffs=np.array([0.0, 0.0], dtype=np.float32),
+                    thin_prism_coeffs=np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+                ),
+            )
+
+            # Store empty masks
+            masks_writer.store_camera_masks(
+                camera_id=ncore_cam_id,
+                mask_images={},
+            )
+
+            # Store camera extrinsic (sensor -> rig)
+            poses_writer.store_static_pose(
+                source_frame_id=ncore_cam_id,
+                target_frame_id="rig",
+                pose=T_cam_rig.astype(np.float32),
+            )
+
+    def _decode_tracklets(
+        self,
+        tracklet_path: UPath,
+        store_writer: SequenceComponentGroupsWriter,
+        component_groups: ComponentGroupAssignments,
+        lidar_timestamps: list[int],
+    ) -> None:
+        """Parse tracklets and store as cuboid track observations in lidar frame.
+
+        KITTI tracklet poses are in the velodyne frame at the mid-scan reference
+        time. The viewer transforms them to world via the pose graph at runtime
+        using the lidar_top -> rig -> world chain.
+        """
+        tracklets = parse_tracklets(str(tracklet_path))
+
+        if not tracklets:
+            self.logger.info("No tracklets found")
+            return
+
+        cuboid_track_observations: list[CuboidTrackObservation] = []
+
+        for idx, tracklet in enumerate(tracklets):
+            track_id = f"{tracklet.object_type}_{idx}"
+
+            for pose_idx, pose in enumerate(tracklet.poses):
+                frame_idx = tracklet.first_frame + pose_idx
+
+                if frame_idx >= len(lidar_timestamps):
+                    break
+
+                frame_timestamp_us = lidar_timestamps[frame_idx]
+
+                # KITTI tracklet (tx,ty,tz) is at the bottom-center of the box.
+                # BBox3 expects the centroid, so shift Z up by half the height.
+                centroid_z = pose.tz + tracklet.h / 2.0
+
+                cuboid_track_observations.append(
+                    CuboidTrackObservation(
+                        track_id=track_id,
+                        class_id=tracklet.object_type,
+                        timestamp_us=frame_timestamp_us,
+                        reference_frame_id=LIDAR_ID,
+                        reference_frame_timestamp_us=frame_timestamp_us,
+                        bbox3=BBox3.from_array(
+                            np.array(
+                                [
+                                    pose.tx,
+                                    pose.ty,
+                                    centroid_z,
+                                    tracklet.l,
+                                    tracklet.w,
+                                    tracklet.h,
+                                    pose.rx,
+                                    pose.ry,
+                                    pose.rz,
+                                ],
+                                dtype=np.float32,
+                            )
+                        ),
+                        source=LabelSource.EXTERNAL,
+                    )
+                )
+
+        store_writer.register_component_writer(
+            CuboidsComponent.Writer,
+            "default",
+            component_groups.cuboid_track_observations_component_group,
+        ).store_observations(cuboid_track_observations)
+
+        self.logger.info(f"Stored {len(cuboid_track_observations)} cuboid observations from {len(tracklets)} tracklets")
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+@cli.command()
+@click.option(
+    "--store-type",
+    type=click.Choice(["itar", "directory"], case_sensitive=False),
+    default="itar",
+    show_default=True,
+    help="Output store type",
+)
+@click.option(
+    "component_group_profile",
+    "--profile",
+    type=click.Choice(["default", "separate-sensors", "separate-all"], case_sensitive=False),
+    default="separate-sensors",
+    show_default=True,
+    help=""""Output profile, one of:
+        - "default": All components defaults or overrides
+        - "separate-sensors": Each sensor gets its own group named "<sensor_id>", remaining components use overrides
+        - "separate-all": Each component type gets its own group named after the component type""",
+)
+@click.option(
+    "store_sequence_meta", "--sequence-meta/--no-sequence-meta", default=True, help="Generate sequence meta-data?"
+)
+@click.pass_context
+def kitti_v4(ctx, *_, **kwargs):
+    """KITTI Raw data conversion (V4 format)"""
+
+    config = KittiConverter4Config(**{**vars(ctx.obj), **kwargs})
+
+    KittiConverter4.convert(config)

--- a/tools/data_converter/kitti/converter_test.py
+++ b/tools/data_converter/kitti/converter_test.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the KITTI raw data converter (V4 format)."""
+
+import os
+import tempfile
+import unittest
+
+from typing import Literal, cast
+
+import numpy as np
+
+from parameterized import parameterized_class
+from upath import UPath
+
+from ncore.impl.data.types import OpenCVPinholeCameraModelParameters
+from ncore.impl.data.v4.components import (
+    CameraSensorComponent,
+    CuboidsComponent,
+    IntrinsicsComponent,
+    LidarSensorComponent,
+    PosesComponent,
+    SequenceComponentGroupsReader,
+)
+from tools.data_converter.kitti.converter import KittiConverter4, KittiConverter4Config
+
+
+@parameterized_class(
+    ("store_type"),
+    [
+        ("itar",),
+        ("directory",),
+    ],
+)
+class TestKittiConverter(unittest.TestCase):
+    """Integration tests for KITTI raw data converter.
+
+    Requires KITTI_RAW_DIR environment variable pointing to a KITTI raw date
+    directory (e.g. /tmp/kitti_test_data/2011_09_26) containing at least one
+    drive sequence with calibration files and tracklet labels.
+    """
+
+    store_type: Literal["itar", "directory"]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.kitti_dir = os.environ.get("KITTI_RAW_DIR")
+        if cls.kitti_dir is None:
+            raise unittest.SkipTest("KITTI_RAW_DIR not set -- skipping KITTI integration tests")
+
+        cls._tempdir = tempfile.TemporaryDirectory(prefix="kitti_test_")
+        cls.output_dir = cls._tempdir.name
+
+        # Run the converter once for all tests
+        config = KittiConverter4Config(
+            root_dir=cls.kitti_dir,
+            output_dir=cls.output_dir,
+            no_cameras=False,
+            camera_ids=None,
+            no_lidars=False,
+            lidar_ids=None,
+            no_radars=False,
+            radar_ids=None,
+            verbose=False,
+            debug=False,
+            debug_port=5678,
+            store_type=cls.store_type,
+            component_group_profile="separate-sensors",
+            store_sequence_meta=True,
+        )
+        KittiConverter4.convert(config)
+
+        # Find output sequence directory
+        seq_dirs = list(UPath(cls.output_dir).glob("*_drive_*_sync"))
+        assert len(seq_dirs) == 1, f"Expected 1 sequence, found {len(seq_dirs)}"
+        cls.seq_dir = seq_dirs[0]
+
+        # Open reader via the sequence meta JSON file
+        meta_files = list(cls.seq_dir.glob("*.json"))
+        assert len(meta_files) == 1, f"Expected 1 meta JSON, found {len(meta_files)}"
+        cls.reader = SequenceComponentGroupsReader([meta_files[0]])
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tempdir.cleanup()
+
+    # --- Poses ----------------------------------------------------------------
+
+    def test_sequence_has_dynamic_rig_to_world_pose(self):
+        """Verify dynamic rig-> world ego pose exists."""
+        poses_readers = self.reader.open_component_readers(PosesComponent.Reader)
+        self.assertEqual(len(poses_readers), 1)
+        poses_reader = list(poses_readers.values())[0]
+
+        poses, timestamps = poses_reader.get_dynamic_pose("rig", "world")
+        self.assertEqual(poses.shape[1:], (4, 4))
+        self.assertGreater(poses.shape[0], 0)
+        self.assertEqual(timestamps.shape[0], poses.shape[0])
+
+    def test_sequence_has_static_world_to_world_global(self):
+        """Verify static world-> world_global pose exists."""
+        poses_readers = self.reader.open_component_readers(PosesComponent.Reader)
+        poses_reader = list(poses_readers.values())[0]
+
+        static_poses = dict(poses_reader.get_static_poses())
+        self.assertIn(("world", "world_global"), static_poses)
+        pose = static_poses[("world", "world_global")]
+        self.assertEqual(pose.shape, (4, 4))
+
+    def test_first_pose_near_identity(self):
+        """Verify first ego pose is near identity (local origin)."""
+        poses_readers = self.reader.open_component_readers(PosesComponent.Reader)
+        poses_reader = list(poses_readers.values())[0]
+
+        poses, _ = poses_reader.get_dynamic_pose("rig", "world")
+        first_pose = poses[0]
+        np.testing.assert_array_almost_equal(first_pose, np.eye(4), decimal=3)
+
+    def test_oxts_generic_data(self):
+        """Verify raw OXTS data stored as generic data on poses component."""
+        poses_readers = self.reader.open_component_readers(PosesComponent.Reader)
+        poses_reader = list(poses_readers.values())[0]
+
+        # Check generic data arrays exist
+        self.assertTrue(poses_reader.has_generic_data("oxts_data"))
+        self.assertTrue(poses_reader.has_generic_data("oxts_timestamps_us"))
+
+        oxts_data = poses_reader.get_generic_data("oxts_data")
+        self.assertEqual(oxts_data.ndim, 2)
+        self.assertGreater(oxts_data.shape[0], 0)
+        self.assertEqual(oxts_data.shape[1], 30)  # 30 OXTS fields
+
+        # Check field names in metadata
+        meta = poses_reader.generic_meta_data
+        self.assertIn("oxts_field_names", meta)
+        oxts_field_names = cast(list, meta["oxts_field_names"])
+        self.assertEqual(len(oxts_field_names), 30)
+        self.assertEqual(oxts_field_names[0], "lat")
+
+    # --- Cameras --------------------------------------------------------------
+
+    def test_four_cameras_exist(self):
+        """Verify all 4 camera readers exist with frames."""
+        camera_readers = self.reader.open_component_readers(CameraSensorComponent.Reader)
+        expected_ids = {"camera_gray_left", "camera_gray_right", "camera_color_left", "camera_color_right"}
+        self.assertEqual(set(camera_readers.keys()), expected_ids)
+        for cam_id, cam_reader in camera_readers.items():
+            self.assertGreater(cam_reader.frames_count, 0, f"{cam_id} should have frames")
+
+    def test_camera_intrinsics_zero_distortion(self):
+        """Verify camera intrinsics have zero distortion (rectified images)."""
+        intrinsics_readers = self.reader.open_component_readers(IntrinsicsComponent.Reader)
+        self.assertEqual(len(intrinsics_readers), 1)
+        intrinsics_reader = list(intrinsics_readers.values())[0]
+
+        for cam_id in ["camera_gray_left", "camera_gray_right", "camera_color_left", "camera_color_right"]:
+            params = intrinsics_reader.get_camera_model_parameters(cam_id)
+            self.assertIsInstance(params, OpenCVPinholeCameraModelParameters)
+            params = cast(OpenCVPinholeCameraModelParameters, params)
+            # Distortion should be zero for rectified images
+            np.testing.assert_array_equal(params.radial_coeffs, np.zeros(6, dtype=np.float32))
+            np.testing.assert_array_equal(params.tangential_coeffs, np.zeros(2, dtype=np.float32))
+            # Focal length should be positive
+            self.assertTrue(np.all(params.focal_length > 0))
+
+    def test_camera_extrinsics_stored_as_static_poses(self):
+        """Verify each camera has a static sensor-> rig extrinsic pose."""
+        poses_readers = self.reader.open_component_readers(PosesComponent.Reader)
+        poses_reader = list(poses_readers.values())[0]
+
+        static_poses = dict(poses_reader.get_static_poses())
+        for cam_id in ["camera_gray_left", "camera_gray_right", "camera_color_left", "camera_color_right"]:
+            self.assertIn((cam_id, "rig"), static_poses, f"Missing static pose for {cam_id}")
+            pose = static_poses[(cam_id, "rig")]
+            self.assertEqual(pose.shape, (4, 4))
+
+    # --- Lidar ----------------------------------------------------------------
+
+    def test_lidar_exists_with_frames(self):
+        """Verify lidar reader exists with frames."""
+        lidar_readers = self.reader.open_component_readers(LidarSensorComponent.Reader)
+        self.assertIn("lidar_top", lidar_readers)
+        lidar_reader = lidar_readers["lidar_top"]
+        self.assertGreater(lidar_reader.frames_count, 0)
+
+    def test_lidar_extrinsic_stored_as_static_pose(self):
+        """Verify lidar has a static sensor-> rig extrinsic pose."""
+        poses_readers = self.reader.open_component_readers(PosesComponent.Reader)
+        poses_reader = list(poses_readers.values())[0]
+
+        static_poses = dict(poses_reader.get_static_poses())
+        self.assertIn(("lidar_top", "rig"), static_poses)
+        pose = static_poses[("lidar_top", "rig")]
+        self.assertEqual(pose.shape, (4, 4))
+
+    # --- Cuboids (Tracklets) -------------------------------------------------
+
+    def test_cuboid_observations_exist(self):
+        """Verify cuboid track observations were stored from tracklets."""
+        cuboid_readers = self.reader.open_component_readers(CuboidsComponent.Reader)
+        self.assertEqual(len(cuboid_readers), 1)
+        cuboid_reader = list(cuboid_readers.values())[0]
+
+        observations = list(cuboid_reader.get_observations())
+        self.assertGreater(len(observations), 0)
+
+        # Check first observation has expected fields
+        obs = observations[0]
+        self.assertIsInstance(obs.track_id, str)
+        self.assertIsInstance(obs.class_id, str)
+        self.assertEqual(obs.reference_frame_id, "lidar_top")
+
+    # --- Sequence Meta --------------------------------------------------------
+
+    def test_sequence_meta_file_exists(self):
+        """Verify sequence meta JSON file was written."""
+        meta_files = list(self.seq_dir.glob("*.json"))
+        self.assertEqual(len(meta_files), 1)
+
+    def test_sequence_id_matches_drive_name(self):
+        """Verify the sequence ID matches the drive directory name."""
+        self.assertIn("drive", self.reader.sequence_id)
+        self.assertIn("sync", self.reader.sequence_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/data_converter/kitti/main.py
+++ b/tools/data_converter/kitti/main.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""KITTI converter CLI entry point."""
+
+from tools.data_converter.cli import cli
+from tools.data_converter.kitti.converter import kitti_v4  # noqa: F401 -- registers CLI command
+
+
+if __name__ == "__main__":
+    cli(show_default=True)

--- a/tools/data_converter/kitti/utils.py
+++ b/tools/data_converter/kitti/utils.py
@@ -1,0 +1,439 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""KITTI raw data utilities.
+
+OXTS-to-pose math is vendored from pykitti (MIT license, see NOTICE file).
+"""
+
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET
+
+from collections import namedtuple
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+
+from scipy.spatial.transform import Rotation
+
+from ncore.impl.common.transformations import se3_inverse
+
+
+# Type alias for path arguments (compatible with UPath, Path, and str)
+PathLike = Union[str, "os.PathLike[str]"]
+
+
+# -----------------------------------------------------------------------------
+# Constants
+# -----------------------------------------------------------------------------
+
+R_EARTH = 6378137.0  # WGS-84 Earth radius in meters
+
+OXTS_FIELD_NAMES: list[str] = [
+    "lat",
+    "lon",
+    "alt",
+    "roll",
+    "pitch",
+    "yaw",
+    "vn",
+    "ve",
+    "vf",
+    "vl",
+    "vu",
+    "ax",
+    "ay",
+    "az",
+    "af",
+    "al",
+    "au",
+    "wx",
+    "wy",
+    "wz",
+    "wf",
+    "wl",
+    "wu",
+    "pos_accuracy",
+    "vel_accuracy",
+    "navstat",
+    "numsats",
+    "posmode",
+    "velmode",
+    "orimode",
+]
+
+OxtsPacket = namedtuple("OxtsPacket", OXTS_FIELD_NAMES)
+
+
+# -----------------------------------------------------------------------------
+# Calibration parsing
+# -----------------------------------------------------------------------------
+
+
+def parse_calib_cam_to_cam(filepath: PathLike) -> dict[str, np.ndarray]:
+    """Parse calib_cam_to_cam.txt.
+
+    Returns a dict with keys like ``P_rect_00`` (3x4), ``R_rect_00`` (3x3),
+    ``S_rect_00`` (1x2), ``S_00`` (1x2), ``K_00`` (3x3), ``D_00`` (1x5),
+    ``R_00`` (3x3), ``T_00`` (1x3) for cameras 00 through 03.
+    """
+    data: dict[str, np.ndarray] = {}
+    with open(filepath, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip()
+
+            # Skip non-numeric entries
+            if key in ("calib_time", "corner_dist"):
+                continue
+
+            values = np.array([float(x) for x in value.split()], dtype=np.float64)
+
+            # Reshape based on key prefix
+            if key.startswith("S_rect_") or key.startswith("S_"):
+                data[key] = values.reshape(1, 2)
+            elif key.startswith("K_"):
+                data[key] = values.reshape(3, 3)
+            elif key.startswith("D_"):
+                data[key] = values.reshape(1, 5)
+            elif key.startswith("R_rect_"):
+                data[key] = values.reshape(3, 3)
+            elif key.startswith("R_"):
+                data[key] = values.reshape(3, 3)
+            elif key.startswith("T_"):
+                data[key] = values.reshape(1, 3)
+            elif key.startswith("P_rect_"):
+                data[key] = values.reshape(3, 4)
+            else:
+                data[key] = values
+
+    return data
+
+
+def parse_calib_rigid(filepath: PathLike) -> np.ndarray:
+    """Parse a rigid-body calibration file (calib_velo_to_cam.txt or calib_imu_to_velo.txt).
+
+    Returns a 4x4 SE3 homogeneous transformation matrix (float64).
+    """
+    data: dict[str, np.ndarray] = {}
+    with open(filepath, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip()
+
+            if key in ("calib_time",):
+                continue
+
+            values = np.array([float(x) for x in value.split()], dtype=np.float64)
+            data[key] = values
+
+    R = data["R"].reshape(3, 3)
+    T = data["T"].reshape(3, 1)
+
+    transform = np.eye(4, dtype=np.float64)
+    transform[:3, :3] = R
+    transform[:3, 3] = T.flatten()
+    return transform
+
+
+# -----------------------------------------------------------------------------
+# OXTS parsing + pose computation (vendored from pykitti, MIT license)
+# -----------------------------------------------------------------------------
+
+
+def load_oxts_packets(oxts_dir: PathLike) -> tuple[list[OxtsPacket], np.ndarray]:
+    """Load OXTS data from a directory of per-frame .txt files.
+
+    Args:
+        oxts_dir: Path to oxts/data/ directory containing numbered .txt files.
+
+    Returns:
+        A tuple of (list of OxtsPacket namedtuples, raw_array [N, 30] float64).
+    """
+    oxts_dir = Path(oxts_dir)
+    files = sorted(oxts_dir.glob("*.txt"))
+
+    packets: list[OxtsPacket] = []
+    raw_rows: list[np.ndarray] = []
+
+    for filepath in files:
+        with open(filepath, "r") as f:
+            values = [float(x) for x in f.readline().split()]
+        packets.append(OxtsPacket(*values))
+        raw_rows.append(np.array(values, dtype=np.float64))
+
+    raw_array = np.stack(raw_rows, axis=0) if raw_rows else np.empty((0, 30), dtype=np.float64)
+    return packets, raw_array
+
+
+def poses_from_oxts(packets: list[OxtsPacket]) -> tuple[np.ndarray, np.ndarray]:
+    """Compute ego poses from OXTS packets using Mercator projection.
+
+    Vendored from pykitti (MIT license). See NOTICE file.
+
+    Args:
+        packets: List of OxtsPacket namedtuples.
+
+    Returns:
+        T_rig_world: [N, 4, 4] float64 array of rig-to-world poses, rebased to first frame.
+        T_world_world_global: [4, 4] float64, the first pose before rebasing (global origin).
+    """
+    if not packets:
+        return np.empty((0, 4, 4), dtype=np.float64), np.eye(4, dtype=np.float64)
+
+    # Mercator scale factor from first packet latitude
+    scale = np.cos(packets[0].lat * np.pi / 180.0)
+
+    poses: list[np.ndarray] = []
+    for packet in packets:
+        # Mercator projection
+        tx = scale * packet.lon * np.pi * R_EARTH / 180.0
+        ty = scale * R_EARTH * np.log(np.tan((90.0 + packet.lat) * np.pi / 360.0))
+        tz = packet.alt
+
+        # Rotation from roll, pitch, yaw (ZYX intrinsic = XYZ extrinsic)
+        R = Rotation.from_euler("ZYX", [packet.yaw, packet.pitch, packet.roll]).as_matrix()
+
+        T = np.eye(4, dtype=np.float64)
+        T[:3, :3] = R
+        T[0, 3] = tx
+        T[1, 3] = ty
+        T[2, 3] = tz
+        poses.append(T)
+
+    poses_array = np.stack(poses, axis=0)
+
+    # The first pose defines the origin (world_global)
+    T_world_world_global = poses_array[0].copy()
+
+    # Rebase: make first pose the origin
+    T_rig_world = se3_inverse(T_world_world_global)[None] @ poses_array
+
+    return T_rig_world, T_world_world_global
+
+
+# -----------------------------------------------------------------------------
+# Velodyne
+# -----------------------------------------------------------------------------
+
+
+def load_velodyne_scan(filepath: PathLike) -> np.ndarray:
+    """Load a Velodyne point cloud binary file.
+
+    Returns:
+        np.ndarray of shape [N, 4] float32 (x, y, z, reflectance).
+    """
+    points = np.fromfile(str(filepath), dtype=np.float32).reshape(-1, 4)
+    return points
+
+
+def compute_velodyne_timestamps_us(
+    points: np.ndarray,
+    start_us: int,
+    end_us: int,
+) -> np.ndarray:
+    """Compute per-point timestamps from azimuth angle for a Velodyne HDL-64E scan.
+
+    The HDL-64E fires starting at the back of the vehicle and rotates counter-clockwise
+    (as seen from above). Using: fraction = (pi - atan2(y, x)) / (2 * pi)
+
+    Args:
+        points: [N, 4] float32 array (x, y, z, reflectance).
+        start_us: Start-of-spin timestamp in microseconds.
+        end_us: End-of-spin timestamp in microseconds.
+
+    Returns:
+        [N] uint64 array of per-point timestamps in microseconds.
+    """
+    x = points[:, 0]
+    y = points[:, 1]
+
+    # atan2(y, x) gives angle from +x axis; pi - atan2(y,x) gives angle from -x (rear)
+    fraction = (np.pi - np.arctan2(y, x)) / (2.0 * np.pi)
+
+    # Clamp to [0, 1] for safety
+    fraction = np.clip(fraction, 0.0, 1.0)
+
+    timestamps = start_us + fraction * (end_us - start_us)
+    return timestamps.astype(np.uint64)
+
+
+# -----------------------------------------------------------------------------
+# Timestamps
+# -----------------------------------------------------------------------------
+
+
+def load_timestamps(filepath: PathLike) -> list[int]:
+    """Load timestamps from a KITTI timestamps file.
+
+    Each line is in the format 'YYYY-MM-DD HH:MM:SS.NNNNNNNNN'.
+
+    Returns:
+        List of timestamps in microseconds from epoch.
+    """
+    timestamps: list[int] = []
+    with open(filepath, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            # Parse: "2011-09-26 14:14:10.924614488"
+            # Python datetime only supports up to microsecond precision,
+            # so we parse manually for nanosecond timestamps
+            date_part, time_part = line.split(" ")
+            time_main, frac = time_part.split(".")
+
+            # Parse date and time components
+            dt = datetime.strptime(f"{date_part} {time_main}", "%Y-%m-%d %H:%M:%S")
+            dt = dt.replace(tzinfo=timezone.utc)
+
+            # Convert to microseconds from epoch
+            epoch_us = int(dt.timestamp() * 1_000_000)
+
+            # Add fractional seconds (nanosecond precision -> microseconds)
+            # Pad/truncate to 9 digits (nanoseconds)
+            frac = frac.ljust(9, "0")[:9]
+            frac_us = int(frac) // 1000  # nanoseconds to microseconds
+
+            timestamps.append(epoch_us + frac_us)
+
+    return timestamps
+
+
+# -----------------------------------------------------------------------------
+# Tracklets
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class TrackletPose:
+    """A single pose of a tracklet object at a specific frame."""
+
+    tx: float
+    ty: float
+    tz: float
+    rx: float
+    ry: float
+    rz: float
+    state: int
+    occlusion: int
+    truncation: int
+
+
+@dataclass
+class Tracklet:
+    """A tracklet object spanning multiple frames."""
+
+    object_type: str
+    h: float
+    w: float
+    l: float
+    first_frame: int
+    poses: list[TrackletPose] = field(default_factory=list)
+
+
+def parse_tracklets(filepath: PathLike) -> list[Tracklet]:
+    """Parse a KITTI tracklet_labels.xml file.
+
+    Tracklet coordinates are in the Velodyne frame.
+
+    Args:
+        filepath: Path to tracklet_labels.xml.
+
+    Returns:
+        List of Tracklet objects with object_type, dimensions, first_frame, and per-frame poses.
+    """
+    tree = ET.parse(str(filepath))
+    root = tree.getroot()
+
+    tracklets: list[Tracklet] = []
+
+    # Navigate to the tracklets element
+    tracklets_elem = root.find("tracklets")
+    if tracklets_elem is None:
+        return tracklets
+
+    for item in tracklets_elem.findall("item"):
+        object_type_elem = item.find("objectType")
+        h_elem = item.find("h")
+        w_elem = item.find("w")
+        l_elem = item.find("l")
+        first_frame_elem = item.find("first_frame")
+
+        if any(e is None for e in [object_type_elem, h_elem, w_elem, l_elem, first_frame_elem]):
+            continue
+
+        # After the None-check above, these are guaranteed to be non-None
+        assert object_type_elem is not None
+        assert h_elem is not None and h_elem.text is not None
+        assert w_elem is not None and w_elem.text is not None
+        assert l_elem is not None and l_elem.text is not None
+        assert first_frame_elem is not None and first_frame_elem.text is not None
+        assert object_type_elem.text is not None
+
+        tracklet = Tracklet(
+            object_type=object_type_elem.text.strip(),
+            h=float(h_elem.text),
+            w=float(w_elem.text),
+            l=float(l_elem.text),
+            first_frame=int(first_frame_elem.text),
+        )
+
+        # Parse per-frame poses
+        poses_elem = item.find("poses")
+        if poses_elem is not None:
+            for pose_item in poses_elem.findall("item"):
+                tx_elem = pose_item.find("tx")
+                ty_elem = pose_item.find("ty")
+                tz_elem = pose_item.find("tz")
+                rx_elem = pose_item.find("rx")
+                ry_elem = pose_item.find("ry")
+                rz_elem = pose_item.find("rz")
+                state_elem = pose_item.find("state")
+                occlusion_elem = pose_item.find("occlusion")
+                truncation_elem = pose_item.find("truncation")
+
+                tracklet.poses.append(
+                    TrackletPose(
+                        tx=float(tx_elem.text) if tx_elem is not None and tx_elem.text else 0.0,
+                        ty=float(ty_elem.text) if ty_elem is not None and ty_elem.text else 0.0,
+                        tz=float(tz_elem.text) if tz_elem is not None and tz_elem.text else 0.0,
+                        rx=float(rx_elem.text) if rx_elem is not None and rx_elem.text else 0.0,
+                        ry=float(ry_elem.text) if ry_elem is not None and ry_elem.text else 0.0,
+                        rz=float(rz_elem.text) if rz_elem is not None and rz_elem.text else 0.0,
+                        state=int(state_elem.text) if state_elem is not None and state_elem.text else 0,
+                        occlusion=int(occlusion_elem.text) if occlusion_elem is not None and occlusion_elem.text else 0,
+                        truncation=int(truncation_elem.text)
+                        if truncation_elem is not None and truncation_elem.text
+                        else 0,
+                    )
+                )
+
+        tracklets.append(tracklet)
+
+    return tracklets


### PR DESCRIPTION
## Summary

Add a converter for the [KITTI Vision Benchmark Suite](https://www.cvlibs.net/datasets/kitti/) raw data format (synced+rectified) to NCore V4, addressing #90.

## Sensors

| Sensor | NCore ID | Details |
|--------|----------|---------|
| Left grayscale | `camera_gray_left` | Point Grey Flea 2 CCD, global shutter, rectified |
| Right grayscale | `camera_gray_right` | Same |
| Left color | `camera_color_left` | Same |
| Right color | `camera_color_right` | Same |
| Velodyne HDL-64E | `lidar_top` | Unstructured ray-bundle, per-point timestamps from azimuth |
| OXTS RT3003 | (poses + generic data) | Ego poses via Mercator projection, raw 30-field measurements as generic data |

## Features

- **Ego poses**: Computed from OXTS GPS/IMU via Mercator projection (math vendored from [pykitti](https://github.com/utiasSTARS/pykitti), MIT license). First pose as local origin, `("world", "world_global")` preserves absolute position.
- **Raw OXTS**: 30-field measurements stored as component-level generic data on the poses component via `set_generic_data`.
- **LiDAR timestamps**: Per-point timestamps reconstructed from azimuth angle using known Velodyne HDL-64E spin timing (CCW, 10 Hz).
- **Camera intrinsics**: `OpenCVPinholeCameraModelParameters` with zero distortion (images are already rectified). Focal length and principal point from `P_rect`.
- **3D annotations**: Tracklet labels (`tracklet_labels.xml`) stored as `CuboidsComponent` observations in the velodyne frame.

## Usage

```bash
bazel run //tools/data_converter/kitti -- \
    --root-dir /path/to/2011_09_26 \
    --output-dir /path/to/output \
    kitti-v4
```

## Changes

| File | Description |
|------|-------------|
| `tools/data_converter/kitti/converter.py` | `KittiConverter4` class + `kitti-v4` CLI command |
| `tools/data_converter/kitti/utils.py` | Calibration, OXTS, velodyne, timestamp, tracklet parsing |
| `tools/data_converter/kitti/converter_test.py` | 12 integration tests (requires `KITTI_RAW_DIR` env var) |
| `tools/data_converter/kitti/BUILD.bazel` | Bazel targets |
| `tools/data_converter/kitti/NOTICE` | pykitti MIT license attribution |
| `tools/data_converter/kitti/README.md` | Usage documentation |
| `docs/conversions/kitti/kitti.rst` | Sphinx documentation |
| `docs/conversions/index.rst` | Added KITTI to conversions index |

## Testing

12 integration tests covering poses, cameras, lidar, cuboids, and OXTS generic data. Tests require downloaded KITTI sample data (drive 0048, 22 frames, ~80MB):

```bash
bazel test //tools/data_converter/kitti:pytest_converter_3_11 \
    --test_output=errors \
    --test_env=KITTI_RAW_DIR=/path/to/2011_09_26
```

No new 3rd-party dependencies.

---

## Example projections (color cameras / gray-scale cameras)  
<img width="2000" height="1200" alt="000000color" src="https://github.com/user-attachments/assets/bbe23095-febd-425f-adcf-1278b8b51557" />
<img width="2000" height="1200" alt="000000gray" src="https://github.com/user-attachments/assets/3f0bb998-987d-4b9f-b3ca-07076d345da5" />

## Example in ncore_vis (including cuboid labels)  
<img width="2161" height="945" alt="image" src="https://github.com/user-attachments/assets/42f13cf1-cd89-4581-99ae-0efa7417ef69" />
