### PR TITLE
fix(nuscenes): Update alias name for nuscenes data converter

### DIFF
--- a/tools/data_converter/nuscenes/BUILD.bazel
+++ b/tools/data_converter/nuscenes/BUILD.bazel
@@ -58,7 +58,7 @@ py_binary(
 )
 
 alias(
-    name = "nuscenes-v4",
+    name = "nuscenes",
     actual = ":convert",
 )
 


### PR DESCRIPTION
- Renamed the Bazel alias from `nuscenes-v4` to `nuscenes` in the `tools/data_converter/nuscenes/BUILD.bazel` file
- This way targets `//tools/data_converter/nuscenes` are valid