### PR TITLE
docs(conversions): correct camera model for nuScenes and KITTI

### DIFF
--- a/docs/conversions/kitti/kitti.rst
+++ b/docs/conversions/kitti/kitti.rst
@@ -23,9 +23,8 @@ Camera Sensors
     4. **Right Color (camera_color_right)** -- Point Grey Flea 2, rectified
 
 All cameras use CCD sensors (global shutter) and images are provided
-rectified with zero distortion. The camera intrinsics are stored using
-:class:`~ncore.data.OpenCVPinholeCameraModelParameters` with distortion
-coefficients set to zero.
+rectified with zero distortion, so the camera intrinsics are stored using
+:class:`~ncore.data.IdealPinholeCameraModelParameters`.
 
 LiDAR Sensor
 ^^^^^^^^^^^^^

--- a/docs/conversions/nuscenes/nuscenes.rst
+++ b/docs/conversions/nuscenes/nuscenes.rst
@@ -27,8 +27,8 @@ Camera Sensors
     6. **Back Right (camera_back_right)** -- 1600x900, 70 deg FOV
 
 All cameras use Basler acA1600-60gc sensors (global shutter). Images are
-provided undistorted with zero distortion coefficients. Camera intrinsics
-are stored using :class:`~ncore.data.OpenCVPinholeCameraModelParameters`
+provided undistorted with zero distortion coefficients, so camera intrinsics
+are stored using :class:`~ncore.data.IdealPinholeCameraModelParameters`
 with ``ShutterType.GLOBAL``.
 
 LiDAR Sensor


### PR DESCRIPTION
## Problem

The nuScenes and KITTI conversion pages state that camera intrinsics are stored using
`OpenCVPinholeCameraModelParameters`, but both converters have stored
`IdealPinholeCameraModelParameters` since the ideal pinhole model was introduced. The
wording predates that model and is now inaccurate.

Both datasets ship already-undistorted imagery, so the ideal pinhole is the correct
model — the docs simply describe the pre-`ideal-pinhole` state where a zero-distortion
OpenCV pinhole was the only way to express it.

Verified against the converters:

| Converter | Emits | Docs said |
| --- | --- | --- |
| `tools/data_converter/nuscenes/converter.py:699` | `IdealPinholeCameraModelParameters` | `OpenCVPinhole...` |
| `tools/data_converter/kitti/converter.py:482` | `IdealPinholeCameraModelParameters` | `OpenCVPinhole...` |

This is user-visible: it caused real downstream confusion about which camera model
consumers should expect from these datasets (a NuRec user hit exactly this when
`ideal-pinhole` appeared where the docs promised an OpenCV pinhole).

## Fix

Reword both pages to name `IdealPinholeCameraModelParameters`, mirroring the phrasing
already used by the Argoverse 2 page (which is correct).

## Scope

Audited all six conversion pages against their converters; only these two were stale:

| Page | Converter emits | Docs | Status |
| --- | --- | --- | --- |
| nuscenes | Ideal | OpenCV | **fixed here** |
| kitti | Ideal | OpenCV | **fixed here** |
| argoverse2 | Ideal | Ideal | already correct |
| waymo | OpenCV | OpenCV | already correct |
| colmap | OpenCV + Fisheye | OpenCV + Fisheye | already correct |
| pai | passthrough (all 3) | all 3 | already correct |

## Verification

- `bazel build //docs:ncore` — build succeeded. Note the Sphinx config uses `-W`
  (warnings as errors), so an unresolvable `:class:` reference would fail the build.
- Confirmed the new cross-references resolve to real API anchors in the generated HTML:
  `href="../../apis/data.html#ncore.data.IdealPinholeCameraModelParameters"`.
- `bazel run format.check` — clean.