### PR TITLE
feat(tools): rectification in ncore_vis + export resolution override

### DIFF
--- a/docs/tools/data_vis.rst
+++ b/docs/tools/data_vis.rst
@@ -218,6 +218,21 @@ relative to the inferred default without computing an explicit angle, e.g.
 ``--rectify-fov-factor 0.8`` to keep the central 80% of the natural field of
 view.
 
+``--rectify-resolution`` (e.g. ``1280x720``) exports the rectified pinhole at a
+different output resolution / aspect ratio than the source. The rectified
+intrinsics are re-canvassed onto the requested resolution while preserving the
+per-axis field of view (the focal length and principal point scale with the
+resolution). When omitted, the source resolution is kept. For example::
+
+    bazel run //tools:ncore_export_camera \
+        -- \
+        --output-dir=<OUTPUT_FOLDER> \
+        --camera-id=camera00 \
+        --rectify \
+        --rectify-resolution=1280x720 \
+        v4 \
+        --component-group=<SEQUENCE_META.json>
+
 .. list-table::
    :header-rows: 1
    :widths: 30 10 60
@@ -255,4 +270,7 @@ view.
    * - ``--rectify-fov-factor``
      - ``1.0``
      - Multiplicative factor on the (target or natural) field of view (``> 1`` widens, ``< 1`` narrows)
+   * - ``--rectify-resolution``
+     - (source resolution)
+     - Output resolution ``WxH`` of the rectified pinhole (different resolution / aspect ratio than the source)
 

--- a/docs/tools/ncore_vis.rst
+++ b/docs/tools/ncore_vis.rst
@@ -140,6 +140,14 @@ The **Overlay Settings** folder (collapsed by default) in the Cameras tab
 contains shared controls that apply uniformly to all cameras, grouped by
 feature with the toggle as the first entry in each group:
 
+Rectification:
+
+- **Rectify**: toggle rectification of all camera images to an ideal
+  (distortion-free) pinhole. Overlays project into the rectified target model so
+  they stay faithful with the rectification (see :ref:`rectification`).
+- **Rectify FOV Scale**: scale of the rectified field of view relative to the
+  camera's natural field of view (``> 1`` widens, ``< 1`` narrows)
+
 Cuboid overlay:
 
 - **Overlay Cuboids**: toggle cuboid edge projection on all cameras
@@ -157,6 +165,18 @@ Mask overlay (only shown if masks are available):
 - **Show Mask**: toggle mask overlay on all cameras
 - **Mask Name**: select a named camera mask to overlay
 - **Mask Opacity**: transparency of the mask color tint (default 0.3)
+
+Camera Rectification
+^^^^^^^^^^^^^^^^^^^^
+
+When **Rectify** is enabled, each camera image is remapped to an ideal
+(distortion-free) pinhole using a :class:`~ncore.sensors.Rectificator`, and the
+active camera model used for all overlay projections (lidar, radar, point
+clouds, cuboids) is switched to that ideal-pinhole target so the overlays remain
+aligned with the rectified image. The **Rectify FOV Scale** slider multiplies
+the camera's natural field of view (``> 1`` widens, ``< 1`` narrows); widening
+past the captured field of view yields black borders. See :ref:`rectification`
+for the underlying conversion.
 
 Camera Cuboid Overlay
 ^^^^^^^^^^^^^^^^^^^^^

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -49,3 +49,21 @@ class NPArrayParamType(click.ParamType):
             return np.fromstring(value.replace("[", "").replace("]", ""), sep=",", dtype=self.dtype).reshape(self.dim)
         except ValueError:
             self.fail(f"{value!r} is not a valid numpy array", param, ctx)
+
+
+class ResolutionParamType(click.ParamType):
+    """Click cmdl argument type for a ``'WxH'`` image resolution -> ``(width, height)``"""
+
+    name = "WxH"
+
+    def convert(self, value: Optional[str], param, ctx) -> Optional[Tuple[int, int]]:
+        if value is None:
+            return None
+        try:
+            width_str, height_str = value.lower().split("x")
+            width, height = int(width_str), int(height_str)
+        except ValueError:
+            self.fail(f"{value!r} is not a valid resolution, expected 'WxH' (e.g. '1920x1080')", param, ctx)
+        if width <= 0 or height <= 0:
+            self.fail(f"resolution must be positive, got {value!r}", param, ctx)
+        return (width, height)

