### PR TITLE
fix(evaluate-lidar-model): Downstream inclusing via local / relative …

### DIFF
--- a/tools/ncore_evaluate_lidar_model.py
+++ b/tools/ncore_evaluate_lidar_model.py
@@ -65,13 +65,14 @@ from ncore.impl.data.v4.compat import SequenceLoaderProtocol, SequenceLoaderV4
 from ncore.impl.data.v4.components import SequenceComponentGroupsReader
 from ncore.impl.sensors.camera import CameraModel
 from ncore.impl.sensors.lidar import StructuredLidarModel
-from tools.colormaps import turbo as turbo_colormap
 
 
 try:
     from .cli import OptionalStrParamType
+    from .colormaps import turbo as turbo_colormap
 except ImportError:
     from tools.cli import OptionalStrParamType
+    from tools.colormaps import turbo as turbo_colormap
 
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
This pull request updates import statements in `tools/ncore_evaluate_lidar_model.py` to ensure the correct `turbo_colormap` is imported, regardless of the module's execution context.

Improvements to import handling:

* Modified the import logic to import `turbo_colormap` from `.colormaps` when running as a module, and from `tools.colormaps` otherwise, ensuring compatibility in different execution environments.