### PR TITLE
chore(types): add missing return type annotations across impl/

### DIFF
--- a/ncore/impl/common/transformations.py
+++ b/ncore/impl/common/transformations.py
@@ -148,7 +148,7 @@ class PoseInterpolator:
         """Returns the timestamps corresponding to the original poses used for interpolation"""
         return self._timestamps
 
-    def __init__(self, poses, timestamps):
+    def __init__(self, poses, timestamps) -> None:
         """Initializes the PoseInterpolator
 
         Args:
@@ -354,7 +354,7 @@ class PoseInterpolator:
         return result
 
 
-def so3_trans_2_se3(so3, trans):
+def so3_trans_2_se3(so3, trans) -> np.ndarray:
     """Create a 4x4 rigid transformation matrix given so3 rotation and translation.
 
     Args:
@@ -407,7 +407,7 @@ def se3_inverse(T: np.ndarray, unbatch: bool = True) -> np.ndarray:
     return ret
 
 
-def transform_point_cloud(pc, T):
+def transform_point_cloud(pc, T) -> np.ndarray:
     """Transform the point cloud with the provided transformation matrix,
         support torch.Tensor and np.ndarry.
     Args:
@@ -554,7 +554,7 @@ class MotionCompensator:
     def __init__(
         self,
         pose_graph: PoseGraphInterpolator,
-    ):
+    ) -> None:
         """
         Initializes motion-compensator to use a pose-graph interpolator
 
@@ -704,7 +704,7 @@ class PoseGraphInterpolator:
             target_node: str,
             T_source_target: npt.NDArray[np.floating],
             timestamps_us: Optional[npt.NDArray[np.uint64]],
-        ):
+        ) -> None:
             self.source_node = source_node
             self.target_node = target_node
             self.T_source_target = T_source_target  # either [4,4] (static) or [n,4,4] (dynamic)
@@ -755,7 +755,7 @@ class PoseGraphInterpolator:
             else:
                 raise KeyError("Invalid source/target node for edge")
 
-    def __init__(self, edges: List[Edge]):
+    def __init__(self, edges: List[Edge]) -> None:
         # Collect graph
         self._nodes: Set[str] = set()
         for edge in edges:

--- a/ncore/impl/data/stores.py
+++ b/ncore/impl/data/stores.py
@@ -108,7 +108,7 @@ class IndexedTarStore(Store):
         itar_path: Union[str, Path, UPath],
         mode: Literal["r", "w"] = "r",
         index_tail_read_size: Optional[int] = 1 << 20,  # 1 MiB by default
-    ):
+    ) -> None:
         if mode not in ["r", "w"]:
             raise ValueError("TarRecordIndex: only r/w modes supported")
 
@@ -150,7 +150,7 @@ class IndexedTarStore(Store):
         else:
             self.index = self.TarRecordIndex()
 
-    def __delitem__(self, _: str):
+    def __delitem__(self, _: str) -> None:
         raise NotImplementedError("Deleting items is not supported")
 
     def __iter__(self) -> Iterator[str]:
@@ -190,7 +190,7 @@ class IndexedTarStore(Store):
 
             return value
 
-    def __setitem__(self, item: str, value):
+    def __setitem__(self, item: str, value) -> None:
         if self.mode != "w":
             raise zarr.errors.ReadOnlyError
 
@@ -231,13 +231,13 @@ class IndexedTarStore(Store):
 
             self.index.records[item] = record
 
-    def __enter__(self):
+    def __enter__(self) -> IndexedTarStore:
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
         self.close()
 
-    def close(self):
+    def close(self) -> None:
         """Needs to be called after finishing updating the store"""
         with self.mutex:
             if self.mode == "w":
@@ -250,7 +250,7 @@ class IndexedTarStore(Store):
 
             self.tar_file_object.close()
 
-    def reload_resources(self):
+    def reload_resources(self) -> None:
         """Reloads the tar file object *only* - useful to re-initialize the store in multi-process 'fork()' settings"""
         with self.mutex:
             # get current tar file path and seek positions, and close file object
