### PR TITLE
docs: fix typos in windshield distortion model comments

### DIFF
--- a/ncore/impl/data/types.py
+++ b/ncore/impl/data/types.py
@@ -88,10 +88,10 @@ class ReferencePolynomial(IntEnum):
 
     FORWARD = (
         auto()
-    )  #: The forward polynomial is the reference polynomial, the backward polynomial is it's (approximate) inverse
+    )  #: The forward polynomial is the reference polynomial, the backward polynomial is its (approximate) inverse
     BACKWARD = (
         auto()
-    )  #: The backward polynomial is the reference polynomial, the forward polynomial is it's (approximate) inverse
+    )  #: The backward polynomial is the reference polynomial, the forward polynomial is its (approximate) inverse
 
 
 @dataclass
@@ -103,19 +103,19 @@ class BivariateWindshieldModelParameters(dataclasses_json.DataClassJsonMixin):
     # Forward correction coefficients (project to sensor)
     horizontal_poly: np.ndarray = util.numpy_array_field(
         np.float32
-    )  #: Polynomial coefficients used for forward projection on the horizontal component of a ray via it's projected angle phi=asin(x/norm(x,y)). The polynomial is of order N in both phi and theta with the form P(phi,N)*P(theta,0) + P(phi, N-1)*P(theta,1) ... + P(phi, N-N)*P(theta,N), where P(i, N) is a polynomial over "i" of degree N (float32, [(N + 1) * (N + 2) / 2,])
+    )  #: Polynomial coefficients used for forward projection on the horizontal component of a ray via its projected angle phi=asin(x/norm(x,y)). The polynomial is of order N in both phi and theta with the form P(phi,N)*P(theta,0) + P(phi, N-1)*P(theta,1) ... + P(phi, N-N)*P(theta,N), where P(i, N) is a polynomial over "i" of degree N (float32, [(N + 1) * (N + 2) / 2,])
     vertical_poly: np.ndarray = util.numpy_array_field(
         np.float32
-    )  #: Polynomial coefficients used for forward projection on the vertical component of a ray via it's projected angle theta=asin(y/norm(x,y)). The polynomial is of order M in both phi and theta with the form P(phi,M)*P(theta,0) + P(phi, M-1)*P(theta,1) ... + P(phi, M-M)*P(theta,M), where P(i, M) is a polynomial over "i" of degree M (float32, [(M + 1) * (M + 2) / 2,])
+    )  #: Polynomial coefficients used for forward projection on the vertical component of a ray via its projected angle theta=asin(y/norm(x,y)). The polynomial is of order M in both phi and theta with the form P(phi,M)*P(theta,0) + P(phi, M-1)*P(theta,1) ... + P(phi, M-M)*P(theta,M), where P(i, M) is a polynomial over "i" of degree M (float32, [(M + 1) * (M + 2) / 2,])
 
-    # Backward correction coefficient (project to world)
+    # Backward correction coefficients (project to world)
     horizontal_poly_inverse: np.ndarray = util.numpy_array_field(
         np.float32
-    )  #: Polynomial coefficients used to evaluate the inverse distortion in backprojection of the horizontal component of a ray via it's projected angle phi=asin(x/norm(x,y)). The polynomial is of order N in both phi and theta with the form P(phi,N)*P(theta,0) + P(phi, N-1)*P(theta,1) ... + P(phi, N-N)*P(theta,N), where P(i, N) is a polynomial over "i" of degree N (float32, [(N + 1) * (N + 2) / 2,])
+    )  #: Polynomial coefficients used to evaluate the inverse distortion in backprojection of the horizontal component of a ray via its projected angle phi=asin(x/norm(x,y)). The polynomial is of order N in both phi and theta with the form P(phi,N)*P(theta,0) + P(phi, N-1)*P(theta,1) ... + P(phi, N-N)*P(theta,N), where P(i, N) is a polynomial over "i" of degree N (float32, [(N + 1) * (N + 2) / 2,])
 
     vertical_poly_inverse: np.ndarray = util.numpy_array_field(
         np.float32
-    )  #: Polynomial coefficients used to evaluate the inverse distortion in backprojection of the vertical component of a ray via it's projected angle theta=asin(y/norm(x,y)). The polynomial is of order M in both phi and theta with the form P(phi,M)*P(theta,0) + P(phi, M-1)*P(theta,1) ... + P(phi, M-M)*P(theta,M), where P(i, M) is a polynomial over "i" of degree M (float32, [(M + 1) * (M + 2) / 2,])
+    )  #: Polynomial coefficients used to evaluate the inverse distortion in backprojection of the vertical component of a ray via its projected angle theta=asin(y/norm(x,y)). The polynomial is of order M in both phi and theta with the form P(phi,M)*P(theta,0) + P(phi, M-1)*P(theta,1) ... + P(phi, M-M)*P(theta,M), where P(i, M) is a polynomial over "i" of degree M (float32, [(M + 1) * (M + 2) / 2,])
 
     @staticmethod
     def type() -> str:
@@ -156,7 +156,7 @@ class CameraModelParameters(ABC):
     shutter_type: ShutterType = util.enum_field(ShutterType)  #: Shutter type of the camera's imaging sensor
 
     external_distortion_parameters: Optional[ConcreteExternalDistortionParametersUnion] = (
-        None  #: Optional external distortion source associated to the camera (e.g. windshield). If a source exits, rays will be distorted prior to reaching the camera and it's associated lens distortion if applicable
+        None  #: Optional external distortion source associated to the camera (e.g. windshield). If a source exists, rays will be distorted prior to reaching the camera and its associated lens distortion if applicable
     )
 
     @abstractmethod

--- a/ncore/impl/sensors/camera.py
+++ b/ncore/impl/sensors/camera.py
@@ -87,7 +87,7 @@ class BivariateWindshieldModel(ExternalDistortionModel):
     horizontal_poly: torch.Tensor  #: Polynomial used for horizontal component of distortion in forward direction
     vertical_poly: torch.Tensor  #: Polynomial used for vertical component of distortion in forward direction
 
-    # Backward correction coefficient (transforms internal to external)
+    # Backward correction coefficients (transforms internal to external)
     horizontal_poly_inverse: (
         torch.Tensor
     )  #: Polynomial used for horizontal component of distortion in backward direction
@@ -234,7 +234,7 @@ class CameraModel(BaseModel, ABC):
     external_distortion: Optional[
         ExternalDistortionModel
     ]  #: Source of distortion external to the camera (e.g. windshield). Can be empty (None) if no such source exists.
-    #  If a source exits, rays will be distorted prior to reaching the camera and it's associated lens distortion if applicable
+    #  If a source exists, rays will be distorted prior to reaching the camera and its associated lens distortion if applicable
 
     def __init__(
         self, camera_model_parameters: types.CameraModelParameters, device: Union[str, torch.device], dtype: torch.dtype


### PR DESCRIPTION
Small documentation fix to test the merge queue.

- "exits" -> "exists"
- "it's" -> "its" (possessive, not contraction)
- "coefficient" -> "coefficients" (plural to match forward section headers)