### PR TITLE
feat(packaging): ship PAI converter in nvidia-ncore wheel

### DIFF
--- a/bazel/packaging/BUILD.bazel
+++ b/bazel/packaging/BUILD.bazel
@@ -13,22 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cbor2>=5.9.0; python_version>="3.9"
-cbor2; python_version<"3.9"
-imageio>=2.35.0
-# PyNvVideoCodec: MIT-licensed GPU-accelerated video codec library (NVIDIA).
-# Used for H.264 decode in the PAI data converter. Requires an NVIDIA GPU (Turing+).
-# See https://developer.nvidia.com/pynvvideocodec
-PyNvVideoCodec
-DracoPy>=2.0.0
-remotezip>=0.12.0
-requests>=2.31.0
-rich
-numpy
-pandas
-point-cloud-utils
-pyarrow
-pillow
-scipy
-tqdm
-universal_pathlib
+load("@rules_python//python:defs.bzl", "py_binary")
+
+py_binary(
+    name = "namespace_converter_srcs",
+    srcs = ["namespace_converter_srcs.py"],
+    main = "namespace_converter_srcs.py",
+    visibility = ["//ncore:__subpackages__"],
+)

--- a/bazel/packaging/namespace_converter_srcs.py
+++ b/bazel/packaging/namespace_converter_srcs.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rewrite in-repo tools.* converter sources into ncore.converters for the wheel."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from pathlib import Path
+from typing import List, Optional
+
+
+_SPDX_INIT = """# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+
+_REPLACEMENTS = (
+    ("from tools.data_converter", "from ncore.converters"),
+    ("import tools.data_converter", "import ncore.converters"),
+    ("from tools.debug", "from ncore.converters.debug"),
+    ("from ncore_repo.tools.debug", "from ncore.converters.debug"),
+    ("from external.ncore_repo.tools.debug", "from ncore.converters.debug"),
+)
+
+
+def _dest_for(src: Path) -> Path:
+    parts = src.parts
+    if src.name == "debug.py":
+        return Path("debug.py")
+    if "pai_remote" in parts:
+        return Path("pai") / "pai_remote" / src.name
+    if "pai" in parts:
+        return Path("pai") / src.name
+    if src.name == "cli.py":
+        return Path("cli.py")
+    raise ValueError(f"no wheel path mapping for {src}")
+
+
+def _rewrite(text: str) -> str:
+    for old, new in _REPLACEMENTS:
+        text = text.replace(old, new)
+    return text
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-root", type=Path, required=True)
+    parser.add_argument("srcs", nargs="+", type=Path)
+    args = parser.parse_args(argv)
+
+    written: set[Path] = set()
+    for src in args.srcs:
+        dest = args.out_root / _dest_for(src)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(_rewrite(src.read_text(encoding="utf-8")), encoding="utf-8")
+        written.add(dest)
+
+    for init_dir in (
+        args.out_root,
+        args.out_root / "pai",
+        args.out_root / "pai" / "pai_remote",
+    ):
+        init_dir.mkdir(parents=True, exist_ok=True)
+        init_file = init_dir / "__init__.py"
+        if init_file not in written:
+            init_file.write_text(_SPDX_INIT, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ncore/BUILD.bazel
+++ b/ncore/BUILD.bazel
@@ -15,6 +15,7 @@
 
 load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_python//python:packaging.bzl", "py_package", "py_wheel")
+load("//bazel/pytest:defs.bzl", "pytest_test")
 
 # Proxy library to include PEP 561 type-marker
 py_library(
@@ -45,6 +46,25 @@ py_wheel(
     author = "NVIDIA Corporation",
     description_file = "PYPI_README.md",
     distribution = "nvidia-ncore",
+    entry_points = {
+        "console_scripts": [
+            "ncore-convert = ncore.converters.pai.converter:cli",
+        ],
+    },
+    extra_requires = {
+        "pai": [
+            "click",
+            "debugpy",
+            "DracoPy>=2.0.0",
+            "imageio>=2.35.0",
+            "pandas",
+            "pyarrow",
+            "PyNvVideoCodec",
+            "remotezip>=0.12.0",
+            "requests>=2.31.0",
+            "tqdm",
+        ],
+    },
     homepage = "https://github.com/NVIDIA/ncore",
     license = "Apache-2.0",
     platform = "any",
@@ -75,5 +95,14 @@ py_wheel(
     version = "{BUILD_EMBED_LABEL}",
     deps = [
         ":ncore_pkg",
+        "//ncore/converters:pai_converter_pkg",
     ],
+)
+
+pytest_test(
+    name = "pytest_wheel_packaging",
+    srcs = ["wheel_packaging_test.py"],
+    data = [":ncore_wheel"],
+    # The wheel target depends on DracoPy / PyNvVideoCodec, which are only available for Python 3.11.
+    python_versions = ["3.11"],
 )

--- a/ncore/PYPI_README.md
+++ b/ncore/PYPI_README.md
@@ -20,6 +20,16 @@ A unified data format and library for autonomous vehicle and robotics sensor dat
 pip install nvidia-ncore
 ```
 
+To convert raw [PhysicalAI-Autonomous-Vehicles](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles)
+clips without a source checkout, install the optional PAI converter extra:
+
+```bash
+pip install "nvidia-ncore[pai]"
+ncore-convert --help
+```
+
+See the [PAI data converter README](https://github.com/NVIDIA/ncore/blob/main/tools/data_converter/pai/README.md) for usage.
+
 ## Documentation
 
 <https://nvidia.github.io/ncore>

--- a/ncore/converters/BUILD.bazel
+++ b/ncore/converters/BUILD.bazel
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:packaging.bzl", "py_package")
+
+_NAMESPACED_SRCS = [
+    "__init__.py",
+    "cli.py",
+    "debug.py",
+    "pai/__init__.py",
+    "pai/converter.py",
+    "pai/data_provider.py",
+    "pai/utils.py",
+    "pai/pai_remote/__init__.py",
+    "pai/pai_remote/config.py",
+    "pai/pai_remote/index.py",
+    "pai/pai_remote/remote.py",
+    "pai/pai_remote/streaming.py",
+]
+
+genrule(
+    name = "namespaced_srcs",
+    srcs = [
+        "//tools:debug.py",
+        "//tools/data_converter:cli.py",
+        "//tools/data_converter/pai:converter.py",
+        "//tools/data_converter/pai:data_provider.py",
+        "//tools/data_converter/pai:utils.py",
+        "//tools/data_converter/pai/pai_remote:config.py",
+        "//tools/data_converter/pai/pai_remote:index.py",
+        "//tools/data_converter/pai/pai_remote:remote.py",
+        "//tools/data_converter/pai/pai_remote:streaming.py",
+    ],
+    outs = _NAMESPACED_SRCS,
+    cmd = "$(execpath //bazel/packaging:namespace_converter_srcs) --out-root $(RULEDIR) $(SRCS)",
+    tools = ["//bazel/packaging:namespace_converter_srcs"],
+)
+
+py_library(
+    name = "pylib",
+    srcs = _NAMESPACED_SRCS,
+    visibility = ["//ncore:__pkg__"],
+)
+
+py_package(
+    name = "pai_converter_pkg",
+    packages = [
+        "ncore.converters",
+        "ncore.converters.pai",
+        "ncore.converters.pai.pai_remote",
+    ],
+    visibility = ["//ncore:__pkg__"],
+    deps = [":pylib"],
+)

--- a/ncore/wheel_packaging_test.py
+++ b/ncore/wheel_packaging_test.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import configparser
+import os
+import unittest
+import zipfile
+
+from pathlib import Path
+
+
+def _wheel_path() -> Path:
+    srcdir = Path(os.environ["TEST_SRCDIR"])
+    matches = list(srcdir.glob("*/ncore/nvidia_ncore-*-py3-none-any.whl"))
+    if not matches:
+        matches = list(srcdir.glob("ncore/nvidia_ncore-*-py3-none-any.whl"))
+    assert matches, "nvidia-ncore wheel not found in test runfiles"
+    assert len(matches) == 1, matches
+    return matches[0]
+
+
+class TestPaiWheelPackaging(unittest.TestCase):
+    def test_ncore_wheel_includes_pai_converter_entry_point(self) -> None:
+        with zipfile.ZipFile(_wheel_path()) as wheel:
+            names = wheel.namelist()
+
+            top_level = {name.split("/", 1)[0] for name in names}
+            self.assertIn("ncore", top_level)
+            self.assertNotIn("tools", top_level)
+
+            self.assertIn("ncore/converters/cli.py", names)
+            self.assertIn("ncore/converters/debug.py", names)
+            self.assertIn("ncore/converters/pai/converter.py", names)
+            self.assertIn("ncore/converters/pai/pai_remote/remote.py", names)
+            self.assertNotIn("ncore/converters/pai/pai_remote/downloader.py", names)
+
+            dist_info = next(name for name in names if name.endswith(".dist-info/entry_points.txt"))
+            entry_points = configparser.ConfigParser()
+            entry_points.read_string(wheel.read(dist_info).decode("utf-8"))
+            self.assertEqual(
+                entry_points["console_scripts"]["ncore-convert"],
+                "ncore.converters.pai.converter:cli",
+            )
+
+            metadata_name = dist_info.replace("entry_points.txt", "METADATA")
+            metadata = wheel.read(metadata_name).decode("utf-8")
+            self.assertIn("Requires-Dist: click; extra == 'pai'", metadata)
+            self.assertIn("Requires-Dist: DracoPy>=2.0.0; extra == 'pai'", metadata)
+            self.assertIn("Requires-Dist: PyNvVideoCodec; extra == 'pai'", metadata)
+            self.assertNotIn("Requires-Dist: rich; extra == 'pai'", metadata)

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -19,6 +19,11 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 # targets might be used in various places also outside of the repo, so make it public
 package(default_visibility = ["//visibility:public"])
 
+exports_files(
+    ["debug.py"],
+    visibility = ["//ncore/converters:__pkg__"],
+)
+
 #################################################################
 
 py_library(

--- a/tools/data_converter/BUILD.bazel
+++ b/tools/data_converter/BUILD.bazel
@@ -20,6 +20,11 @@ load("//bazel/pytest:defs.bzl", "pytest_test")
 # targets might be used in various places also outside of the repo, so make it public
 package(default_visibility = ["//visibility:public"])
 
+exports_files(
+    ["cli.py"],
+    visibility = ["//ncore/converters:__pkg__"],
+)
+
 #################################################################
 
 py_library(

--- a/tools/data_converter/pai/BUILD.bazel
+++ b/tools/data_converter/pai/BUILD.bazel
@@ -14,10 +14,46 @@
 # limitations under the License.
 
 load("@ncore_pip_deps//:requirements.bzl", "requirement")
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 # targets might be used in various places also outside of the repo, so make it public
 package(default_visibility = ["//visibility:public"])
+
+exports_files(
+    [
+        "converter.py",
+        "data_provider.py",
+        "utils.py",
+    ],
+    visibility = ["//ncore/converters:__pkg__"],
+)
+
+PAI_CONVERTER_DEPS = [
+    "//ncore:pylib",
+    "//tools/data_converter:pylib_cli",
+    "//tools/data_converter/pai/pai_remote:pylib_pai_remote",
+    requirement("click"),
+    requirement("DracoPy"),
+    requirement("imageio"),
+    requirement("numpy"),
+    requirement("pandas"),
+    requirement("pyarrow"),
+    requirement("pillow"),
+    requirement("PyNvVideoCodec"),
+    requirement("scipy"),
+    requirement("tqdm"),
+    requirement("universal-pathlib"),
+]
+
+py_library(
+    name = "pylib_convert",
+    srcs = [
+        "converter.py",
+        "data_provider.py",
+        "utils.py",
+    ],
+    deps = PAI_CONVERTER_DEPS,
+)
 
 # Standalone CLI binary for converting local PAI data to NCore V4
 py_binary(
@@ -28,22 +64,7 @@ py_binary(
         "utils.py",
     ],
     main = "converter.py",
-    deps = [
-        "//ncore:pylib",
-        "//tools/data_converter:pylib_cli",
-        "//tools/data_converter/pai/pai_remote:pylib_pai_remote",
-        requirement("click"),
-        requirement("DracoPy"),
-        requirement("imageio"),
-        requirement("numpy"),
-        requirement("pandas"),
-        requirement("pyarrow"),
-        requirement("pillow"),
-        requirement("PyNvVideoCodec"),
-        requirement("scipy"),
-        requirement("tqdm"),
-        requirement("universal-pathlib"),
-    ],
+    deps = [":pylib_convert"],
 )
 
 alias(

--- a/tools/data_converter/pai/README.md
+++ b/tools/data_converter/pai/README.md
@@ -17,6 +17,35 @@ Convert clip data from the [NVIDIA PhysicalAI-Autonomous-Vehicles](https://huggi
   # or pass --hf-token hf_... to individual commands
   ```
 
+## Installed package usage
+
+Install the converter from PyPI (no source checkout required):
+
+```bash
+pip install "nvidia-ncore[pai]"
+```
+
+The `ncore-convert` console script exposes the same subcommands as the Bazel target
+`//tools/data_converter/pai:convert`:
+
+```bash
+# Streaming conversion directly from HuggingFace
+ncore-convert --output-dir /path/to/output pai-stream-v4 --clip-id <clip-id>
+
+# Local conversion from pai-clip-dl output
+ncore-convert --root-dir /path/to/data --output-dir /path/to/output pai-v4 --clip-id <clip-id>
+```
+
+The `[pai]` extra installs the converter-specific Python dependencies (Click, DracoPy,
+imageio, pandas, pyarrow, PyNvVideoCodec, remotezip, requests, and others). The base
+`nvidia-ncore` package already provides the core NCore library dependencies
+(including scipy and universal_pathlib). The installed modules live under
+`ncore.converters`. `pai-clip-dl` remains a Bazel-only tool in this repository.
+Camera decode via PyNvVideoCodec requires an NVIDIA GPU (Turing or newer).
+
+For development inside this repository, continue using the Bazel commands documented
+below.
+
 ## Dataset Overview
 
 The dataset contains 306,152 clips organized into ~3,146 chunks of ~100 clips each.

--- a/tools/data_converter/pai/pai_remote/BUILD.bazel
+++ b/tools/data_converter/pai/pai_remote/BUILD.bazel
@@ -18,6 +18,16 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 package(default_visibility = ["//tools/data_converter/pai:__pkg__"])
 
+exports_files(
+    [
+        "config.py",
+        "index.py",
+        "remote.py",
+        "streaming.py",
+    ],
+    visibility = ["//ncore/converters:__pkg__"],
+)
+
 PAI_DL_DEPS = [
     requirement("click"),
     requirement("pandas"),


### PR DESCRIPTION
## Description

Package the PAI data converter in the `nvidia-ncore` wheel so PhysicalAI-AV clips can be converted without a source checkout or Bazel.

- Add `pai_converter_pkg` to `//ncore:ncore_wheel` (converter + `pai_remote` + CLI).
- Expose console script `ncore-convert` → `tools.data_converter.pai.converter:cli`.
- Add optional extra `nvidia-ncore[pai]` for converter deps (Click, DracoPy, imageio, pandas, pyarrow, PyNvVideoCodec, remotezip, requests, tqdm, debugpy).
- Document installed usage in `ncore/PYPI_README.md` and `tools/data_converter/pai/README.md`.
- Cover packaging with `//ncore:pytest_wheel_packaging_3_11`.

`pai-clip-dl` is not shipped as its own console script in this PR; streaming (`pai-stream-v4`) is the primary no-checkout path. Camera decode via PyNvVideoCodec needs an NVIDIA GPU (Turing+).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits are GPG-signed
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing tests pass locally (`bazel test //...`)
- [x] Code is formatted (`bazel run //:format`)
- [x] I have updated documentation as needed
- [x] My changes include SPDX license headers on all new files