@@ -366,10 +366,10 @@ class IndexedTarStore(Store):
         return index, cls.TailBuffer(start=index_start_in_file, data=tail_buffer)
 
     @classmethod
-    def _save_tar_index(cls, tar_file_object: IO[Any], index: TarRecordIndex):
+    def _save_tar_index(cls, tar_file_object: IO[Any], index: TarRecordIndex) -> None:
         """Saves a tar record index at the end of a tar file object (needs to be finalized / have two empty blocks appended already)"""
 
-        def fill_block():
+        def fill_block() -> None:
             # Fill up block with zeros
             _, remainder = divmod(tar_file_object.tell(), tarfile.BLOCKSIZE)
             if remainder > 0:
@@ -420,7 +420,7 @@ class IndexedTarStore(Store):
         fill_block()
 
 
-def consolidate_compressed_metadata(store: zarr.storage.BaseStore, metadata_key=".zmetadata.cbor.xz"):
+def consolidate_compressed_metadata(store: zarr.storage.BaseStore, metadata_key=".zmetadata.cbor.xz") -> None:
     """Consolidate all metadata for groups and arrays within the given store
     into a single compressed cbor resource and put it under the given key.
 
@@ -434,7 +434,7 @@ def consolidate_compressed_metadata(store: zarr.storage.BaseStore, metadata_key=
 
     if version == 2:
 
-        def is_zarr_key(key):
+        def is_zarr_key(key) -> bool:
             return key.endswith(".zarray") or key.endswith(".zgroup") or key.endswith(".zattrs")
 
     else:
@@ -458,7 +458,7 @@ class ConsolidatedCompressedMetadataStore(zarr.storage.ConsolidatedMetadataStore
     """A layer over other storage, where the metadata has been consolidated into a single compressed key."""
 
     # Overwrite constructor to perform decompression of metadata
-    def __init__(self, store: zarr.storage.StoreLike, metadata_key=".zmetadata.cbor.xz"):
+    def __init__(self, store: zarr.storage.StoreLike, metadata_key=".zmetadata.cbor.xz") -> None:
         self.store = Store._ensure_store(store)
 
         # retrieve consolidated metadata

--- a/ncore/impl/data/types.py
+++ b/ncore/impl/data/types.py
@@ -122,7 +122,7 @@ class BivariateWindshieldModelParameters(dataclasses_json.DataClassJsonMixin):
         """Returns a string-identifier of the external distortion model"""
         return "bivariate-windshield"
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         assert isinstance(self.reference_poly, ReferencePolynomial)
 
@@ -180,7 +180,7 @@ class CameraModelParameters(ABC):
             a transformed version of the concrete camera model parameters
         """
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         assert self.resolution.shape == (2,)
         assert self.resolution.dtype == np.dtype("uint64")
@@ -240,7 +240,7 @@ class FThetaCameraModelParameters(CameraModelParameters, dataclasses_json.DataCl
 
     POLYNOMIAL_DEGREE = 6
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         super().__post_init__()
         assert self.principal_point.shape == (2,)
@@ -389,7 +389,7 @@ class OpenCVPinholeCameraModelParameters(CameraModelParameters, dataclasses_json
         """Returns a string-identifier of the camera model"""
         return "opencv-pinhole"
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         super().__post_init__()
         assert self.principal_point.shape == (2,)
@@ -476,7 +476,7 @@ class OpenCVFisheyeCameraModelParameters(CameraModelParameters, dataclasses_json
         """Returns a string-identifier of the camera model"""
         return "opencv-fisheye"
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         super().__post_init__()
         assert self.principal_point.shape == (2,)
@@ -608,7 +608,7 @@ class BaseSpinningLidarModelParameters(BaseLidarModelParameters):
         "cw", "ccw"
     ]  # direction of spinning, either clockwise (cw) or counter-clockwise (ccw) [around z axis]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         assert self.spinning_frequency_hz > 0.0
         assert self.spinning_direction in ["cw", "ccw"]
@@ -624,7 +624,7 @@ class BaseStructuredSpinningLidarModelParameters(BaseSpinningLidarModelParameter
     n_rows: int  # number of rows
     n_columns: int  # number of columns
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         assert self.n_rows > 0
         assert self.n_columns > 0
@@ -649,7 +649,7 @@ class RowOffsetStructuredSpinningLidarModelParameters(
         np.float32
     )  # azimuth angle offsets for each row (optional, can be zero if no row offsets) [around z axis, relative to x axis] [(Nrows,) radians]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
 
         assert self.row_elevations_rad.dtype == np.float32
@@ -771,7 +771,7 @@ class BBox3(dataclasses_json.DataClassJsonMixin):
             rot=(float(array[6]), float(array[7]), float(array[8])),
         )
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         assert isinstance(self.centroid, tuple)
         assert all(isinstance(i, float) for i in self.centroid)
@@ -881,7 +881,7 @@ class LabelType(dataclasses_json.DataClassJsonMixin):
         ),
     )  #: Physical unit of the label values, if applicable
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         assert isinstance(self.category, LabelCategory)
         assert isinstance(self.qualifier, str)
