### PR TITLE
fix(data): search and compare closest_index_sorted exactly

### DIFF
--- a/ncore/impl/data/util.py
+++ b/ncore/impl/data/util.py
@@ -53,18 +53,44 @@ def padded_index_string(index: int, index_digits=INDEX_DIGITS) -> str:
 def closest_index_sorted(sorted_array: np.ndarray, value: int) -> int:
     """Returns the index of the closest value within a *sorted* array relative to a query value.
 
+    Where the query falls exactly between its two neighbours, the later one wins.
+
     Note: we are *not* checking that the input is sorted
     """
     if not len(sorted_array):
         raise ValueError("input array is empty")
 
-    idx = int(np.searchsorted(sorted_array, value, side="left"))
+    sorted_array = np.asarray(sorted_array)
+    # Normalise the query to a python int up front, so the bounds check below and
+    # the dtype conversion after it see exactly the same value. A numpy scalar
+    # would instead be compared under numpy's own promotion rules -- lossy above
+    # 2**53 -- and a float would round differently in the two places, which can
+    # push the search past the end of the array.
+    value = int(value)
 
-    if idx > 0:
-        if idx == len(sorted_array):
-            return idx - 1
-        if abs(value - sorted_array[idx - 1]) < abs(sorted_array[idx] - value):
-            return idx - 1
+    # Answer out-of-range queries from the ends. That also leaves `value` within
+    # the array's own range, so it is representable in the array's dtype and the
+    # search below can run in that dtype -- which is what keeps it exact. Searching
+    # with the python int instead let numpy pick the common type: numpy 1 converts
+    # both to float64, which is lossy above 2**53, so searchsorted landed next to
+    # the true insertion point on uint64 timestamps. The upper bound is strict so a
+    # query equal to a repeated last element still resolves to the start of that run.
+    if value <= sorted_array[0].item():
+        return 0
+    if value > sorted_array[-1].item():
+        return len(sorted_array) - 1
+
+    idx = int(np.searchsorted(sorted_array, sorted_array.dtype.type(value), side="left"))
+
+    # `value` is above the first element and no greater than the last, so
+    # 0 < idx < len(sorted_array) and both neighbours exist. Comparing them as
+    # python scalars keeps the differences exact: `.item()` yields an
+    # arbitrary-precision int for integer dtypes, where subtracting in the array
+    # dtype would instead wrap on an unsigned type (numpy 2 keeps uint64 under
+    # NEP 50; numpy 1 hid that by promoting to float64) and silently pick the
+    # further neighbour.
+    if abs(value - sorted_array[idx - 1].item()) < abs(sorted_array[idx].item() - value):
+        return idx - 1
 
     return idx
 

--- a/ncore/impl/data/util_test.py
+++ b/ncore/impl/data/util_test.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 import unittest
+import warnings
+
+from typing import cast
 
 import numpy as np
 import torch
@@ -59,6 +62,155 @@ class TestClosestIndexSorted(unittest.TestCase):
             check(sorted_timestamp_array, sorted_timestamp_array[idx], idx)  # exact hit
             check(sorted_timestamp_array, sorted_timestamp_array[idx] - 1, idx)  # inexact hit
             check(sorted_timestamp_array, sorted_timestamp_array[idx] + 1, idx)  # inexact hit
