### PR TITLE
docs(support): add NuRec support issue chooser and README support banner

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,7 +3,10 @@
 
 name: Bug Report
 description: Report a bug or unexpected behavior in NCore
+title: "[BUG]"
 labels: ["bug"]
+assignees:
+  - daehyoungko
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# GitHub Issues on this repo are reserved for NCore code-level bugs,
+# documentation requests, and feature requests. Usage/how-to questions about
+# NuRec / Omniverse are routed to the NVIDIA Developer Forum via the
+# contact_link below. Security reports go through NVIDIA's VDP (see SECURITY.md).
 blank_issues_enabled: false
 contact_links:
-  - name: Documentation
+  - name: Ask a NuRec / Omniverse question (usage, how-to)
+    url: https://forums.developer.nvidia.com/c/omniverse/platform/nurec/752
+    about: >
+      Usage and how-to questions about NuRec / Omniverse are not tracked in this
+      repository. Please post them on the NVIDIA Developer Forum (Omniverse /
+      NuRec category), which the support team monitors. GitHub Issues here are
+      for NCore code-level bugs, documentation, and feature requests only.
+  - name: NCore documentation
     url: https://nvidia.github.io/ncore/
-    about: Check the documentation before filing an issue.
+    about: Check the NCore documentation before filing an issue.

--- a/.github/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Documentation Request
+description: Report incorrect or needed documentation for NCore
+title: "[DOC]"
+labels: ["documentation"]
+assignees:
+  - daehyoungko
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to report incorrect documentation or request new documentation.
+        Fill out the section that applies to your request.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Request Type
+      description: Are you reporting incorrect documentation or requesting new documentation?
+      options:
+        - Incorrect documentation
+        - Needed documentation
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Location of Documentation
+      description: For incorrect docs, provide links and line numbers if applicable. For needed docs, describe where it should live.
+    validations:
+      required: false
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Description
+      description: |
+        For incorrect documentation: describe what you found to be incorrect and the steps you took to verify it.
+        For needed documentation: describe what documentation you believe is needed and why.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Fix or Desired Documentation
+      description: Detail your proposed changes, or a clear description of the documentation you would like to see.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, references, or screenshots related to this request.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,7 +3,10 @@
 
 name: Feature Request
 description: Suggest a new feature or enhancement for NCore
+title: "[FEA]"
 labels: ["enhancement"]
+assignees:
+  - daehyoungko
 body:
   - type: markdown
     attributes:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Interested in contributing to NCore? See [CONTRIBUTING.md](CONTRIBUTING.md) for 
 
 This project will download and install additional third-party open source software as dependencies. Review the license terms of these open source projects before use. See [ATTRIBUTIONS.md](ATTRIBUTIONS.md) for a list of direct dependencies and their licenses.
 
+## Support
+
+**`NCore` code-level bugs, documentation issues, and feature requests**: file a [GitHub issue](../../issues/new/choose) using the appropriate template (Bug Report, Documentation Request, or Feature Request). The relevant NVIDIA responder is auto-assigned via the template's `assignees:` field.
+
+**Usage and how-to questions** related to _NuRec_ / _Omniverse_: please post on the [NVIDIA Developer Forum (Omniverse / NuRec)](https://forums.developer.nvidia.com/c/omniverse/platform/nurec/752). Such questions are not tracked in this repository.
+
+**Security vulnerabilities**: please use [NVIDIA's Vulnerability Disclosure Program](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail) (see [SECURITY.md](SECURITY.md)). Do not file security issues publicly here.
+
 ## License
 
 NCore is provided under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full license text.


### PR DESCRIPTION
## Summary

Adds a consistent "New Issue" chooser and a README `## Support` banner to route support traffic for NCore, per the NuRec-family support plan.

Since NCore is a self-contained project, this routing is explicit: **usage / how-to questions about NuRec / Omniverse go to the NVIDIA Developer Forum**, and this repo's GitHub Issues are reserved for **NCore code-level bugs, documentation, and feature requests**.

## Changes

- **`.github/ISSUE_TEMPLATE/config.yml`** -- add an "Ask a NuRec / Omniverse question" contact link pointing at the [NVIDIA Developer Forum (Omniverse / NuRec)](https://forums.developer.nvidia.com/c/omniverse/platform/nurec/752); keep the existing NCore documentation link. The Intigriti VDP **security link is intentionally omitted** because `SECURITY.md` already causes GitHub to add a "Report a security vulnerability" entry to the chooser -- adding the link too would show a duplicate.
- **`bug_report.yml` / `feature_request.yml`** -- add uniform `[BUG]` / `[FEA]` title prefixes and auto-assign `daehyoungko`. Existing form fields and labels (`bug` / `enhancement`) unchanged.
- **`documentation_request.yml`** (new) -- issue form for incorrect or needed documentation (`[DOC]` prefix, `documentation` label, auto-assigned `daehyoungko`), matching the repo's existing `.yml` issue-form style.
- **`README.md`** -- add a `## Support` banner (after the Project Site line) routing questions -> Forum, bugs/docs/features -> GitHub Issues, security -> NVIDIA VDP.

No product code, workflows, `SECURITY.md`, or build files are touched.

## Notes

- Kept the repo's existing `.yml` issue-form format (rather than legacy `.md` templates) for consistency with the current chooser.
- Labels follow NCore's existing conventions (`bug` / `enhancement` / `documentation`).

## Human-only follow-ups (after merge)

- [x] **Grant `daehyoungko` Triage access** (repo Settings -> Collaborators). GitHub silently drops auto-assignment if the user is not a collaborator. (Confirm `daehyoungko` is the intended NCore responder -- inherited from the NuRec-family plan.)
- [x] **Merge this PR.**
- [x] Visit `https://github.com/NVIDIA/ncore/issues/new/choose` -- confirm the 3 templates (Bug / Documentation / Feature) plus the contact links render (and only one security entry appears). File a test issue -> confirm `daehyoungko` is auto-notified -> close it.