@@ -939,7 +939,7 @@ class QuantizationParams(dataclasses_json.DataClassJsonMixin):
         metadata=dataclasses_json.config(exclude=lambda _: True),
     )  #: Numpy dtype for intermediate arithmetic during (de-)quantization
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         assert np.issubdtype(self.quantized_dtype, np.integer), (
             f"quantized_dtype must be an integer type, got {self.quantized_dtype}"
         )
@@ -963,7 +963,7 @@ class LabelSchema(dataclasses_json.DataClassJsonMixin):
     )
     quantization: Optional[QuantizationParams] = None  #: Optional quantization parameters
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         assert isinstance(self.dtype, np.dtype)
         assert isinstance(self.shape_suffix, tuple) and all(isinstance(i, int) for i in self.shape_suffix)
@@ -1045,7 +1045,7 @@ class CuboidTrackObservation(dataclasses_json.DataClassJsonMixin):
             reference_frame_timestamp_us=target_frame_timestamp_us,
         )
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         assert isinstance(self.track_id, str)
         assert isinstance(self.class_id, str)
@@ -1230,7 +1230,7 @@ class PointCloud:
 class EncodedImageData:
     """Represents encoded image data of a specific format in memory"""
 
-    def __init__(self, encoded_image_data: bytes, encoded_image_format: str):
+    def __init__(self, encoded_image_data: bytes, encoded_image_format: str) -> None:
         self._encoded_image_data = encoded_image_data
         self._encoded_image_format = encoded_image_format
 
@@ -1273,7 +1273,7 @@ class CameraLabelDescriptor(dataclasses_json.DataClassJsonMixin):
         cat = self.label_type.category.name.lower()
         return f"{cat}.{self.label_type.qualifier}@{self.camera_id}"
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Sanity checks
         assert isinstance(self.camera_id, str) and len(self.camera_id) > 0, "camera_id should be a non-empty string"
         assert isinstance(self.label_type, LabelType)

--- a/ncore/impl/data/util.py
+++ b/ncore/impl/data/util.py
@@ -68,10 +68,10 @@ def closest_index_sorted(sorted_array: np.ndarray, value: int) -> int:
     return idx
 
 
-def numpy_array_field(datatype: "npt.DTypeLike", default=None):
+def numpy_array_field(datatype: "npt.DTypeLike", default=None) -> Any:
     """Provides encoder / decoder functionality for numpy arrays into field types compatible with dataclass-JSON"""
 
-    def decoder(*args, **kwargs):
+    def decoder(*args, **kwargs) -> np.ndarray:
         return np.array(*args, **kwargs).astype(datatype)
 
     metadata = dataclasses_json.config(encoder=np.ndarray.tolist, decoder=decoder)
@@ -82,21 +82,21 @@ def numpy_array_field(datatype: "npt.DTypeLike", default=None):
         return field(default=None, metadata=metadata)
 
 
-def enum_field(enum_class, default=None):
+def enum_field(enum_class, default=None) -> Any:
     """Provides encoder / decoder functionality for enum types into field types compatible with dataclass-JSON"""
 
-    def encoder(variant):
+    def encoder(variant) -> str:
         """encode enum as name's string representation. This way values in JSON are "human-readable"""
         return variant.name
 
