### PR TITLE
build(format): add ruff check lint pass to //:format and fix violations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,8 @@ This project uses:
 
 Note a special case for Bazel: the commands above are used both for traditional formatting and for linter warnings. Bazel attempts to fix some of the linter warnings automatically as part of the `//:format` target, but others will be left untouched and need to be manually corrected by the user.
 
+For Python, in addition to `ruff format` and import sorting, the `//:format` and `//:format.check` targets run a `ruff check` lint pass using ruff's default rule set (pyflakes `F` plus the pycodestyle `E4`/`E7`/`E9` subsets). The rule selection and per-file ignores are configured under `[tool.ruff.lint]` in `pyproject.toml`. Auto-fixable violations (e.g. unused imports) are corrected by `//:format`; the rest are reported by `//:format.check` and must be fixed manually.
+
 ### Static Type Checking
 
 All Python code is checked with `ty`, which runs automatically as a Bazel aspect during builds.

--- a/bazel/format/ruff_isort.sh
+++ b/bazel/format/ruff_isort.sh
@@ -15,7 +15,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Wrapper to call Ruff via Bazel for both import sorting and formatting
+# Wrapper to call Ruff via Bazel for import sorting, formatting and linting.
+#
+# This is wired into //:format (fix mode) and //:format.check (check mode) as
+# the `python` formatter of the format_multirun in bazel/format/BUILD.bazel.
+
+# Processed files: format_multirun enumerates the files to process with
+# `git ls-files -t --cached --modified --other --exclude-standard`, i.e. tracked
+# files plus untracked-but-not-gitignored files, and passes them as positional
+# arguments, adding `--check` in check mode.
+#
+# Two passes run on that same file list:
+#   1. `ruff check` -- import sorting (isort) and linting in one pass. The rule
+#      selection (including `I` for import sorting) and per-file ignores live in
+#      [tool.ruff.lint] in pyproject.toml.
+#   2. `ruff format` -- formatting. Kept separate because `ruff format` does not
+#      sort imports (https://docs.astral.sh/ruff/formatter/#sorting-imports).
 
 # --- begin runfiles.bash initialization v3 ---
 # Copy-pasted from the Bazel Bash runfiles library v3.
@@ -56,12 +71,14 @@ for arg in "$@"; do
 done
 
 if [ -n "$CHECK_ARG" ]; then
-    # Check mode: show what would change + fail on diff
+    # Check mode: fail on any lint/import-order violation, then on format diff.
     set -e
-    $RUFF_BIN check --select I --force-exclude --diff $FILES
+    $RUFF_BIN check --force-exclude --diff $FILES
     $RUFF_BIN format --check --force-exclude --diff $FILES
 else
-    # Fix mode: apply changes
-    $RUFF_BIN check --select I --fix $FILES
+    # Fix mode: apply import sorting + auto-fixable lint fixes, then format.
+    # Do not abort on unfixable violations so that //:format still formats
+    # everything it can; //:format.check reports the remaining violations.
+    $RUFF_BIN check --force-exclude --fix $FILES || true
     $RUFF_BIN format --force-exclude $FILES
 fi

--- a/ncore/impl/data/v4/compat_test.py
+++ b/ncore/impl/data/v4/compat_test.py
@@ -16,7 +16,7 @@
 import tempfile
 import unittest
 
-from typing import List, Literal, Tuple, Union
+from typing import List, Literal, Tuple
 
 import numpy as np
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,17 @@ exclude = [
     ".ci-keep",
 ]
 
