### PR TITLE
refactor(data): memoize EncodedImageData.get_decoded_image per instance

### DIFF
--- a/ncore/impl/data/BUILD.bazel
+++ b/ncore/impl/data/BUILD.bazel
@@ -103,5 +103,6 @@ pytest_test(
         ":pylib_types",
         "//ncore/impl/common:pylib_transformations",
         requirement("numpy"),
+        requirement("pillow"),
     ],
 )

--- a/ncore/impl/data/types.py
+++ b/ncore/impl/data/types.py
@@ -23,7 +23,6 @@ import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
 from enum import IntEnum, auto, unique
-from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -1499,6 +1498,7 @@ class EncodedImageData:
     def __init__(self, encoded_image_data: bytes, encoded_image_format: str) -> None:
         self._encoded_image_data = encoded_image_data
         self._encoded_image_format = encoded_image_format
+        self._decoded_image: Optional[PILImage.Image] = None
 
     def get_encoded_image_data(self) -> bytes:
         """Returns encoded image data"""
@@ -1508,10 +1508,19 @@ class EncodedImageData:
         """Returns encoded image format"""
         return self._encoded_image_format
 
-    @lru_cache(maxsize=1)
     def get_decoded_image(self) -> PILImage.Image:
-        """Returns decoded image from image data"""
-        return PILImage.open(io.BytesIO(self.get_encoded_image_data()), formats=[self.get_encoded_image_format()])
+        """Returns decoded image from image data.
+
+        The result is memoized per instance. (Using ``functools.lru_cache`` on a
+        method is avoided here: it keys the cache on ``self`` and keeps a global,
+        process-wide strong reference to the instance, which both leaks memory and
+        survives ``fork()`` into DataLoader workers in whatever state it held.)
+        """
+        if self._decoded_image is None:
+            self._decoded_image = PILImage.open(
+                io.BytesIO(self.get_encoded_image_data()), formats=[self.get_encoded_image_format()]
+            )
+        return self._decoded_image
 
 
 class EncodedImageHandle(Protocol):

--- a/ncore/impl/data/types_test.py
+++ b/ncore/impl/data/types_test.py
@@ -13,15 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import unittest
 
 from typing import Optional
 
 import numpy as np
 import numpy.testing as npt
+import PIL.Image as PILImage
 
 from ncore.impl.common.transformations import PoseGraphInterpolator
-from ncore.impl.data.types import PointCloud
+from ncore.impl.data.types import EncodedImageData, PointCloud
 
 
 class TestPointCloud(unittest.TestCase):
@@ -310,3 +312,48 @@ class TestPointCloud(unittest.TestCase):
         # (0,1,0) rotated +90° Z -> (-1,0,0)
         pc_b = pc_world.transform("sensor_b", 0, pg)
         npt.assert_allclose(pc_b.get_attribute("normal"), [[-1.0, 0.0, 0.0]], atol=1e-6)
+
+
+def _encode_png(arr: np.ndarray) -> bytes:
+    buf = io.BytesIO()
+    PILImage.fromarray(arr, mode="RGB").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestEncodedImageData(unittest.TestCase):
+    """Tests for EncodedImageData decode."""
+
+    @staticmethod
+    def _sample_png() -> bytes:
+        rng = np.random.default_rng(0)
+        return _encode_png(rng.integers(0, 256, size=(8, 8, 3), dtype=np.uint8))
+
+    def test_decode_roundtrip(self) -> None:
+        """get_decoded_image() returns a usable image of the expected size."""
+        image = EncodedImageData(self._sample_png(), "PNG").get_decoded_image()
+        self.assertEqual(np.asarray(image.convert("RGB")).shape, (8, 8, 3))
+
+    def test_decode_is_memoized(self) -> None:
+        """Repeated calls return the same decoded object (per-instance memoization)."""
+        image_data = EncodedImageData(self._sample_png(), "PNG")
+        self.assertIs(image_data.get_decoded_image(), image_data.get_decoded_image())
+
+    def test_memoization_survives_interleaved_instances(self) -> None:
+        """Memoization is stable across interleaved use of other instances.
+
+        Guards against regressing to a method-level ``lru_cache(maxsize=1)``,
+        whose single global slot would be evicted by the intervening
+        ``other`` call, so ``first.get_decoded_image()`` would re-decode and
+        return a different object on the second call.
+        """
+        png = self._sample_png()
+        first = EncodedImageData(png, "PNG")
+        other = EncodedImageData(png, "PNG")
+        a1 = first.get_decoded_image()
+        other.get_decoded_image()  # would evict a method-level maxsize=1 cache
+        a2 = first.get_decoded_image()
+        self.assertIs(a1, a2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Replace `@lru_cache(maxsize=1)` on the `EncodedImageData.get_decoded_image`
method with per-instance memoization.

`lru_cache` on a *method* keys the cache on `self`, which:

- holds a process-wide strong reference to every cached instance (a memory
  leak), and
- with `maxsize=1`, evicts the single global slot whenever *any other*
  `EncodedImageData` instance decodes -- so it does not actually memoize per
  instance.

Storing the decoded image on the instance (`self._decoded_image`) fixes both:
stable per-instance memoization, and no global state that leaks or survives
`fork()` into DataLoader workers.

## Tests

Adds `TestEncodedImageData` in `types_test.py`:

- `test_decode_roundtrip` -- decode produces an image of the expected size.
- `test_decode_is_memoized` -- repeated calls on one instance return the same
  object.
- `test_memoization_survives_interleaved_instances` -- decoding another
  instance in between does not evict the first instance's cached image. This
  test fails against the old method-level `lru_cache(maxsize=1)` and passes
  with per-instance memoization, so it guards the regression.

Adds the `pillow` test dependency to the `pytest_types` target.

## Context

This came out of investigating a reported `'_idat' object has no attribute
'fileno'` crash in forked DataLoader workers, originally attributed to
`get_decoded_image()` returning a lazy PIL image. On closer inspection of the
real traceback that signature is a PNG **encode** path (PIL `ImageFile._save`,
where `_idat` is the PNG encoder wrapper), not this decode path, and in the
pinned Pillow (12.2.0) the relevant `fileno()` calls are guarded by
`except AttributeError`. So this PR does **not** claim to fix that crash; it is
a focused cleanup of an unrelated latent issue (the method-level `lru_cache`)
found during that investigation. Behavior of `get_decoded_image()` is otherwise
unchanged (still lazy decode via `PILImage.open`).

## Verification

- `bazel test //ncore/impl/data:pytest_types_3_11 //ncore/impl/data:pytest_types_3_8` -- pass.
- `bazel run format` -- clean.
