### PR TITLE
fix(sensors): floor the angles-to-columns map index in integer arithmetic

### DIFF
--- a/ncore/impl/sensors/lidar.py
+++ b/ncore/impl/sensors/lidar.py
@@ -406,9 +406,17 @@ class RowOffsetStructuredSpinningLidarModel(StructuredLidarModel):
         _, idxs = kdtree.query(grid_rays.sensor_rays.cpu().numpy())
         idxs = to_torch(idxs, device=self.device, dtype=torch.int32)
 
-        # Map the indices to the columns by dividing with the total number of rows and (implicit) flooring
+        # Map the indices to the columns by dividing with the total number of rows and flooring.
+        # The division is done in integers: routing it through a float divide would be exact only
+        # while the flat index stays below 2**24 (the point where float32 can no longer represent
+        # consecutive integers), above which the quotient rounds up at every element whose index is
+        # just past a multiple of n_rows and the cell is assigned to the next column. Today's maps
+        # stay well below that (7372800 elements for a 128x3600 sensor at resolution factor 4), so
+        # this is behaviour-preserving, but it removes the dependency on that headroom.
         self.angles_to_columns_map = (
-            (idxs / self.n_rows).to(self.angles_to_columns_map_dtype).reshape(grid_elevations_rad.shape)
+            torch.div(idxs, self.n_rows, rounding_mode="floor")
+            .to(self.angles_to_columns_map_dtype)
+            .reshape(grid_elevations_rad.shape)
         )
 
     def sensor_angles_relative_frame_times(self, sensor_angles: Union[torch.Tensor, np.ndarray]) -> torch.Tensor:

--- a/ncore/impl/sensors/lidar_test.py
+++ b/ncore/impl/sensors/lidar_test.py
@@ -17,6 +17,7 @@ import itertools
 import json
 import os
 import unittest
+import unittest.mock
 
 from typing import Tuple
 
@@ -27,6 +28,7 @@ import torch
 from ncore.impl.common.transformations import se3_inverse
 from ncore.impl.common.util import unpack_optional
 from ncore.impl.data.types import RowOffsetStructuredSpinningLidarModelParameters
+from ncore.impl.sensors import lidar as lidar_module
 from ncore.impl.sensors.common import to_torch
 from ncore.impl.sensors.lidar import RowOffsetStructuredSpinningLidarModel
 
@@ -185,6 +187,70 @@ class TestRowOffsetStructuredSpinningLidarModel(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             relative_timestamps, relative_timestamp_reconstructed.cpu().numpy(), decimal=6
         )
+
+    def test_angles_to_columns_map_values(self):
+        """Every mapped column index must be a valid column of the model.
+
+        The map is built by flooring a flat element index by the row count, so a
+        rounding error there shows up as an out-of-range or off-by-one column.
+        """
+        self.lidar_model._init_angles_to_columns_map()
+        angles_to_columns_map = unpack_optional(self.lidar_model.angles_to_columns_map)
+
+        self.assertEqual(
+            tuple(angles_to_columns_map.shape),
+            (
+                self.param_file_mapresfactor[1] * self.model_parameters.n_rows,
+                self.param_file_mapresfactor[1] * self.model_parameters.n_columns,
+            ),
+        )
+        self.assertGreaterEqual(int(angles_to_columns_map.min()), 0)
+        self.assertLessEqual(int(angles_to_columns_map.max()), self.model_parameters.n_columns - 1)
+
+    def test_flat_index_to_column_is_exact_integer_division(self):
+        """The flat-index-to-column conversion must be an exact integer floor.
+
+        _init_angles_to_columns_map turns a flat element index (column-major, so
+        flat = column * n_rows + row) into a column index. Routing that through a
+        float divide is exact only while the flat index stays below 2**24, where
+        float32 can still represent consecutive integers; above it the quotient
+        rounds up at every index just past a multiple of n_rows, moving those
+        cells into the next column.
+
+        A model with that many elements (>2**24, i.e. a >16.7M-point KD-tree) is
+        far too expensive to build here, so the nearest-neighbour lookup is
+        stubbed to return flat indices straddling the limit. That still exercises
+        the real conversion inside _init_angles_to_columns_map. Realistic sizes
+        are covered end-to-end by test_angles_to_columns.
+        """
+        n_rows = self.model_parameters.n_rows
+        model = RowOffsetStructuredSpinningLidarModel(
+            self.model_parameters,
+            angles_to_columns_map_init=False,
+            angles_to_columns_map_resolution_factor=1,  # keep the stubbed grid small
+            angles_to_columns_map_dtype=torch.int32,  # the injected indices exceed int16
+            device=self.device,
+            dtype=self.dtype,
+        )
+        n_grid = self.model_parameters.n_rows * self.model_parameters.n_columns
+        # Start a couple of whole columns below 2**24 so the range crosses the
+        # first flat index whose float32 representation rounds into the next column.
+        flat_indices = np.arange(2**24 - 2 * n_rows, 2**24 - 2 * n_rows + n_grid, dtype=np.int64)
+
+        class _StubKDTree:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            def query(self, *args, **kwargs):
+                return np.zeros(n_grid, dtype=np.float64), flat_indices
+
+        with unittest.mock.patch.object(lidar_module.scipy_spatial, "cKDTree", _StubKDTree):
+            model._init_angles_to_columns_map()
+
+        expected = torch.tensor(flat_indices // n_rows, dtype=torch.int32).reshape(
+            self.model_parameters.n_rows, self.model_parameters.n_columns
+        )
+        self.assertTrue(torch.equal(unpack_optional(model.angles_to_columns_map).cpu(), expected))
 
     def test_rolling_shutter_projection(self):
         """Make sure rolling-shutter unprojection / projection work (mostly) consistent"""


