### PR TITLE
feat(deps): make torch an optional dependency, only required for sensor evaluation

### DIFF
--- a/ncore/BUILD.bazel
+++ b/ncore/BUILD.bazel
@@ -62,10 +62,14 @@ py_wheel(
         "zarr>=2.12.0,<3.0.0",
         "cbor2",
         "scipy",
-        "torch",
         "typing_extensions",
         "universal_pathlib",
     ],
+    extra_requires = {
+        "sensors": [
+            "torch",
+        ],
+    },
     summary = "A unified data format and library for AV / robotics",
     # Build / deploy wheels:
     # - bazel build //ncore:ncore_wheel.dist --stamp --embed_label=<VERSION>

--- a/ncore/sensors/__init__.py
+++ b/ncore/sensors/__init__.py
@@ -13,17 +13,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Package exposing methods related to NCore's sensor types"""
+"""Package exposing methods related to NCore's sensor types.
 
-from ncore.impl.sensors.camera import (
-    BivariateWindshieldModel,
-    CameraModel,
-    ExternalDistortionModel,
-    FThetaCameraModel,
-    OpenCVFisheyeCameraModel,
-    OpenCVPinholeCameraModel,
-)
-from ncore.impl.sensors.lidar import LidarModel, RowOffsetStructuredSpinningLidarModel, StructuredLidarModel
+This module requires PyTorch. Install it with: pip install ncore[sensors]
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from ncore.impl.sensors.camera import (
+        BivariateWindshieldModel as BivariateWindshieldModel,
+        CameraModel as CameraModel,
+        ExternalDistortionModel as ExternalDistortionModel,
+        FThetaCameraModel as FThetaCameraModel,
+        OpenCVFisheyeCameraModel as OpenCVFisheyeCameraModel,
+        OpenCVPinholeCameraModel as OpenCVPinholeCameraModel,
+    )
+    from ncore.impl.sensors.lidar import (
+        LidarModel as LidarModel,
+        RowOffsetStructuredSpinningLidarModel as RowOffsetStructuredSpinningLidarModel,
+        StructuredLidarModel as StructuredLidarModel,
+    )
 
 
 __all__ = [
@@ -37,3 +52,30 @@ __all__ = [
     "StructuredLidarModel",
     "RowOffsetStructuredSpinningLidarModel",
 ]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        try:
+            import torch  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "torch is required for sensor model evaluation. "
+                "Install it with: pip install ncore[sensors]"
+            ) from None
+
+        if name in (
+            "BivariateWindshieldModel",
+            "CameraModel",
+            "ExternalDistortionModel",
+            "FThetaCameraModel",
+            "OpenCVFisheyeCameraModel",
+            "OpenCVPinholeCameraModel",
+        ):
+            module = importlib.import_module("ncore.impl.sensors.camera")
+        else:
+            module = importlib.import_module("ncore.impl.sensors.lidar")
+
+        return getattr(module, name)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

- Make `torch` an optional dependency -- users who only need data reading (`ncore.data`) no longer need PyTorch installed
- `ncore.sensors` now uses lazy imports via `__getattr__`, importing torch only when a sensor class is accessed
- Clear `ImportError` message guides users to install `ncore[sensors]` if torch is missing
- Wheel updated: torch moved from `requires` to `extra_requires = {"sensors": ["torch"]}`
- All data tests pass without torch at import time; all sensor tests pass with torch available