+
+    def test_uint64_timestamps_are_exact(self) -> None:
+        """uint64 timestamps are searched and compared exactly, not via float64.
+
+        Regression, with one failure mode per numpy major version -- both found
+        by fuzzing against an exact python-int reference:
+
+        - numpy 1 compares a python int against an integer array in float64,
+          which is lossy above 2**53, so searchsorted lands next to the true
+          insertion point and the wrong neighbour wins.
+        - numpy 2 searches exactly (NEP 50), but for the same reason keeps the
+          neighbour subtraction in uint64. Where the old code computed
+          `sorted_array[idx] - value` with a larger value on the right, the
+          result wrapped to ~1.8e19 instead of going negative, so the nearer
+          neighbour lost the comparison. numpy 1 had hidden that wrap by
+          promoting to float64.
+
+        Each case below therefore fails on exactly one of the two versions, so
+        together they pin the behaviour on both.
+        """
+        cases = (
+            # Lands 1 below element 3; float64 search (numpy 1) mis-locates it.
+            (
+                (
+                    3993155382513731309,
+                    3993155382513864527,
+                    3993155382513998127,
+                    3993155382514268707,
+                    3993155382514642505,
+                ),
+                3993155382514455305,
+                3,
+            ),
+            # 302 above element 3, 243857 below element 4; uint64 wrap (numpy 2).
+            (
+                (
+                    3060375013392637474,
+                    3060375013392686493,
+                    3060375013392765053,
+                    3060375013392945927,
+                    3060375013393190086,
+                ),
+                3060375013392946229,
+                3,
+            ),
+        )
+        for values, query, expected in cases:
+            timestamps_us = np.array(values, dtype=np.uint64)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")  # a uint64 wrap raises a RuntimeWarning
+                self.assertEqual(closest_index_sorted(timestamps_us, query), expected, f"query={query}")
+
+        # Exhaustive agreement with an exact python-int reference near the seams.
+        timestamps_us = np.array(cases[1][0], dtype=np.uint64)
+        exact = [int(x) for x in timestamps_us]
+        for element in exact:
+            for delta in (-2, -1, 0, 1, 2):
+                query = element + delta
+                expected = min(
+                    range(len(exact)),
+                    key=lambda i, q=query: (abs(exact[i] - q), -i),  # ties -> larger index
+                )
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error")
+                    self.assertEqual(closest_index_sorted(timestamps_us, query), expected, f"query={query}")
+
+    def test_uint64_query_out_of_range(self) -> None:
+        """Queries outside the array (or outside the dtype) resolve to an end.
+
+        A negative query cannot be represented as uint64: numpy 2 raises
+        OverflowError rather than converting it, so it must be answered before
+        reaching any array arithmetic.
+        """
+        timestamps_us = np.array([1000, 2000, 3000], dtype=np.uint64)
+
+        for query, expected in ((-5, 0), (0, 0), (999, 0), (5000, 2), (2**64 + 7, 2), (10**25, 2)):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                self.assertEqual(closest_index_sorted(timestamps_us, query), expected, f"query={query}")
+
+    def test_ties_resolve_to_larger_index(self) -> None:
+        """A query exactly between its two neighbours keeps selecting the later one."""
+        self.assertEqual(closest_index_sorted(np.array([1000, 2000], dtype=np.uint64), 1500), 1)
+        self.assertEqual(closest_index_sorted(np.array([1000.0, 2000.0]), 1500), 1)
+
+    def test_duplicate_elements(self) -> None:
+        """Repeated elements keep resolving to the first of the run.
+
+        The end-of-range shortcuts must not swallow a query that lands exactly on
+        a duplicated last element: that one still has to go through the search, or
+        it would report the end of the run instead of its start.
+        """
+        self.assertEqual(closest_index_sorted(np.array([870, 870, 1331, 1331], dtype=np.uint64), 1331), 2)
+        self.assertEqual(closest_index_sorted(np.array([10, 20, 20, 30], dtype=np.uint64), 20), 1)
+        self.assertEqual(closest_index_sorted(np.array([10, 20, 20, 30], dtype=np.uint64), 21), 2)
+
+    def test_numpy_scalar_queries(self) -> None:
+        """A numpy scalar query is normalised, so it stays as exact as a python int.
+
+        The signature asks for a python int, but a numpy scalar is easy to pass by
+        accident (`arr[i]` rather than `arr[i].item()`). Left alone it would be
+        compared under numpy's own promotion rules, which are lossy above 2**53,
+        and a float would additionally round differently in the bounds check than
+        in the dtype conversion -- far enough to push the search past the end of
+        the array. Both cases below are real, found by fuzzing.
+        """
+        # np.uint64 query: without normalisation this answers 1 instead of 0.
+        timestamps_us = np.array(
+            [
+                1445925052418470747,
+                1445925052418504286,
+                1445925052418750773,
+                1445925052418898571,
+                1445925052419344034,
+            ],
+            dtype=np.uint64,
+        )
+        query = 1445925052418487440  # 16693 above element 0, 16846 below element 1
+        for scalar in (query, np.uint64(query), np.int64(query)):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                # cast: passing a numpy scalar is off-contract, which is the point.
+                self.assertEqual(closest_index_sorted(timestamps_us, cast(int, scalar)), 0, f"query={scalar!r}")
+
+        # float query: without normalisation this raises IndexError. A float cannot
+        # hold such a timestamp at all, but it must still resolve to a valid index.
+        timestamps_us = np.array(
+            [
+                2579916036746490823,
+                2579916036746617919,
+                2579916036747054606,
+                2579916036747107128,
+                2579916036747196230,
+            ],
+            dtype=np.uint64,
+        )
+        self.assertIn(
+            closest_index_sorted(timestamps_us, cast(int, np.float64(2579916036747196561))),
+            range(len(timestamps_us)),
+        )
+
+    def test_float_arrays_still_supported(self) -> None:
+        """Float arrays are compared as floats rather than truncated to integers."""
+        values = np.array([0.0, 1.5, 3.0], dtype=np.float64)
+
+        self.assertEqual(closest_index_sorted(values, 0), 0)
+        self.assertEqual(closest_index_sorted(values, 1), 1)
+        self.assertEqual(closest_index_sorted(values, 2), 1)  # 1.5 is nearer than 3.0
+        self.assertEqual(closest_index_sorted(values, 3), 2)
 
 
 class TestComputeMaxAngleWithMonotonicity(unittest.TestCase):


