### PR TITLE
fix(bazel): update bazel dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,11 +24,11 @@ module(
 
 bazel_dep(name = "aspect_rules_lint", version = "2.5.2")
 bazel_dep(name = "rules_uv", version = "0.88.0")
-bazel_dep(name = "rules_shell", version = "0.5.0")
+bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_multirun", version = "0.13.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.1")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
 
 ## protobuf


### PR DESCRIPTION
This pull request updates dependency versions in the `MODULE.bazel` file to keep the project up-to-date with the latest features and security patches.

Dependency upgrades:

* Upgraded `rules_shell` from version 0.5.0 to 0.6.1.
* Upgraded `bazel_skylib` from version 1.7.1 to 1.8.2.