+[tool.ruff.lint]
+# Keep ruff's default rule set (currently pycodestyle E4/E7/E9 + pyflakes F)
+# and additionally enable `isort` import sorting (I), so a single `ruff check`
+# run by bazel/format/ruff_isort.sh handles both ordering and linting
+extend-select = ["I"]
+
+[tool.ruff.lint.per-file-ignores]
+# Generated protobuf modules are not hand-edited; do not lint them
+"*_pb2.py" = ["F401", "F403", "F405", "E402"]
+"*_pb2_grpc.py" = ["F401", "F403", "F405", "E402"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["ncore", "tools"]
 default-section = "third-party"

--- a/tools/data_converter/kitti/utils.py
+++ b/tools/data_converter/kitti/utils.py
@@ -352,7 +352,7 @@ class Tracklet:
     object_type: str
     h: float
     w: float
-    l: float
+    l: float  # noqa: E741 -- KITTI length dimension (matches the <l> XML tag; paired with h/w)
     first_frame: int
     poses: list[TrackletPose] = field(default_factory=list)
 

--- a/tools/data_converter/nuscenes/converter.py
+++ b/tools/data_converter/nuscenes/converter.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 import logging
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Dict, List, Literal, Optional
 
 import click
@@ -532,8 +532,6 @@ class NuScenesConverter4(FileBasedDataConverter):
             self.logger.info(
                 f"Upsampled model to {self._lidar_model_resolution}x ({lidar_model_parameters.n_columns} columns)"
             )
-
-        n_model_cols = lidar_model_parameters.n_columns
 
         # --- Process each frame ---
         optimization_data: List[AlignedFrameData] = []

--- a/tools/data_converter/nuscenes/converter_test.py
+++ b/tools/data_converter/nuscenes/converter_test.py
@@ -29,7 +29,6 @@ import unittest
 from typing import Literal, cast
 
 import numpy as np
-import torch
 
 from parameterized import parameterized_class
 from upath import UPath

--- a/tools/data_converter/pai/converter.py
+++ b/tools/data_converter/pai/converter.py
@@ -38,7 +38,7 @@ import tempfile
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, Literal, Optional, cast
+from typing import Callable, Dict, Literal, cast
 
 import click
 import DracoPy  # ty:ignore[unresolved-import]

--- a/tools/data_converter/pai/data_provider.py
+++ b/tools/data_converter/pai/data_provider.py
@@ -28,7 +28,7 @@ import json
 import logging
 
 from pathlib import Path
-from typing import Any, Dict, Protocol, cast, runtime_checkable
+from typing import Any, Dict, Protocol, runtime_checkable
 
 import pandas as pd
 import pyarrow.parquet as pq

--- a/tools/data_converter/structured_lidar_model_test.py
+++ b/tools/data_converter/structured_lidar_model_test.py
@@ -22,11 +22,8 @@ import numpy as np
 from ncore.impl.data import util as data_util
 from tools.data_converter.structured_lidar_model import (
     HDL32E_ELEVATIONS_RAD,
-    HDL32E_FIRING_PAIR_INTERVAL_US,
     HDL32E_N_BEAMS,
     HDL32E_N_COLUMNS,
-    HDL32E_SCAN_DURATION_US,
-    AlignedFrameData,
     ColumnAlignment,
     _binned_correction,
     assign_model_columns,

--- a/tools/data_converter/waymo/deps.py
+++ b/tools/data_converter/waymo/deps.py
@@ -21,3 +21,15 @@ from waymo_open_dataset import dataset_pb2, label_pb2  # ty:ignore[unresolved-im
 from waymo_open_dataset.protos import camera_segmentation_pb2  # ty:ignore[unresolved-import]
 from waymo_open_dataset.utils import range_image_utils as waymo_range_image_utils  # ty:ignore[unresolved-import]
 from waymo_open_dataset.utils import transform_utils as waymo_transform_utils  # ty:ignore[unresolved-import]
+
+
+# This module deliberately re-exports the Waymo Open Dataset symbols above so
+# that the rest of the converter imports them from a single proxy location.
+__all__ = [
+    "tf",
+    "dataset_pb2",
+    "label_pb2",
+    "camera_segmentation_pb2",
+    "waymo_range_image_utils",
+    "waymo_transform_utils",
+]

--- a/tools/ncore_evaluate_lidar_model.py
+++ b/tools/ncore_evaluate_lidar_model.py
@@ -533,7 +533,7 @@ def _print_summary(
     print(f"LIDAR MODEL EVALUATION SUMMARY ({len(all_metrics)} frames, {total_points:,} valid points)")
     print("=" * 70)
 
-    print(f"\n  Combined angular error (all valid points):")
+    print("\n  Combined angular error (all valid points):")
     print(f"    mean   = {weighted_mean:.4f} deg")
     print(f"    median = {np.median(all_median):.4f} deg")
     print(f"    p95    = {np.median(all_p95):.4f} deg (median of per-frame p95)")
@@ -555,7 +555,7 @@ def _print_summary(
         print(f"    p95         = {px_p95:.2f} px")
 
     # Per-frame table
-    print(f"\n  Per-frame breakdown:")
+    print("\n  Per-frame breakdown:")
     print(f"    {'Frame':>6} {'N pts':>8} {'Mean(deg)':>10} {'P95(deg)':>10} {'Az err':>10} {'El err':>10}")
     print(f"    {'-' * 6} {'-' * 8} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 10}")
     for m in all_metrics:
@@ -564,7 +564,7 @@ def _print_summary(
         )
 
     # Per-row breakdown (aggregated across all frames)
-    print(f"\n  Per-row (beam) breakdown:")
+    print("\n  Per-row (beam) breakdown:")
     print(f"    {'Row':>4} {'Mean(deg)':>10} {'Mean far(deg)':>14}")
     print(f"    {'-' * 4} {'-' * 10} {'-' * 14}")
 
@@ -584,7 +584,7 @@ def _print_summary(
             print(f"    {r:4d} {row_mean:10.4f} {row_mean_far:14.4f}")
 
     # Detect systematic patterns
-    print(f"\n  Systematic pattern detection:")
+    print("\n  Systematic pattern detection:")
     row_means = row_err_sum / np.maximum(row_count, 1)
     best_row = int(np.argmin(row_means))
     worst_row = int(np.argmax(row_means))
@@ -594,7 +594,7 @@ def _print_summary(
 
     # Per-frame variance (indicates alignment instability)
     frame_means = [m.mean_err_deg for m in all_metrics]
-    print(f"\n  Frame-to-frame consistency:")
+    print("\n  Frame-to-frame consistency:")
     print(f"    Mean of frame means: {np.mean(frame_means):.4f} deg")
     print(f"    Std of frame means:  {np.std(frame_means):.4f} deg")
     print(f"    Best frame:  {all_metrics[int(np.argmin(frame_means))].frame_index} ({min(frame_means):.4f} deg)")

--- a/tools/ncore_project_pc_to_img.py
+++ b/tools/ncore_project_pc_to_img.py
@@ -16,7 +16,6 @@
 import dataclasses
 import logging
 
-from email.policy import default
 from pathlib import Path
 from typing import Optional, Tuple
 


### PR DESCRIPTION
## What

Adds a `ruff check` lint pass to the NCore formatting pipeline (`//:format` and `//:format.check`) using ruff's default rule set (`E4`, `E7`, `E9`, `F`), and fixes all pre-existing violations so the check is green.

## How

**Wiring + config**
- Extends `bazel/format/ruff_isort.sh` (the `python` slot of the `format_multirun`) with a `ruff check` lint pass. Two passes run on the same file list: `ruff check` (import sorting + linting in one pass), then `ruff format`.
  - fix mode (`//:format`): applies import sorting and auto-fixable lint fixes, does not abort on unfixable violations so the rest of the format pipeline still runs
  - check mode (`//:format.check`): fails on any lint/import-order violation, then on format diff
- `pyproject.toml`: adds `[tool.ruff.lint]` with `extend-select = ["I"]` (ruff's default rule set -- pycodestyle `E4`/`E7`/`E9` + pyflakes `F` -- plus isort import sorting) and `per-file-ignores` exempting generated protobuf modules (`*_pb2.py`, `*_pb2_grpc.py`).
- Documents the new pass in `CONTRIBUTING.md`.

**Violation fixes**
- **F401** (unused imports): removed genuinely unused imports; the Waymo dependency proxy module (`tools/data_converter/waymo/deps.py`) declares its re-exports in `__all__`.
- **F541** (f-strings without placeholders): dropped redundant `f` prefixes.
- **F841** (unused local): removed a dead assignment in the nuScenes converter.
- **E741** (ambiguous name): kept the KITTI `l` length field (matches the `<l>` XML tag, paired with `h`/`w`) with an explicit `# noqa: E741`.

## Verification

- `bazel run //:format.check` -> **All checks passed!**
- `bazel build //tools/... //ncore/...` succeeds (including the `ty` type-check aspect).
- No functional behavior changed.
