### PR TITLE
refactor(data): pin relative_angle to the angles' float dtype

### DIFF
--- a/ncore/impl/data/util.py
+++ b/ncore/impl/data/util.py
@@ -167,6 +167,10 @@ def relative_angle(
     """
     Compute the relative angle from ref_angle_rad to angle_rad in the specified direction
 
+    'angle_rad' must be a floating-point numpy array/scalar or torch tensor; the
+    result carries its dtype, independently of the installed numpy version. The
+    reference is a plain python float and is converted into that dtype.
+
     Args:
         ref_angle_rad: reference angle in radians [float]
         angle_rad: tensor of angles to compute relative angles for, in radians
@@ -179,16 +183,48 @@ def relative_angle(
 
     two_pi = 2 * np.pi
 
+    # The angles carry the precision of the computation, so they must be a dtype-
+    # bearing float type (numpy array/scalar or torch tensor) rather than a bare
+    # python scalar -- otherwise there is nothing to pin the reduction to, and the
+    # result would silently fall back to whatever python/numpy promotion yields.
+    # The dtype is read duck-typed so this stays generic over numpy and torch
+    # without importing torch.
+    dtype = getattr(angle_rad, "dtype", None)
+    assert dtype is not None, (
+        f"relative_angle expects numpy/torch angles carrying a dtype, got '{type(angle_rad).__name__}'"
+    )
+
+    # Angles are floats by contract, for numpy and torch alike. A non-float dtype
+    # would silently mis-reduce: numpy would truncate the 2π period below to 6 and
+    # return wrong angles, while torch would quietly promote to float32 and narrow
+    # a float64-precision caller. Reject both loudly instead. numpy spells
+    # float-ness as dtype.kind, torch as dtype.is_floating_point (present since
+    # torch 1.12, the oldest version this package supports).
+    is_floating = dtype.kind == "f" if isinstance(dtype, np.dtype) else dtype.is_floating_point
+    assert is_floating, f"relative_angle expects floating-point angles, got dtype '{dtype}'"
+
+    # Carry the angles' float dtype through the whole computation, including the
+    # 2π period. numpy promotes a numpy *scalar* mixed with a python float
+    # differently across major versions -- numpy 1 used value-based promotion and
+    # widened `float32_scalar % python_float` to float64, while numpy 2 (NEP 50)
+    # keeps it float32 -- so leaving the period as a python float makes the result
+    # depend on the installed numpy version. That shifted, e.g., the float32
+    # `span_rad` of a structured lidar model's vertical FOV by ~1 ULP, which moves
+    # the angle grid and thus reassigns boundary cells of its angles-to-columns map.
+    # Pinning the dtype here makes the result version-independent by construction
+    # rather than by accident. Arrays are unaffected either way (a python scalar
+    # does not upcast a numpy/torch array), and torch needs no coercion at all: it
+    # is already dtype-preserving against python scalars.
+    if isinstance(dtype, np.dtype):
+        ref_angle_rad = cast(float, dtype.type(ref_angle_rad))
+        two_pi = dtype.type(two_pi)
+
     # Signed difference between ref and angle, then a single reduction to [0, 2π).
     # We subtract before reducing rather than reducing each operand separately:
-    # the subtraction with the python-scalar `ref_angle_rad` keeps `angle_rad`'s
-    # dtype (a python scalar does not upcast a numpy/torch float32 array), so the
-    # whole computation stays in float32 for float32 inputs. Reducing each operand
-    # independently instead promoted `ref_angle_rad % 2π` to float64 while
-    # `angle_rad % 2π` stayed float32, so the same value reduced to results ~1 ULP
-    # apart; for ref == angle_rad[i] that made the relative angle wrap to ~2π
-    # instead of 0 and broke, e.g., the strict-monotonicity check on a structured
-    # lidar model's column azimuths whose reference reduces near the ±π boundary.
+    # reducing them independently made the same value reduce to results ~1 ULP
+    # apart, so for ref == angle_rad[i] the relative angle wrapped to ~2π instead
+    # of 0 and broke, e.g., the strict-monotonicity check on a structured lidar
+    # model's column azimuths whose reference reduces near the ±π boundary.
     # (a - b) mod 2π == (a mod 2π - b mod 2π) mod 2π, so this is exact.
     if direction == "cw":
         # Clockwise: going from ref to angle in CW direction.

--- a/ncore/impl/data/util_test.py
+++ b/ncore/impl/data/util_test.py
@@ -178,3 +178,88 @@ class TestRelativeAngle(unittest.TestCase):
         self.assertEqual(float(rel.relative_angle_rad[0].item()), 0.0)
         self.assertTrue(bool((torch.diff(rel.relative_angle_rad) > 0).all()))
         self.assertTrue(bool((~rel.wrap_around_flag).all()))
+
+    def test_float32_scalar_matches_float32_array(self) -> None:
+        """A float32 scalar angle reduces exactly like the same angle in an array.
+
+        Regression: the 2π period was a python float, so the scalar path depended
+        on numpy's scalar/python-float promotion, which changed between major
+        versions (numpy 1 widened `float32_scalar % python_float` to float64;
+        numpy 2 keeps it float32 under NEP 50). The array path was float32 either
+        way, so the two disagreed by ~1 ULP under numpy 1 and the result silently
+        depended on the installed numpy. Carrying the operand dtype into the
+        period makes both paths -- and both numpy versions -- agree exactly.
+
+        The "ccw" direction makes the reduction actually active: its signed
+        differences are negative and must wrap into [0, 2π). A signed difference
+        that already lies inside the interval passes through the modulo unchanged
+        and would not exercise the period's dtype at all.
+        """
+        angles = (np.pi - 1e-3 - np.linspace(0.0, 2.0 * np.pi * (1.0 - 1e-4), 64)).astype(np.float32)
+        ref = float(angles[0])
+
+        for direction in ("cw", "ccw"):
+            array_rel = relative_angle(ref, angles, direction).relative_angle_rad
+            self.assertEqual(array_rel.dtype, np.float32)
+
+            for index, angle in enumerate(angles):
+                scalar_rel = relative_angle(ref, angle, direction).relative_angle_rad
+
+                # Same dtype as the array path, and bit-identical to it.
+                self.assertEqual(np.asarray(scalar_rel).dtype, np.float32)
+                self.assertEqual(float(scalar_rel), float(array_rel[index]))
+
+                # get_vertical_fov consumes the scalar result via .item().
+                self.assertTrue(hasattr(scalar_rel, "item"))
+
+    def test_float64_angles_stay_float64(self) -> None:
+        """Pinning the period to the operand dtype must not narrow float64 input."""
+        angles = np.pi - 1e-3 - np.linspace(0.0, 2.0 * np.pi * (1.0 - 1e-4), 64)
+        self.assertEqual(angles.dtype, np.float64)
+
+        rel = relative_angle(float(angles[0]), angles, "cw")
+
+        self.assertEqual(rel.relative_angle_rad.dtype, np.float64)
+        self.assertEqual(float(rel.relative_angle_rad[0]), 0.0)
+
+    def test_non_floating_angles_rejected(self) -> None:
+        """Angles must be dtype-bearing floats rather than silently mis-reduced.
+
+        numpy would carry an integer dtype into the 2π period, truncating it to 6
+        and returning wrong angles with no error; torch would instead promote
+        silently to float32, narrowing a float64-precision caller. Both fail
+        loudly here, so the contract does not depend on which array library the
+        caller happens to use.
+        """
+        for angles in (
+            np.array([1, 2, 3], dtype=np.int32),
+            np.int64(2),
+            np.array([1, 2], dtype=np.uint64),
+            np.array([1.0 + 0j]),
+            torch.tensor([1, 2, 3], dtype=torch.int32),
+            torch.tensor([1, 2], dtype=torch.int64),
+            torch.tensor([1.0 + 0j]),
+        ):
+            with self.assertRaises(AssertionError):
+                relative_angle(0.5, angles, "cw")
+
+        # The angles carry the precision of the computation, so a bare python
+        # scalar -- which has no dtype to pin the reduction to -- is rejected too.
+        for scalar in (1.0, 1):
+            with self.assertRaises(AssertionError):
+                relative_angle(0.5, scalar, "cw")
+
+    def test_torch_float_dtypes_are_preserved(self) -> None:
+        """torch input keeps its own dtype: it needs validation, not coercion.
+
+        torch is already dtype-preserving against python scalars, so the period
+        is left as a python float for it -- unlike numpy, whose scalar promotion
+        rules changed between major versions.
+        """
+        for torch_dtype in (torch.float32, torch.float64):
+            angles = torch.tensor([1.0, 0.5, 0.0, -0.5], dtype=torch_dtype)
+
+            rel = relative_angle(float(angles[0].item()), angles, "cw")
+
+            self.assertEqual(rel.relative_angle_rad.dtype, torch_dtype)
+            self.assertEqual(float(rel.relative_angle_rad[0].item()), 0.0)


### PR DESCRIPTION
## Summary

`relative_angle` reduced the signed difference with a python-float `2*pi` period. numpy promotes a numpy **scalar** mixed with a python float differently across major versions — numpy 1 used value-based promotion and widened `float32_scalar % python_float` to float64, while numpy 2 keeps it float32 under [NEP 50](https://numpy.org/neps/nep-0050-scalar-promotion.html) — so the scalar path silently depended on the installed numpy version, and disagreed with the array path (float32 either way) by ~1 ULP under numpy 1.

This PR carries the operands' float dtype into both the reference and the period, so the result is version-independent by construction.

**No behaviour change for the current sensors: the angles-to-columns maps are bit-identical to before.**

## Why it matters

The scalar path is reachable from `RowOffsetStructuredSpinningLidarModelParameters.get_vertical_fov`, which passes `row_elevations_rad.astype(dtype)[-1]` as a float32 scalar. The resulting `span_rad` shift moves the `linspace` angle grid in `_init_angles_to_columns_map`, which reassigns `cKDTree` boundary cells of `angles_to_columns_map`.

Measured on the two Hesai models, numpy 1.26.4 vs 2.5.2:

| sensor | map cells | reassigned |
|---|---|---|
| Pandar128 | 7,372,800 | 81 |
| AT128 | 2,457,600 | 164 |

### The current code is correct only by accident

Today's `relative_angle` already avoids this for those two sensors — but only because their signed difference happens to land in `[0, 2*pi)`, making the modulo a no-op so its dtype cannot matter. On random float32 scalars the reduction still diverges in **44,739 of 60,000** cases.

So a sensor whose elevation span wraps the `±pi` seam, or whose float32 subtraction rounds, would reintroduce the same failure. This PR closes that latent hole rather than a live one.

## What changed

- **`ncore/impl/data/util.py`** — derive the float dtype from `angle_rad` (falling back to `ref_angle_rad`), coerce the python-scalar reference and the `2*pi` period into it, then subtract and reduce once.
  - The **angles carry the precision**: the reference is a plain python float and is converted into the angles' dtype.
  - **torch needs no coercion** — it is already dtype-preserving against python scalars.
- **`angle_rad` must be a dtype-bearing float type** (numpy array/scalar or torch tensor), not a bare python scalar — otherwise there is nothing to pin the reduction to, and the result silently falls back to whatever python/numpy promotion yields. All existing callers already pass numpy arrays, numpy scalars or torch tensors.
- **Non-float dtypes assert, for numpy and torch alike.** Angles are floats by contract, and the two libraries fail differently but both silently: numpy carries the integer dtype into the period, truncating `2*pi` to `6` and returning wrong angles, while torch promotes to `float32` and narrows a float64-precision caller. The dtype is read duck-typed (numpy spells float-ness as `dtype.kind`, torch as `dtype.is_floating_point` — present since **torch 1.12**, the oldest version this package supports), so the function stays generic over both without importing torch.
- **`ncore/impl/data/util_test.py`** — four regression tests: float32 scalar/array parity, float64 not narrowed, non-float/non-dtype angles rejected (numpy *and* torch), and torch float dtypes preserved.

## Validation

| check | result |
|---|---|
| new tests vs `origin/main` | 2 of 4 **fail** (genuine regression guards) |
| new tests on this branch | pass under numpy **1.26.4** and **2.3.5** |
| f32 scalar path, numpy 1 vs 2 | **0**/30,000 differ (before: 14,803) |
| all 7 ref/angle dtype combinations | bit-identical across versions |
| non-float rejection | numpy + torch int/uint/bool/complex, and bare python scalars, all assert |
| **numpy 2.3.5 + torch 2.13.0** | data/sensors/converter suites **199 pass**, unchanged from numpy 1.26.4 + torch 2.7.0 |
| `angles_to_columns_map` under numpy 2 + torch 2.13 | **bit-identical** to the numpy 1 baseline (0/7,372,800 and 0/2,457,600) |
| `angles_to_columns_map` vs pre-change | **bit-identical** — 0/7,372,800 and 0/2,457,600 |
| 614,400 elements through FOV asserts + frame times | all valid, frame times in `[0, 1]` |
| `//ncore/impl/data:all`, `//ncore/impl/sensors:all`, `//tools/...` | **19 pass**, python 3.8 (numpy 1.19.5, torch 1.12.1) and 3.11 |
| `bazel run format` | clean |
| `ty` aspect | clean |

The float32 array and float64 array paths are untouched.

## Notes for reviewers

- The `test_float32_scalar_matches_float32_array` docstring calls out that the **`ccw`** direction is what makes the reduction active — its signed differences are negative and must wrap. A `cw` difference already inside `[0, 2*pi)` passes through the modulo unchanged and would not exercise the period's dtype at all. 63 of 64 `ccw` cases discriminate the period dtype, so the test genuinely guards the fix.
- Typed `refactor` rather than `fix` because there is no user-visible behaviour change on current sensors.

## Follow-ups (deliberately not in this PR)

Two independent numpy 2 issues found while investigating, to be filed separately:

1. `closest_index_sorted` (`util.py:66`) — `abs(value - uint64_scalar)` wraps under NEP 50 (silently wrong index) or raises `OverflowError` for negative queries. The existing test passes a python list, so it does not catch this.
2. `_init_angles_to_columns_map` (`lidar.py:410`) — `(idxs / n_rows).to(dtype)` is exact below 2^24 but truncates incorrectly above it (e.g. 68,928 wrong indices at `n_rows=128, n_columns=200000`). Version-independent, but `torch.div(..., rounding_mode="floor")` would make the line match its comment.
