### PR TITLE
fix(ci): restrict cache-save to push events only

### DIFF
--- a/.github/actions/setup-bazel/action.yml
+++ b/.github/actions/setup-bazel/action.yml
@@ -78,8 +78,10 @@ runs:
           - MODULE.bazel
           - deps/pip/requirements_3_8.txt
           - deps/pip/requirements_3_11.txt
-        # Only save caches on push (not on PRs) to avoid cache pollution
-        cache-save: ${{ github.event_name != 'pull_request' }}
+        # Only save caches on push to main/PR branches (not on merge_group) to avoid
+        # cache pollution. merge_group runs use ephemeral refs that are never reused,
+        # so caches saved there waste the 10 GB budget without any restore benefit.
+        cache-save: ${{ github.event_name == 'push' }}
         # Bump to force-invalidate all CI caches (e.g. after changing cache structure)
         cache-version: 2
         # Add custom bazelrc options: color / timestamps / conditionally skip GPU tests


### PR DESCRIPTION
## Problem

After adding `merge_group` triggers (for GitHub merge queue), cache restoration
started failing on merge queue runs. This is because:

1. `merge_group` runs execute under ephemeral one-shot refs
   (`refs/gh-readonly-queue/main/pr-*-*`). GitHub Actions caches are scoped by
   ref, so caches saved from these refs are never restored by subsequent runs.

2. The previous condition `github.event_name != 'pull_request'` evaluates to
   `true` for `merge_group` events, causing caches to be saved to dead-end ref
   scopes -- wasting the 10 GB repository cache budget without any restore benefit.

## Fix

Change the `cache-save` condition from:
```yaml
cache-save: ${{ github.event_name != 'pull_request' }}
```

to:
```yaml
cache-save: ${{ github.event_name == 'push' }}
```

This ensures only `push` events (to `main` and `pull-request/*` branches) save
caches. `merge_group` runs still **restore** from `main`'s cache via the
restore-key prefix fallback, they just don't save unreachable entries.