### PR DESCRIPTION
## Summary

`_init_angles_to_columns_map` turns the nearest-neighbour flat element index (column-major, so `flat = column * n_rows + row`) into a column index by dividing by `n_rows` and truncating on the cast to the map dtype:

```python
(idxs / self.n_rows).to(self.angles_to_columns_map_dtype)
```

The division runs in **float32**, which represents consecutive integers only below 2^24. Above that the quotient rounds up at every flat index just past a multiple of `n_rows`, moving those cells into the next column:

| model | elements | wrong indices |
|---|---|---|
| 128 x 3600 (today's Hesai) | 460,800 | 0 |
| 512 x 14400 (largest map here) | 7,372,800 | 0 |
| 128 x 140000 | 17,920,000 | **8,928** |
| 64 x 300000 | 19,200,000 | **37,856** |
| 128 x 200000 | 25,600,000 | **68,928** |

First divergence at flat index 16,777,343: float gives column 131073, exact floor gives 131072.

## Not a numpy-version issue

Unlike the sibling fixes in #172 and #173, this is **version-independent** — the same counts reproduce under torch 2.7.0 and 2.13.0. It is latent headroom, not a live regression.

Today's maps stay well below the limit, so this is **behaviour-preserving**: the maps for both Hesai models come out bit-identical. It removes the dependency on that headroom and makes the line do what its comment already claimed ("dividing with the total number of rows and flooring").

`torch.div`'s `rounding_mode` has been available since torch 1.8, well below the **1.12.1** pinned for the python 3.8 toolchain (verified against the actual pinned wheel).

## Tests

A model with >2^24 elements would need a >16.7M-point KD-tree, far too expensive for a unit test. So the new test **stubs the nearest-neighbour lookup** to return flat indices straddling 2^24, which still exercises the real conversion inside `_init_angles_to_columns_map`. It fails on the unfixed code for **all 16 parameterisations**.

> An earlier version of this test asserted the arithmetic directly rather than going through the model — it passed on the unfixed code, so it would not have caught a revert. The stub version is bound to the implementation.

A second test pins the mapped columns to the model's valid `[0, n_columns - 1]` range.

## Validation

| check | result |
|---|---|
| new test vs pre-fix | **16 of 16 parameterisations fail** |
| new test with fix | all pass |
| `angles_to_columns_map` vs pre-fix | **bit-identical** (0/7,372,800 and 0/2,457,600) |
| `//ncore/impl/data:all`, `//ncore/impl/sensors:all`, `//tools/...` | **19 pass**, python 3.8 (numpy 1.19.5, torch 1.12.1) and 3.11 |
| numpy 1.26.4 + torch 2.7.0 / numpy 2.3.5 + torch 2.13.0 | maps bit-identical, all 614,400 elements pass FOV asserts |
| `bazel run format`, `ty` | clean |

### Downstream

Ran NRE against this branch via `--test_env=PYTHONPATH` (sentinel-verified the override was live): `//libs/vren:lidars_test`, `//nre/models/gaussians:gsplat_lidar_test`, `//nre/datasets/samplers:all` — **8 pass**.

Rebased onto `main` after #172 and #173 merged; re-validated there (19 bazel targets, both numpy/torch combinations, maps bit-identical to current `main`).