--- a/tools/ncore_export_camera.py
+++ b/tools/ncore_export_camera.py
@@ -38,9 +38,9 @@ from ncore.impl.sensors.rectification import Rectificator
 
 
 try:
-    from .cli import OptionalStrParamType
+    from .cli import OptionalStrParamType, ResolutionParamType
 except ImportError:
-    from tools.cli import OptionalStrParamType
+    from tools.cli import OptionalStrParamType, ResolutionParamType
 
 
 @dataclass(kw_only=True, slots=True, frozen=True)
@@ -60,6 +60,7 @@ class CLIBaseParams:
         rectify: Whether to rectify frames to an ideal pinhole camera before exporting
         rectify_target_fov_deg: Optional target full field of view [deg] of the rectified pinhole
         rectify_fov_factor: Multiplicative factor applied to the target (or natural) field of view
+        rectify_resolution: Optional output resolution (width, height) of the rectified pinhole
     """
 
     camera_id: str
@@ -74,6 +75,7 @@ class CLIBaseParams:
     rectify: bool
     rectify_target_fov_deg: Optional[float]
     rectify_fov_factor: float
+    rectify_resolution: Optional[Tuple[int, int]]
 
 
 @click.group()
@@ -121,6 +123,13 @@ class CLIBaseParams:
     default=1.0,
     help="Multiplicative factor applied to the (target or natural) field of view before rectifying; "
     ">1 widens, <1 narrows (only used with --rectify)",
+)
+@click.option(
+    "--rectify-resolution",
+    type=ResolutionParamType(),
+    default=None,
+    help="Output resolution 'WxH' of the rectified pinhole, allowing a different resolution / aspect "
+    "ratio than the source (only used with --rectify). If omitted, the source resolution is kept.",
 )
 @click.pass_context
 def cli(ctx, **kwargs):
@@ -202,6 +211,20 @@ def _build_rectificator(
 
     target_parameters = IdealPinholeCameraModelParameters.from_source(source_parameters, target_fov=target_fov)
 
+    # Optionally re-canvas onto a different output resolution / aspect ratio. A per-axis
+    # image-domain scale (new_res / current_res) scales the focal length and principal
+    # point together with the resolution, so the field of view is preserved on each axis
+    # (a pinhole's per-axis FOV = 2*atan(half_extent / focal) is invariant to this scale).
+    if params.rectify_resolution is not None:
+        current_resolution = target_parameters.resolution
+        scale = (
+            float(params.rectify_resolution[0]) / float(current_resolution[0]),
+            float(params.rectify_resolution[1]) / float(current_resolution[1]),
+        )
+        target_parameters = target_parameters.transform(
+            image_domain_scale=scale, new_resolution=params.rectify_resolution
+        )
+
     source_model = CameraModel.from_parameters(source_parameters, device="cpu")
     target_model = CameraModel.from_parameters(target_parameters, device="cpu")
     return Rectificator(source_model, target_model), target_parameters
@@ -231,7 +254,8 @@ def run(params: CLIBaseParams, loader: SequenceLoaderProtocol) -> None:
             json.dump(encode_camera_model_parameters(target_parameters), f, indent=2)
         logger.info(
             f"Rectifying '{params.camera_id}' to an ideal pinhole "
-            f"(target_fov_deg={params.rectify_target_fov_deg}, fov_factor={params.rectify_fov_factor}). "
+            f"(target_fov_deg={params.rectify_target_fov_deg}, fov_factor={params.rectify_fov_factor}, "
+            f"resolution={params.rectify_resolution}). "
             f"Rectified intrinsics written to '{intrinsics_path}'"
         )
 

--- a/tools/ncore_vis/BUILD.bazel
+++ b/tools/ncore_vis/BUILD.bazel
@@ -89,6 +89,7 @@ py_library(
         "//ncore/impl/data:pylib_types",
         "//ncore/impl/data:pylib_util",
         "//ncore/impl/sensors:pylib_camera",
+        "//ncore/impl/sensors:pylib_rectification",
         "//tools:pylib_colormaps",
         requirement("numpy"),
         requirement("opencv_python_headless"),

--- a/tools/ncore_vis/components/camera.py
+++ b/tools/ncore_vis/components/camera.py
@@ -30,9 +30,10 @@ import viser
 from scipy.spatial.transform import Rotation as RotLib
 
 from ncore.impl.common.transformations import HalfClosedInterval, transform_point_cloud
-from ncore.impl.data.types import FrameTimepoint, LabelCategory, LabelSource
+from ncore.impl.data.types import FrameTimepoint, IdealPinholeCameraModelParameters, LabelCategory, LabelSource
 from ncore.impl.data.util import closest_index_sorted
 from ncore.impl.sensors.camera import CameraModel
+from ncore.impl.sensors.rectification import Rectificator
 from tools.colormaps import jet as jet_colormap
 from tools.colormaps import turbo as turbo_colormap
 from tools.ncore_vis.components.base import VisualizationComponent, register_component
@@ -232,6 +233,16 @@ class CameraComponent(VisualizationComponent):
         # Camera model device and cached CameraModel instances (one per camera sensor)
         self._device: str = "cuda" if torch.cuda.is_available() else "cpu"
         self._camera_models: Dict[str, CameraModel] = {}
+
+        # Optional rectification to an ideal pinhole camera. When enabled, camera images
+        # are remapped to a distortion-free pinhole and overlays project into that target
+        # domain so they stay faithful. ``_rectify_fov_factor`` scales the natural field of
+        # view (>1 widens, <1 narrows).
+        self._rectify: bool = False
+        self._rectify_fov_factor: float = 1.0
+        self._target_models: Dict[str, CameraModel] = {}
+        self._rectificators: Dict[str, Rectificator] = {}
+
         self._build_camera_models()
 
         # Cache camera aspect ratios and load static masks
@@ -288,6 +299,26 @@ class CameraComponent(VisualizationComponent):
                     self._device = device_dropdown.value
                     self._build_camera_models()
                     self._refresh_all_cameras()
+
+                # -- Rectification to an ideal pinhole --
+                rectify_checkbox = self.client.gui.add_checkbox(
+                    "Rectify",
+                    initial_value=self._rectify,
+                    hint="Rectify camera images to an ideal (distortion-free) pinhole; overlays project faithfully",
+                )
+                rectify_fov_slider = self.client.gui.add_slider(
+                    "Rectify FOV Scale",
+                    min=0.3,
+                    max=1.5,
+                    step=0.05,
+                    initial_value=self._rectify_fov_factor,
+                    hint="Scale of the rectified field of view relative to the camera's natural FOV "
+                    "(>1 widens, <1 narrows)",
+                )
+                self._bind_rectification_settings(
+                    rectify_checkbox=rectify_checkbox,
+                    rectify_fov_slider=rectify_fov_slider,
+                )
 
                 # -- Cuboid overlay --
                 overlay_cuboids_checkbox = self.client.gui.add_checkbox(
@@ -719,7 +750,12 @@ class CameraComponent(VisualizationComponent):
             self._refresh_all_cameras()
 
     def _build_camera_models(self) -> None:
-        """Build (or rebuild) the per-camera :class:`CameraModel` cache using ``self._device``."""
+        """Build (or rebuild) the per-camera :class:`CameraModel` cache using ``self._device``.
+
+        Also (re)builds the ideal-pinhole target models and :class:`Rectificator` instances
+        used when rectification is enabled. Call after changing ``self._device``,
+        ``self._rectify`` or ``self._rectify_fov_factor``.
+        """
         self._camera_models = {
             camera_id: CameraModel.from_parameters(
                 self.data_loader.get_camera_sensor(camera_id).model_parameters,
@@ -728,6 +764,47 @@ class CameraComponent(VisualizationComponent):
             )
             for camera_id in self.data_loader.camera_ids
         }
+
+        self._target_models = {}
+        self._rectificators = {}
+        if self._rectify:
+            for camera_id in self.data_loader.camera_ids:
+                source_params = self.data_loader.get_camera_sensor(camera_id).model_parameters
+                target_fov = self._rectify_fov_factor * IdealPinholeCameraModelParameters.natural_fov(source_params)
+                target_params = IdealPinholeCameraModelParameters.from_source(source_params, target_fov=target_fov)
+                target_model = CameraModel.from_parameters(target_params, device=self._device, dtype=torch.float32)
+                self._target_models[camera_id] = target_model
+                self._rectificators[camera_id] = Rectificator(self._camera_models[camera_id], target_model)
+
+    def _render_camera_model(self, camera_id: str) -> CameraModel:
+        """Returns the camera model overlays should project into for *camera_id*.
+
+        When rectification is enabled this is the ideal-pinhole target model (so overlays
+        align with the rectified image); otherwise the source camera model.
+        """
+        if self._rectify and camera_id in self._target_models:
+            return self._target_models[camera_id]
+        return self._camera_models[camera_id]
+
+    def _bind_rectification_settings(
+        self,
+        rectify_checkbox: viser.GuiInputHandle[bool],
+        rectify_fov_slider: viser.GuiInputHandle[float],
+    ) -> None:
+        """Wire the rectification toggle and FOV-scale slider (rebuild targets, then refresh)."""
+
+        @rectify_checkbox.on_update
+        def _(_: viser.GuiEvent) -> None:
+            self._rectify = rectify_checkbox.value
+            self._build_camera_models()
+            self._refresh_all_cameras()
+
+        @rectify_fov_slider.on_update
+        def _(_: viser.GuiEvent) -> None:  # type: ignore[no-redef]
+            self._rectify_fov_factor = rectify_fov_slider.value
+            if self._rectify:
+                self._build_camera_models()
+                self._refresh_all_cameras()
 
     def _refresh_all_cameras(self) -> None:
         """Re-render all cameras in parallel (used when a shared overlay setting changes)."""
@@ -789,6 +866,14 @@ class CameraComponent(VisualizationComponent):
                 pil_img = pil_img.convert("RGB")
             image = np.asarray(pil_img)
 
+            # Optional rectification to an ideal pinhole (overlays below project into the
+            # rectified target domain via _render_camera_model, so they stay faithful).
+            aspect = self._aspects[camera_id]
+            if self._rectify and (rectificator := self._rectificators.get(camera_id)) is not None:
+                image = rectificator.apply(image).detach().cpu().numpy().astype(np.uint8)
+                width, height = self._target_models[camera_id].resolution.tolist()
+                aspect = float(width) / float(height)
+
             if self._project_lidar:
                 try:
                     image = self._overlay_lidar_projection(camera_id, frame_idx, image)
@@ -833,7 +918,7 @@ class CameraComponent(VisualizationComponent):
             frustum_handle = self.client.scene.add_camera_frustum(
                 f"/cameras/{camera_id}/pose/frustum",
                 fov=_DEFAULT_CAMERA_FOV,
-                aspect=self._aspects[camera_id],
+                aspect=aspect,
                 scale=_DEFAULT_CAMERA_SCALE,
                 image=image,
                 visible=visible,
@@ -987,7 +1072,7 @@ class CameraComponent(VisualizationComponent):
 
         cam = self.data_loader.get_camera_sensor(camera_id)
         lidar_sensor = self.data_loader.get_lidar_sensor(lidar_id)
-        camera_model = self._camera_models[camera_id]
+        camera_model = self._render_camera_model(camera_id)
 
         # Find closest lidar frame to the camera frame (by center-of-frame timestamp)
         cam_interval = self.data_loader.get_sensor_frame_interval_us(camera_id, frame_idx)
@@ -1073,7 +1158,7 @@ class CameraComponent(VisualizationComponent):
         """Project a single radar sensor's point cloud onto *image* (mutates in-place)."""
         cam = self.data_loader.get_camera_sensor(camera_id)
         radar_sensor = self.data_loader.get_radar_sensor(radar_id)
