### PR TITLE
build(bazelignore): Ignore .venv directory in .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -18,4 +18,5 @@ bazel-out
 bazel-testlogs
 modules
 
+.venv
 .worktrees


### PR DESCRIPTION
This pull request makes a small update to the `.bazelignore` file by adding the `.venv` directory to the list of ignored paths. This helps ensure that Bazel does not process or cache files from Python virtual environments.