### PR TITLE
fix(transformations): type transform_point_cloud as polymorphic

### DIFF
--- a/ncore/impl/common/transformations.py
+++ b/ncore/impl/common/transformations.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import sys
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union, overload
 
 import numpy as np
 
@@ -30,6 +30,11 @@ from ncore.impl.common.util import unpack_optional
 
 if TYPE_CHECKING:
     import numpy.typing as npt  # type: ignore[import-not-found]  # noqa: F401
+
+    # torch is used for type annotations only - this module deliberately keeps its
+    # runtime dependencies to numpy + scipy (see //ncore/impl/common:pylib_transformations),
+    # so 'torch' is not resolvable to the type checker here.
+    import torch  # type: ignore[import-not-found]  # noqa: F401  # ty: ignore[unresolved-import]
 
 
 def time_bounds(timestamps_us: List[int], seek_sec: Optional[float], duration_sec: Optional[float]) -> tuple[int, int]:
@@ -407,9 +412,21 @@ def se3_inverse(T: np.ndarray, unbatch: bool = True) -> np.ndarray:
     return ret
 
 
-def transform_point_cloud(pc, T) -> np.ndarray:
+@overload
+def transform_point_cloud(pc: np.ndarray, T) -> np.ndarray: ...
+
+
+@overload
+def transform_point_cloud(pc: "torch.Tensor", T) -> "torch.Tensor": ...
+
+
+def transform_point_cloud(pc, T):
     """Transform the point cloud with the provided transformation matrix,
         support torch.Tensor and np.ndarry.
+
+    The returned type matches the type of ``pc``: a numpy array in, a numpy array
+    out; a torch tensor in, a torch tensor out.
+
     Args:
         pc (np.array): point cloud coordinates (x,y,z) [num_pts, 3] or [bs, num_pts, 3]
         T (np.array): se3 transformation matrix  [4, 4] or [bs, 4, 4]


### PR DESCRIPTION
## Problem

`transform_point_cloud()` is annotated `-> np.ndarray`, but it explicitly supports both
numpy arrays and torch tensors — as its own docstring says ("support torch.Tensor and
np.ndarry") — and returns whichever type it was given:

```python
    if len(pc.shape) == 3:
        if isinstance(pc, np.ndarray):
            trans_pts = T[:, :3, :3] @ pc.transpose(0, 2, 1) + T[:, :3, 3:4]
            return trans_pts.transpose(0, 2, 1)
        else:
            trans_pts = T[:, :3, :3] @ pc.permute(0, 2, 1) + T[:, :3, 3:4]
            return trans_pts.permute(0, 2, 1)   # <-- torch.Tensor, not np.ndarray
```

The `.permute()` branch can only be a torch tensor, so the declared return type is
factually wrong for every torch caller.

The annotation was added in 19.4.0 (it was unannotated before), so this is a
regression for downstream type checking. In NuRec/NRE the bump from 19.1.1 to 19.5.0
produced errors at every torch call site, e.g.:

```
nre/datasets/ncore.py:3258: error: Argument 1 to "zeros_like" has incompatible type
    "ndarray[Any, Any]"; expected "Tensor"  [arg-type]
nre/render/render.py:1523: error: Argument "point_positions" to "LidarFrame" has
    incompatible type "ndarray[Any, Any]"; expected "Tensor"  [arg-type]
apps/aux_gen/estimators.py:589: error: Incompatible types in assignment (expression
    has type "Tensor", variable has type "ndarray[Any, Any]")  [assignment]
```

Downstreams currently have to either `cast(...)` or blanket-ignore these, which
silences genuine type errors rather than fixing anything.

## Fix

Add `@overload` signatures so the return type follows the input type: numpy in →
numpy out, torch in → torch out. The runtime implementation is unchanged.

`torch` is imported **under `TYPE_CHECKING` only**, so
`//ncore/impl/common:pylib_transformations` keeps its existing runtime dependencies
(numpy + scipy) and does **not** gain a torch dependency. Verified by AST inspection
that no module-level torch import is introduced, and there is already precedent for
`TYPE_CHECKING`-only imports in this file (`numpy.typing`) and in
`ncore/impl/common/util.py`.

Also documents the type-preserving behaviour in the docstring.

## Verification

- `bazel run format.check` — clean (90 files already formatted).
- `bazel test //ncore/impl/common:test_3_11 //ncore/impl/common:test_3_8` — both PASSED.
  The overloads are Python 3.8-compatible (string annotations under
  `from __future__ import annotations`).
- mypy resolution confirmed:
  ```
  transform_point_cloud(np.zeros((1,4,3)), np.eye(4))    -> numpy.ndarray[...]
  transform_point_cloud(torch.zeros(1,4,3), torch.eye(4)) -> torch._tensor.Tensor
  ```
- Confirmed `torch` appears only inside the `TYPE_CHECKING` guard, never at module level.

## Note

A patch release containing this would be appreciated — it unblocks removing the
temporary `cast()` workarounds on the NRE side (currently marked with a TODO
referencing this fix).