### PR TITLE
build(bazelignore): Add .worktrees to .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -17,3 +17,5 @@ bazel-bin
 bazel-out
 bazel-testlogs
 modules
+
+.worktrees


### PR DESCRIPTION
This pull request makes a minor update to the `.bazelignore` file to improve the Bazel build environment by excluding additional directories.

- Added `.worktrees` to the `.bazelignore` file to prevent Bazel from indexing or building files in Git worktree directories.