### PR TITLE
Fix IndexedTarStore writer reload truncation

### DIFF
--- a/ncore/impl/data/stores.py
+++ b/ncore/impl/data/stores.py
@@ -262,9 +262,9 @@ class IndexedTarStore(Store):
                 self.tar_file_object = self.itar_upath.open("rb")
             else:
                 # universal_path for Python 3.8 (<=0.2.6) doesn't expose a
-                # write/read mode in it's static type-hints, although "wb+" is still accepted
+                # write/read mode in it's static type-hints, although "rb+" is still accepted
                 # if the FS supports it, so ignore type-checker here
-                self.tar_file_object = self.itar_upath.open("wb+")  # type: ignore[call-overload]
+                self.tar_file_object = self.itar_upath.open("rb+")  # type: ignore[call-overload]
 
             if self.mode == "w":
                 # assign the new file object to the tar file (only required for write mode)

--- a/ncore/impl/data/stores_test.py
+++ b/ncore/impl/data/stores_test.py
@@ -132,6 +132,29 @@ class TestIndexedTarStore(unittest.TestCase):
                     else:
                         zarr.open(store=s_itar_in, mode="r")
 
+    def test_reload_resources_preserves_write_mode_archive(self):
+        """Verify writer resource reload does not truncate already-written archive data."""
+        with tempfile.NamedTemporaryFile(suffix=".itar") as f:
+            with IndexedTarStore(f.name, mode="w") as store:
+                store["first"] = b"first payload"
+                store.tar_file_object.flush()
+
+                size_before_reload = Path(f.name).stat().st_size
+                self.assertGreater(size_before_reload, 0)
+
+                store.reload_resources()
+
+                self.assertEqual(Path(f.name).stat().st_size, size_before_reload)
+                self.assertEqual(store["first"], b"first payload")
+
+                store["second"] = b"second payload"
+                self.assertEqual(store["first"], b"first payload")
+                self.assertEqual(store["second"], b"second payload")
+
+            with IndexedTarStore(f.name, mode="r") as store:
+                self.assertEqual(store["first"], b"first payload")
+                self.assertEqual(store["second"], b"second payload")
+
     def test_index_tail_cache_avoids_extra_file_reads(self):
         """Payloads fully covered by the index tail read must not trigger further ``read()`` calls."""
 


### PR DESCRIPTION
## Summary

`IndexedTarStore.reload_resources()` reopened write-mode archives with `wb+`, which truncates the archive during an in-progress write. This changes the writer reload path to reopen the existing archive with `rb+` so already-written tar payloads remain intact.

I also added a regression test that writes one entry, reloads writer resources, verifies the file size and payload are preserved, writes a second entry, and then reopens the archive in read mode to check both entries.

## Test

`PYTHONPATH=$PWD uv run --no-project --python 3.12 --with 'pytest==8.3.4' --with 'cbor2==5.9.0' --with 'numcodecs==0.15.1' --with 'numpy==1.26.4' --with 'parameterized==0.9.0' --with 'universal-pathlib==0.3.6' --with 'zarr==2.18.4' pytest -q ncore/impl/data/stores_test.py`

Result: `26 passed`
