### PR TITLE
perf(ci): drop repository-cache to eliminate 3 min download overhead

### DIFF
--- a/.github/actions/setup-bazel/action.yml
+++ b/.github/actions/setup-bazel/action.yml
@@ -70,26 +70,20 @@ runs:
         bazelisk-cache: true
         # Store build cache per workflow
         disk-cache: ${{ github.workflow }}
-        # Share repository cache between workflows.
-        # The repo contents cache (--repo_contents_cache, enabled by default since Bazel 8.3.0)
-        # lives under the repository cache directory, so caching it here also persists
-        # cached repo contents (Python interpreters, pip wheels, etc.) across CI runs.
-        repository-cache: |
-          - MODULE.bazel
-          - deps/pip/requirements_3_8.txt
-          - deps/pip/requirements_3_11.txt
+        # Skip repository-cache: at ~12 GB it takes longer to download+extract than
+        # to let Bazel re-fetch wheels in parallel. The committed MODULE.bazel.lock
+        # eliminates PyPI index queries, and the disk-cache covers build actions.
         # Only save caches on push to main/PR branches (not on merge_group) to avoid
         # cache pollution. merge_group runs use ephemeral refs that are never reused,
         # so caches saved there waste the 10 GB budget without any restore benefit.
         cache-save: ${{ github.event_name == 'push' }}
         # Bump to force-invalidate all CI caches (e.g. after changing cache structure)
-        cache-version: 2
+        cache-version: 3
         # Add custom bazelrc options: color / timestamps / conditionally skip GPU tests
         bazelrc: |
             build --color=yes
             build --show_timestamps
             ${{ inputs.gpu-enabled != 'true' && 'test --config=no-gpu' || '' }}
-            common --repo_contents_cache=~/.cache/bazel-repo/contents
 
     # Ensure bazelisk is on PATH for subsequent steps. The setup-bazel action
     # uses core.addPath() which doesn't propagate through composite actions


### PR DESCRIPTION
## Problem

The 12 GB repository cache takes **~3 min** to download and extract (serial tar decompression at ~120 MB/s). Despite this cost, the analysis phase still stalls for ~2.5 min materializing whl_library repos. The cache is a net negative -- it adds more latency than it saves.

## Why it's now safe to remove

With PR #134 landing the committed `MODULE.bazel.lock`:
- **PyPI Simple API queries are eliminated** -- the lockfile caches all module extension outputs
- **The disk-cache (191 MB, ~2s restore)** covers all build actions and test results
- Bazel re-fetches pip wheels **in parallel** on cold runs, which is comparable to or faster than the serial 12 GB tar extraction

## Changes

1. Remove `repository-cache` from `setup-bazel` configuration
2. Remove `--repo_contents_cache` bazelrc injection (Bazel 8.3+ enables this by default anyway; it just uses the default location now)
3. Bump `cache-version` to 3 to invalidate the now-unused 12 GB cache entries

## Expected Impact

- **Eliminates ~3 min** of cache download+extract on every run
- CI cache budget drops from ~36 GB to **~500 MB** (just bazelisk + disk-cache)
- Cold runs (no disk cache) will re-fetch wheels in parallel -- expected ~2 min penalty
- Warm runs (disk cache hit) should complete in **~3-4 min** total

## Risk

First run after merge will be a cold build (disk-cache key changes due to version bump). Subsequent runs will be fast once the new disk-cache is saved.