### PR TITLE
fix(types): correct dtype validation in BivariateWindshieldModelParameters

### DIFF
--- a/ncore/impl/data/types.py
+++ b/ncore/impl/data/types.py
@@ -130,13 +130,13 @@ class BivariateWindshieldModelParameters(dataclasses_json.DataClassJsonMixin):
         assert self.horizontal_poly.dtype == np.dtype("float32")
 
         assert self.vertical_poly.ndim == 1
-        assert self.horizontal_poly.dtype == np.dtype("float32")
+        assert self.vertical_poly.dtype == np.dtype("float32")
 
         assert self.horizontal_poly_inverse.ndim == 1
-        assert self.horizontal_poly.dtype == np.dtype("float32")
+        assert self.horizontal_poly_inverse.dtype == np.dtype("float32")
 
         assert self.vertical_poly_inverse.ndim == 1
-        assert self.horizontal_poly.dtype == np.dtype("float32")
+        assert self.vertical_poly_inverse.dtype == np.dtype("float32")
 
 
 # Represents the collection of all concrete external distortion types


### PR DESCRIPTION
## Summary

- Fix copy-paste bug in `BivariateWindshieldModelParameters.__post_init__()` where four assertions all checked `self.horizontal_poly.dtype` instead of the correct field
- `vertical_poly.dtype`, `horizontal_poly_inverse.dtype`, and `vertical_poly_inverse.dtype` are now validated correctly
- Without this fix, invalid data passes validation silently