### PR TITLE
docs: clarify NCore positioning and NuRec relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![CI](https://github.com/NVIDIA/ncore/actions/workflows/ci.yml/badge.svg)](https://github.com/NVIDIA/ncore/actions/workflows/ci.yml)
 
-NCore provides data representations, APIs, and tools to support data-driven neural reconstructions with a focus on robotics and autonomous vehicle data.
+NVIDIA NCore is an open, self-contained multi-sensor data platform with a focus on robotics and autonomous vehicle data. It defines a canonical component-based data format, GPU-accelerated camera and LiDAR sensor models, dataset converters, and APIs for reconstruction and simulation. NCore is used by NVIDIA Omniverse NuRec and other research and development workflows.
 
 **Project Site:** [research.nvidia.com/labs/sil/projects/ncore](https://research.nvidia.com/labs/sil/projects/ncore)
 


### PR DESCRIPTION
## What changed

- Reworked the README opening to present NCore as a general, self-contained multi-sensor data platform.
- Kept NVIDIA Omniverse NuRec as one downstream use rather than NCore's exclusive purpose.
- Incorporates Janick's feedback from the source sheet.

## Repository metadata to apply after review

- **About:** NVIDIA NCore is an open, self-contained data platform with a focus on robotics and autonomous vehicle data, providing a consistent multi-sensor representation, APIs, and simulation tools.
- **Topics:** nvidia, physical-ai, autonomous-vehicles, robotics, neural-reconstruction, nurec, simulation, data-format, multi-sensor, lidar, sensor-simulation, dataset, openusd

GitHub About text and topics are repository settings, so they are listed here for maintainer review rather than changed in this branch.

## Validation

- `git diff --check`
- README-only change

Source copy: https://docs.google.com/spreadsheets/d/1IxLuj3hxhN5y3d0fmIxGh9n2LiSq2Su2cTe9qpdAOKI/edit?gid=823075834#gid=823075834
