### PR TITLE
test(data): fix flaky quantized depth roundtrip tests

### DIFF
--- a/ncore/impl/data/v4/components_test.py
+++ b/ncore/impl/data/v4/components_test.py
@@ -2275,8 +2275,10 @@ class TestCameraLabelsComponent(unittest.TestCase):
             )
         )
 
-        # Original data in range [0, 65.535] so it fits uint16 after quantization
-        original = np.random.default_rng().random((32, 48), dtype=np.float32) * 60.0
+        # Original data in range [0, 65.535] so it fits uint16 after quantization.
+        # Seed the RNG so the test is deterministic and not flaky across CI runs.
+        max_value = 60.0
+        original = np.random.default_rng(0).random((32, 48), dtype=np.float32) * max_value
 
         writer.store_label(data=original, timestamp_us=1_000_000)
 
@@ -2285,8 +2287,12 @@ class TestCameraLabelsComponent(unittest.TestCase):
 
         dequantized = reader.get_label(1_000_000).get_data()
 
-        # Expect quantization error of at most 0.5 * scale = 0.0005
-        np.testing.assert_allclose(dequantized, original, atol=0.5 * quant.scale, rtol=0)
+        # Ideal quantization error is at most 0.5 * scale. Both `original` and the
+        # dequantized output are float32, so each carries up to ~max_value * eps_f32
+        # of representation error on top of the rounding error. Allow for that margin
+        # so the bound is not violated by float32 rounding alone.
+        atol = 0.5 * quant.scale + 2.0 * max_value * float(np.finfo(np.float32).eps)
+        np.testing.assert_allclose(dequantized, original, atol=atol, rtol=0)
 
         tmpdir.cleanup()
 
@@ -2316,8 +2322,9 @@ class TestCameraLabelsComponent(unittest.TestCase):
             )
         )
 
-        # Data in range [-100, 227.67] maps to int16 range [0, 32767]
-        original = (np.random.default_rng().random((16, 24), dtype=np.float32) * 300.0) - 100.0
+        # Data in range [-100, 227.67] maps to int16 range [0, 32767].
+        # Seed the RNG so the test is deterministic and not flaky across CI runs.
+        original = (np.random.default_rng(0).random((16, 24), dtype=np.float32) * 300.0) - 100.0
 
         writer.store_label(data=original, timestamp_us=1_000_000)
 
@@ -2356,7 +2363,8 @@ class TestCameraLabelsComponent(unittest.TestCase):
             )
         )
 
-        original = np.random.default_rng().random((16, 24), dtype=np.float32) * 60.0
+        # Seed the RNG so the test is deterministic and not flaky across CI runs.
+        original = np.random.default_rng(0).random((16, 24), dtype=np.float32) * 60.0
 
         writer.store_label(data=original, timestamp_us=1_000_000)
 


### PR DESCRIPTION
## Problem

The `test_quantized_depth_roundtrip` test in `ncore/impl/data/v4/components_test.py` fails intermittently in CI (e.g. [run 27951090321](https://github.com/NVIDIA/ncore/actions/runs/27951090321/job/82707893779?pr=158)):

```
test_quantized_depth_roundtrip
>   np.testing.assert_allclose(dequantized, original, atol=0.5 * quant.scale, rtol=0)
E   AssertionError
```

## Root cause

Two issues compound:

1. **Unseeded RNG** -- the three quantized-roundtrip tests used `np.random.default_rng()` with no seed, so each CI run drew different data and results were non-reproducible.
2. **Too-tight tolerance** -- the ideal quantization error is at most `0.5 * scale`, but the source `original` is float32 and the dequantized output is also cast back to float32. Each carries up to `~max_value * eps_f32` of representation error on top of the rounding error. The measured `|dequantized - original|` therefore occasionally exceeds the exact `0.5 * scale` bound (about 0.8% of random seeds for the float64-intermediate case), tripping the assertion with `rtol=0`.

## Fix

- **Seed the RNG** (`np.random.default_rng(0)`) in all three quantized roundtrip tests so runs are deterministic and reproducible.
- **Widen the tolerance** for the float64-intermediate uint16 case to `0.5 * scale + 2 * max_value * eps_f32`, reflecting the real float32 representation error budget. The other two cases already used looser bounds (`scale` / `1.0 * scale`).

Verified the widened bound holds across 5000 seeds (worst observed error 0.000500 vs atol 0.000514), so the test stays green even if the seed changes later.

## Testing

```
bazelisk test //ncore/impl/data/v4:pytest_components_3_11
//ncore/impl/data/v4:pytest_components_3_11   PASSED
```