### PR TITLE
test(nuscenes): update camera intrinsics test for ideal pinhole model

### DIFF
--- a/tools/data_converter/nuscenes/converter_test.py
+++ b/tools/data_converter/nuscenes/converter_test.py
@@ -34,7 +34,7 @@ import torch
 from parameterized import parameterized_class
 from upath import UPath
 
-from ncore.impl.data.types import OpenCVPinholeCameraModelParameters, RowOffsetStructuredSpinningLidarModelParameters
+from ncore.impl.data.types import IdealPinholeCameraModelParameters, RowOffsetStructuredSpinningLidarModelParameters
 from ncore.impl.data.v4.components import (
     CameraSensorComponent,
     CuboidsComponent,
@@ -167,8 +167,13 @@ class TestNuScenesConverter(unittest.TestCase):
         for cam_id, cam_reader in camera_readers.items():
             self.assertGreater(cam_reader.frames_count, 0, f"{cam_id} should have frames")
 
-    def test_camera_intrinsics_zero_distortion(self):
-        """Verify camera intrinsics have zero distortion (undistorted images)."""
+    def test_camera_intrinsics_ideal_pinhole(self):
+        """Verify camera intrinsics are distortion-free ideal pinholes.
+
+        nuScenes images are already undistorted, so the converter stores an ideal
+        (distortion-free) pinhole model -- there are no distortion coefficients to
+        check, only valid focal length and principal point.
+        """
         intrinsics_readers = self.reader.open_component_readers(IntrinsicsComponent.Reader)
         self.assertEqual(len(intrinsics_readers), 1)
         intrinsics_reader = list(intrinsics_readers.values())[0]
@@ -182,11 +187,10 @@ class TestNuScenesConverter(unittest.TestCase):
             "camera_back_right",
         ]:
             params = intrinsics_reader.get_camera_model_parameters(cam_id)
-            self.assertIsInstance(params, OpenCVPinholeCameraModelParameters)
-            params = cast(OpenCVPinholeCameraModelParameters, params)
-            np.testing.assert_array_equal(params.radial_coeffs, np.zeros(6, dtype=np.float32))
-            np.testing.assert_array_equal(params.tangential_coeffs, np.zeros(2, dtype=np.float32))
+            self.assertIsInstance(params, IdealPinholeCameraModelParameters)
+            params = cast(IdealPinholeCameraModelParameters, params)
             self.assertTrue(np.all(params.focal_length > 0))
+            self.assertTrue(np.all(params.principal_point > 0))
 
     def test_camera_extrinsics_stored_as_static_poses(self):
         """Verify each camera has a static sensor -> rig extrinsic pose."""


### PR DESCRIPTION
## Summary

`tools/data_converter/nuscenes/converter_test.py::test_camera_intrinsics_zero_distortion` fails on the current converter output:

```
AssertionError: IdealPinholeCameraModelParameters(...) is not an instance of
<class 'ncore.impl.data.types.OpenCVPinholeCameraModelParameters'>
```

The nuScenes converter was changed to store camera intrinsics as `IdealPinholeCameraModelParameters` (distortion-free) instead of `OpenCVPinholeCameraModelParameters`, but the test still asserted the OpenCV type and inspected its `radial_coeffs` / `tangential_coeffs`. The test was not updated alongside that converter change.

## Fix

Update the test (renamed to `test_camera_intrinsics_ideal_pinhole`) to:
- assert the `IdealPinholeCameraModelParameters` type the converter now emits, and
- validate `focal_length` and `principal_point` instead of distortion coefficients (an ideal pinhole is distortion-free by construction, so there are none to check).

## Validation

`NUSCENES_DIR=... bazel test //tools/data_converter/nuscenes:pytest_converter_3_11` passes (the full converter integration suite, both `itar` and `directory` store types).

This is split out from the lidar-model fix (#148) since it is an independent, pre-existing test/converter inconsistency.