### PR DESCRIPTION
## Summary

`closest_index_sorted` located the query with `np.searchsorted` and then compared the two neighbouring elements with numpy arithmetic. Both steps lose exactness on uint64 timestamps, **with one failure mode per numpy major version** — both found by fuzzing against the intended algorithm evaluated in python ints, and both returning a *silently wrong index*:

- **numpy 1** compares a python int against an integer array by converting both to float64, which is lossy above 2^53, so `searchsorted` lands next to the true insertion point and the wrong neighbour wins.
- **numpy 2** searches exactly (NEP 50) but, for the same reason, keeps the neighbour subtraction in the array dtype. Where the old code computed `sorted_array[idx] - value` with a larger value on the right, the uint64 result **wrapped to ~1.8e19** instead of going negative, so the nearer neighbour lost the comparison. numpy 1 had hidden that wrap by promoting to float64. numpy 2 also raises `OverflowError` for a negative query.

Fuzzing 80,000 uint64 queries (mixed magnitudes, ~40% with duplicate elements) against the reference:

| | wrong index | differs from old |
|---|---|---|
| old, numpy 1.26.4 | 1889 | — |
| old, numpy 2.3.5 | 2242 | — |
| **new, both** | **0** | only where old was wrong |

## What changed

Bound the query by the array's own range first. Out-of-range queries are answered by the end elements, and what remains is representable in the array's dtype — so the search can run in that dtype and stay exact. That also guarantees both neighbours exist, which **removes the two index guards** the old code needed. The neighbours are then compared as python scalars: `.item()` yields an arbitrary-precision int for integer dtypes, so the differences cannot overflow or round.

The net result is *shorter* than the original:

```python
if value <= sorted_array[0].item():
    return 0
if value > sorted_array[-1].item():
    return len(sorted_array) - 1

idx = int(np.searchsorted(sorted_array, sorted_array.dtype.type(value), side="left"))

if abs(value - sorted_array[idx - 1].item()) < abs(sorted_array[idx].item() - value):
    return idx - 1
return idx
```

The query is normalised with `int()` up front so the bounds check and the dtype conversion see the same value. No dtype branching, no type introspection, and float arrays are unaffected — nothing is truncated to an integer.

### Addressing the review comments

Both comments asked the same thing: if `value` is declared `int`, why introspect it? Fair — and following that through shrank the function rather than growing it.

**"do we not trust the inputs?" / "it should be a form of int"** — agreed. The `isinstance(value, (int, np.integer))` test, the `not isinstance(value, bool)` guard (there only because `bool` subclasses `int`), and the `dtype.kind in "iu"` branch are all gone. What replaced them is a single unconditional `int(value)`. Bounding the query by the array's range then made the old `if idx > 0` / `if idx == len(...)` guards unreachable, so those went too.