-        camera_model = self._camera_models[camera_id]
+        camera_model = self._render_camera_model(camera_id)
 
         # Find closest radar frame to the camera frame (by center-of-frame timestamp)
         cam_interval = self.data_loader.get_sensor_frame_interval_us(camera_id, frame_idx)
@@ -1149,7 +1234,7 @@ class CameraComponent(VisualizationComponent):
 
         cam = self.data_loader.get_camera_sensor(camera_id)
         source = self.data_loader.get_point_clouds_source(source_id)
-        camera_model = self._camera_models[camera_id]
+        camera_model = self._render_camera_model(camera_id)
 
         if source.pcs_count == 0:
             return image
@@ -1299,7 +1384,7 @@ class CameraComponent(VisualizationComponent):
             Copy of the image with visible cuboid edges drawn.
         """
         cam = self.data_loader.get_camera_sensor(camera_id)
-        camera_model = self._camera_models[camera_id]
+        camera_model = self._render_camera_model(camera_id)
 
         world_id = self.data_loader.world_frame_id
         pose_graph = self.data_loader.pose_graph


### PR DESCRIPTION
## Summary

Two rectification-related tool features building on the merged ideal-pinhole / `Rectificator` work (PR #143). No library/API changes.

1. **`ncore_vis` camera rectification** — view rectified camera images in the visualizer, with overlays (lidar / radar / point clouds / cuboids) projected faithfully into the rectified domain. Optional FOV-scale slider.
2. **`ncore_export_camera` resolution override** — export rectified frames at a different resolution / aspect ratio than the source.

## 1. ncore_vis camera rectification

- New **"Rectify"** checkbox + **"Rectify FOV Scale"** slider in the camera Overlay Settings.
- When enabled, each camera image is remapped to an ideal pinhole via a `Rectificator`, and all overlays project into the **target** (ideal-pinhole) model so they stay aligned with the rectified image (i.e. it tweaks the active camera model used for projections).
- Per-camera target models + `Rectificator`s are built alongside the camera models and rebuilt when the projection device, rectify toggle, or FOV scale changes (mirroring the existing device-rebuild pattern).
- Overlays use a new `_render_camera_model()` accessor (target model when rectifying, source otherwise); the frustum aspect follows the target resolution.
- FOV scale multiplies the camera's natural FOV (`> 1` widens, `< 1` narrows).

<img width="1607" height="983" alt="image" src="https://github.com/user-attachments/assets/37787216-7dc1-4c0e-83e0-02852ee36c42" />

## 2. ncore_export_camera resolution

- New `--rectify-resolution WxH` (e.g. `1280x720`) exports the rectified pinhole at a different resolution / aspect ratio than the source.
- Implemented purely in the tool: after building the ideal-pinhole target via `from_source(...)`, a per-axis image-domain `transform(new_res / current_res, new_resolution=...)` re-canvasses it onto the requested resolution. Because the focal length and principal point scale with the resolution, the per-axis field of view is preserved. If omitted, the source resolution is kept.

### Examples

Original
<img width="960" height="540" alt="original" src="https://github.com/user-attachments/assets/e63b24e3-686a-4298-b35b-d84ae23fe1e4" />

https://github.com/user-attachments/assets/82ce2457-e076-4cb0-93b4-88c816d4c549


Rectified Natural
<img width="960" height="540" alt="rectified_natural_fov" src="https://github.com/user-attachments/assets/7c448296-c5df-47fb-9d08-c6e602daf779" />

https://github.com/user-attachments/assets/afcae555-52f7-47e7-a53c-11931e026f55

Rectified 1.45 scale
<img width="960" height="540" alt="rectified_scale_1 45" src="https://github.com/user-attachments/assets/9f58d128-6729-45c1-821b-0a7b203d4017" />

https://github.com/user-attachments/assets/c3e2cf82-f976-4d1d-8f11-5f4a3c261ff5

## Testing

- Existing ideal-pinhole / factory / rectification tests unchanged and passing (102 passed, 1 skipped GPU) — no library changes.
- Smoke-tested on real PAI data: `--rectify-resolution 1280x720` produces a 1280x720 image whose per-axis FOV (91.97/60.50 deg) is identical to the default 1920x1080 export; the vis rectification path (target-model build + `Rectificator.apply` + aspect) verified across FOV scales.
- `ruff` + `ty` clean on changed files (incl. the viser component); `bazel run format` clean.

## Notes

- Added `//ncore/impl/sensors:pylib_rectification` to `//tools/ncore_vis:pylib_components` deps (camera component now imports `Rectificator`).
- The vis GUI itself can't be exercised in headless CI (interactive viser); validated via the underlying rectification building blocks on real data.