-    def decoder(variant):
+    def decoder(variant) -> Any:
         """load enum variant from name's string to value map of the enumeration type"""
         return enum_class.__members__[variant]
 
     return field(default=default, metadata=dataclasses_json.config(encoder=encoder, decoder=decoder))
 
 
-def dtype_field(default: Optional[np.dtype] = None):
+def dtype_field(default: Optional[np.dtype] = None) -> Any:
     """Provides encoder / decoder functionality for numpy dtype fields into field types compatible with dataclass-JSON.
 
     Serializes as the dtype's string name (e.g., ``"float32"``, ``"uint8"``).

--- a/ncore/impl/data/v4/compat.py
+++ b/ncore/impl/data/v4/compat.py
@@ -375,7 +375,7 @@ class SequenceLoaderV4(SequenceLoaderProtocol):
             )
 
         @override
-        def get_frame_ray_bundle_direction(self, frame_index):
+        def get_frame_ray_bundle_direction(self, frame_index: int) -> "npt.NDArray[np.float32]":
             """Returns the per-ray directions for the ray-bundle for a specific frame"""
             return self.ray_bundle_reader.get_frame_ray_bundle_data(
                 self.frames_timestamps_us[frame_index, FrameTimepoint.END.value].item(), "direction"

--- a/ncore/impl/data/v4/components.py
+++ b/ncore/impl/data/v4/components.py
@@ -727,7 +727,7 @@ class PosesComponent:
 
             self.data: Dict = {"static_poses": {}, "dynamic_poses": {}}
 
-        def finalize(self):
+        def finalize(self) -> None:
             """Actually store the json-encoded pose data"""
 
             self._group.create_group("static_poses").attrs.put(self.data["static_poses"])
@@ -1055,7 +1055,7 @@ class BaseSensorComponentWriter(ComponentWriter):
             int, int
         ] = {}  # collect end-of-frame timestamps mapping to start of frame timestamps
 
-    def finalize(self):
+    def finalize(self) -> None:
         """Perform final operations after all user-data was written to the sensor component"""
 
         # Collect all frame timestamps to be stored as global property (supporting no frames at all and out-of-order frames)
@@ -1419,7 +1419,7 @@ class CameraSensorComponent:
         class EncodedImageDataHandle:
             """References encoded image data without loading it"""
 
-            def __init__(self, image_dataset: zarr.Array):
+            def __init__(self, image_dataset: zarr.Array) -> None:
                 self._image_dataset = image_dataset
 
             def get_data(self) -> types.EncodedImageData:

--- a/ncore/impl/sensors/camera.py
+++ b/ncore/impl/sensors/camera.py
@@ -141,7 +141,7 @@ class BivariateWindshieldModel(ExternalDistortionModel):
         )
 
     @staticmethod
-    def compute_poly_order(poly_coeffs: torch.Tensor):
+    def compute_poly_order(poly_coeffs: torch.Tensor) -> int:
         """Computes the order of a bivariate polynomial give it's array of coefficients"""
         order = 0
         num_terms = 0

--- a/ncore/impl/sensors/lidar.py
+++ b/ncore/impl/sensors/lidar.py
@@ -311,7 +311,7 @@ class RowOffsetStructuredSpinningLidarModel(StructuredLidarModel):
             sensor_rays=torch.stack([x, y, z], dim=-1), valid_flag=self._valid_sensor_angles(sensor_angles)
         )
 
-    def _init_angles_to_columns_map(self):
+    def _init_angles_to_columns_map(self) -> None:
         """Computes angles to column map as a 2D array of shape resolution_factor * (n_rows, n_columns)."""
 
         assert torch.iinfo(self.angles_to_columns_map_dtype).max >= self.n_columns - 1, (


### PR DESCRIPTION
## Summary

- Add missing return type annotations to ~35 functions across `ncore/impl/`
- Covers `stores.py`, `util.py`, `types.py`, `transformations.py`, `components.py`, `compat.py`, `lidar.py`, `camera.py`
- Mostly `__post_init__` -> None, `__init__` -> None, `__enter__`/`__exit__`, `close()`/`finalize()`, and inferred types for utility functions