### PR TITLE
fix(format): use portable shebang in ruff_isort.sh

### DIFF
--- a/bazel/format/ruff_isort.sh
+++ b/bazel/format/ruff_isort.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Summary

- Change `#!/bin/bash` to `#!/usr/bin/env bash` in `bazel/format/ruff_isort.sh`

This is a best-practice portability fix. `/usr/bin/env bash` resolves `bash` from
`$PATH` rather than assuming a hardcoded `/bin/bash`, which doesn't exist on all
Linux distributions (e.g. NixOS). No behavior change on Ubuntu/Debian where
`/bin/bash` exists.