### PR TITLE
fix(pai-converter): center ego-vehicle bbox z-gate at height/2

### DIFF
--- a/tools/data_converter/pai/utils.py
+++ b/tools/data_converter/pai/utils.py
@@ -56,8 +56,13 @@ def filter_ego_vehicle_points(
     half_width = vehicle_bbox["width"] / 2 + padding
     half_height = vehicle_bbox["height"] / 2 + padding
 
-    # Center offset
+    # Box center in the rig frame. x uses the rear-axle-to-bbox-center offset; z
+    # uses the vehicle mid-height because the rig z origin is at ground level, so
+    # the box must span ground..roof. Centering z at 0 leaves the upper body / roof
+    # (z > height/2 + padding) outside the box, so ego self-returns near a
+    # roof-mounted lidar are not filtered.
     center_x = vehicle_bbox["rear_axle_to_bbox_center"]
+    center_z = vehicle_bbox["height"] / 2
 
     # Check if points are outside bbox
     valid = np.logical_or.reduce(
@@ -66,8 +71,8 @@ def filter_ego_vehicle_points(
             points_rig[:, 0] > (center_x + half_length),
             points_rig[:, 1] < -half_width,
             points_rig[:, 1] > half_width,
-            points_rig[:, 2] < -half_height,
-            points_rig[:, 2] > half_height,
+            points_rig[:, 2] < (center_z - half_height),
+            points_rig[:, 2] > (center_z + half_height),
         ]
     )
 


### PR DESCRIPTION
## Description

Fixes a bug in the PAI converter's ego-vehicle bbox filter that leaves Lidar self-return points near the ego roof unfiltered.

**Root cause.** In `tools/data_converter/pai/utils.py`, the function `filter_ego_vehicle_points` only offsets the box center in x (`rear_axle_to_bbox_center`), while y and z stay centered at 0. According to the [PAI coordinate-system docs](https://github.com/NVlabs/physical_ai_av/wiki/2.--Coordinate-Systems), the rig z origin is at ground level, so the z-gate spans `[-(h/2+pad), h/2+pad]` instead of `[ground-pad, roof+pad]`. Thus the self-return points at upper roof part fall outside the box and are not filtered. 

**Fix.** Center the z-gate at `height/2` so the box spans from ground to roof:

**Verification**. Confirmed on a PAI clip as shown below, red = box before this fix, green = after (rear y-z views); the red box top cuts through the middle of ego vehicle while the green box encloses the vehicle entirely.

<img width="1120" height="570" alt="ego bbox before/after" src="https://github.com/user-attachments/assets/1086ac7f-2e4a-4a7e-bebe-c73e05a78ee1" />

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)