**"could we use `value = np.asarray(value)` or so?"** — this one I'd push back on. Making the query a numpy scalar is what *causes* the bug: under NEP 50 the neighbour subtraction then stays in `uint64` and wraps to ~1.8e19. Keeping it a python int is precisely what makes the arithmetic arbitrary-precision and exact. So the conversion needs to go the other way, hence `int()`.

`np.asarray` is still applied to `sorted_array`, since the function reads `.dtype` and the pre-existing `test_regular` passes a python list — without it that call becomes an `AttributeError`. Happy to drop it and convert the test instead if you would rather take the annotation literally on both arguments.

### Why the `int(value)` normalisation earns its line

Every caller today already passes a python int (ncore's own via `get_frame_timestamp_us`, NRE's timestamp sampler via `.item()`), so this is a safety net rather than a functional requirement. It is worth having: without it, an accidentally-passed numpy scalar is compared under numpy's own promotion rules, and a float rounds differently in the bounds check than in the dtype conversion.

Fuzzing 20,000 high-magnitude queries per value type:

| query type | without `int()` | with `int()` |
|---|---|---|
| python int (the contract) | 0 wrong | 0 wrong |
| `np.uint64` | **4 wrong** (numpy 1) | 0 wrong |
| `np.int64` | 0 wrong | 0 wrong |
| `np.float64` / python float | 4 wrong + **1 IndexError** | 3 wrong, no crash |

The `IndexError` is the sharp edge: the float passes the upper-bound check but converts up to the last element, so the search runs off the end. The 3 remaining float misses are unfixable — a float64 cannot hold these timestamps, and is already off by 112–220 *before* the call; the function answers correctly for the value it was actually given.

The upper bound is **deliberately strict**: a query landing exactly on a repeated last element still goes through the search and resolves to the start of that run, as before. A non-strict bound silently changed that; `test_duplicate_elements` pins it.

Affected callers — `SequenceProtocol.get_closest_frame_index` via `compat.py:407` and `tools/ncore_vis/components/camera.py:1027` — are otherwise unchanged for in-range microsecond timestamps, which sit below 2^53 today.

> The existing regression test passed a python **list** rather than a uint64 array, so it could not observe any of this. Input is now normalised with `np.asarray`, so the dtype is well defined either way.

## Validation

| check | result |
|---|---|
| new tests vs `main` | **fail on numpy 1.26.4 *and* 2.3.5** (one case per version) |
| new tests with fix | pass on both |
| 80,000-query fuzz vs reference | 0 wrong on both; differs from old only where old was wrong |
| value-type fuzz (int / np.uint64 / np.int64 / float) | exact for every integer type on both versions |
| `//ncore/impl/data:all`, `//ncore/impl/sensors:all`, `//tools/...` | **19 pass**, python 3.8 (numpy 1.19.5, torch 1.12.1) and 3.11 |
| numpy 1.26.4 + torch 2.7.0 / numpy 2.3.5 + torch 2.13.0 | all suites pass on both |
| `bazel run format`, `ty` | clean |

### Downstream

`nre/datasets/samplers/timestamp.py:72` is the only NRE caller of this symbol, and NRE has no test covering that sampler. So its call path was replayed directly: an `int64` frame-timestamp tensor (per `RigTrajectory.cameras_frame_timestamps_us`), `rng.choice(...).item()` as the query, over 4000 trials including duplicated end timestamps and magnitudes above 2^53.

**Identical indices before and after on both numpy versions**, no overflow warnings, and every sampled timestamp still resolves to a frame carrying exactly that timestamp.

NRE bazel tests against this branch via `--test_env=PYTHONPATH` (sentinel-verified the override was live): `//nre/datasets/samplers:all`, `//libs/vren:lidars_test`, `//nre/models/gaussians:gsplat_lidar_test` — **8 pass**.

Also audited the wider surface: every production caller reaches `closest_index_sorted` through `get_frame_timestamp_us`, which already wraps in `int()` — ncore's `ncore_vis` components and tools, and NRE's `nre/viewer/ncore_dataset_interface.py` and `internal/scripts/ncore_vis/loader.py`. (`nre/nrm/datasets/samplers.py` defines its own unrelated `get_closest_frame_index`.)

