### PR TITLE
chore: add from __future__ import annotations to all Python files

### DIFF
--- a/ncore/data/__init__.py
+++ b/ncore/data/__init__.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """Package exposing methods related to NCore's basic data types and abstract APIs"""
 
 from ncore.impl.data.compat import (

--- a/ncore/data/test.py
+++ b/ncore/data/test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the
 
+from __future__ import annotations
+
 
 def test_import_package():
     """Make sure package can be imported"""

--- a/ncore/data/v4/__init__.py
+++ b/ncore/data/v4/__init__.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """Package exposing methods related to NCore's V4 data interaction APIs"""
 
 from ncore.impl.data.v4.compat import SequenceLoaderV4

--- a/ncore/data/v4/test.py
+++ b/ncore/data/v4/test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 
 def test_import_package():
     """Make sure package can be imported"""

--- a/ncore/data_converter/__init__.py
+++ b/ncore/data_converter/__init__.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """Package containing common and abstract functionality to implement NCore data-converters"""
 
 from ncore.impl.data_converter.base import (

--- a/ncore/data_converter/test.py
+++ b/ncore/data_converter/test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 
 def test_import_package():
     """Make sure package can be imported"""

--- a/ncore/impl/common/transformations_test.py
+++ b/ncore/impl/common/transformations_test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 
 from pathlib import Path

--- a/ncore/impl/data/stores_test.py
+++ b/ncore/impl/data/stores_test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import tempfile
 import unittest

--- a/ncore/impl/data/types_test.py
+++ b/ncore/impl/data/types_test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 
 from typing import Optional

--- a/ncore/impl/data/util.py
+++ b/ncore/impl/data/util.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import re
 
 from dataclasses import dataclass, field

--- a/ncore/impl/data/util_test.py
+++ b/ncore/impl/data/util_test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 
 import numpy as np

--- a/ncore/impl/data/v4/compat_test.py
+++ b/ncore/impl/data/v4/compat_test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import tempfile
 import unittest
 

--- a/ncore/impl/data/v4/components_test.py
+++ b/ncore/impl/data/v4/components_test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import dataclasses
 import io
 import tempfile

--- a/ncore/impl/sensors/camera_test.py
+++ b/ncore/impl/sensors/camera_test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import dataclasses
 import itertools
 import os

--- a/ncore/impl/sensors/common.py
+++ b/ncore/impl/sensors/common.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Optional, Union, cast
 
 import numpy as np

--- a/ncore/impl/sensors/lidar_test.py
+++ b/ncore/impl/sensors/lidar_test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import json
 import os

--- a/ncore/sensors/__init__.py
+++ b/ncore/sensors/__init__.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """Package exposing methods related to NCore's sensor types"""
 
 from ncore.impl.sensors.camera import (

--- a/ncore/sensors/test.py
+++ b/ncore/sensors/test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 
 def test_import_package():
     """Make sure package can be imported"""

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import click

--- a/tools/data_converter/cli.py
+++ b/tools/data_converter/cli.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 
 from types import SimpleNamespace

--- a/tools/data_converter/kitti/converter_test.py
+++ b/tools/data_converter/kitti/converter_test.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """Integration tests for the KITTI raw data converter (V4 format)."""
 
 import os

--- a/tools/data_converter/kitti/main.py
+++ b/tools/data_converter/kitti/main.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """KITTI converter CLI entry point."""
 
 from tools.data_converter.cli import cli

--- a/tools/data_converter/pai/utils.py
+++ b/tools/data_converter/pai/utils.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """Utility functions for Physical AI data processing."""
 
 import io

--- a/tools/data_converter/waymo/deps.py
+++ b/tools/data_converter/waymo/deps.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """Proxy module for Waymo Open Dataset dependencies."""
 
 import tensorflow.compat.v1 as tf  # ty:ignore[unresolved-import]

--- a/tools/debug.py
+++ b/tools/debug.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 
 from pathlib import Path

--- a/tools/ncore_export_camera.py
+++ b/tools/ncore_export_camera.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 
 from dataclasses import dataclass

--- a/tools/ncore_export_colored_pc.py
+++ b/tools/ncore_export_colored_pc.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 
 from dataclasses import dataclass

--- a/tools/ncore_export_ply.py
+++ b/tools/ncore_export_ply.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 
 from dataclasses import dataclass

--- a/tools/ncore_project_pc_to_img.py
+++ b/tools/ncore_project_pc_to_img.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import dataclasses
 import logging
 import os

--- a/tools/ncore_sequence_meta.py
+++ b/tools/ncore_sequence_meta.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 import logging
 

--- a/tools/ncore_vis/components/__init__.py
+++ b/tools/ncore_vis/components/__init__.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """Visualization components for the NCore interactive viewer.
 
 To add a custom component:


### PR DESCRIPTION
## Summary

- Add `from __future__ import annotations` to 31 Python files that were missing it
- Covers `ncore/data/`, `ncore/sensors/`, `ncore/impl/`, `tools/`, and test files
- Aligns all files with the project coding convention specified in AGENTS.md