### PR TITLE
ci: remove redundant tag trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ on:
     branches:
     - main
     - 'pull-request/[0-9]+'
-    tags:
-    - '**'
   merge_group:
     branches: [main]
 


### PR DESCRIPTION
Tag push events trigger `build-and-test` but the deploy/publish jobs all gate on `github.ref == 'refs/heads/main' && github.event_name == 'push'`, so the tag-triggered runs are purely redundant -- the code was already tested when it landed on main.

This removes the `tags: ['**']` trigger, leaving only branch pushes and merge_group events.