### PR TITLE
feat(sensors): open camera model factory and make CameraModel generic in its parameters

### DIFF
--- a/docs/data/sensor_models.rst
+++ b/docs/data/sensor_models.rst
@@ -433,7 +433,7 @@ Use :meth:`IdealPinholeCameraModelParameters.natural_fov(source)
 
    import numpy as np
    from ncore.data import IdealPinholeCameraModelParameters
-   from ncore.sensors import CameraModel, Rectificator
+   from ncore.sensors import Rectificator, camera_model_from_parameters
 
    source_params = source_model.get_parameters()
 
@@ -446,7 +446,7 @@ Use :meth:`IdealPinholeCameraModelParameters.natural_fov(source)
    )
    target_params = IdealPinholeCameraModelParameters.from_source(source_params, target_fov=np.radians(90.0))
 
-   target = CameraModel.from_parameters(target_params)
+   target = camera_model_from_parameters(target_params)
    rect = Rectificator(source_model, target)
 
 Rectificator

--- a/ncore/impl/data/types.py
+++ b/ncore/impl/data/types.py
@@ -147,8 +147,13 @@ CameraModelParametersSelf = TypeVar("CameraModelParametersSelf", bound="CameraMo
 
 
 @dataclass
-class CameraModelParameters(ABC):
-    """Represents parameters common to all camera models"""
+class CameraModelParameters(dataclasses_json.DataClassJsonMixin, ABC):
+    """Represents parameters common to all camera models
+
+    The JSON (de)serialization interface (:meth:`to_dict` / :meth:`from_dict`) is provided by
+    :class:`dataclasses_json.DataClassJsonMixin` on this base, so that code operating on the
+    abstract type can serialize parameters without narrowing to a concrete model first.
+    """
 
     resolution: np.ndarray = util.numpy_array_field(
         np.uint64
@@ -180,6 +185,17 @@ class CameraModelParameters(ABC):
             a transformed version of the concrete camera model parameters
         """
 
+    @staticmethod
+    def type() -> str:
+        """Returns a string-identifier of the camera model
+
+        Concrete camera model parameters must override this with their own stable identifier; it
+        keys the serialized representation (see :func:`encode_camera_model_parameters`). This is
+        deliberately not an :func:`abstractmethod` so that adding it to this base does not render
+        pre-existing out-of-tree subclasses non-instantiable.
+        """
+        raise NotImplementedError("Concrete camera model parameters must implement type()")
+
     def __post_init__(self) -> None:
         # Sanity checks
         assert self.resolution.shape == (2,)
@@ -194,7 +210,7 @@ class CameraModelParameters(ABC):
 
 
 @dataclass
-class FThetaCameraModelParameters(CameraModelParameters, dataclasses_json.DataClassJsonMixin):
+class FThetaCameraModelParameters(CameraModelParameters):
     """Represents FTheta-specific camera model parameters"""
 
     @unique
@@ -439,7 +455,7 @@ class PinholeCameraModelParameters(CameraModelParameters):
 
 
 @dataclass
-class IdealPinholeCameraModelParameters(PinholeCameraModelParameters, dataclasses_json.DataClassJsonMixin):
+class IdealPinholeCameraModelParameters(PinholeCameraModelParameters):
     """Represents an ideal (distortion-free) pinhole camera
 
     An ideal pinhole maps normalized camera coordinates directly to image coordinates
@@ -615,7 +631,7 @@ class IdealPinholeCameraModelParameters(PinholeCameraModelParameters, dataclasse
 
 
 @dataclass
-class OpenCVPinholeCameraModelParameters(PinholeCameraModelParameters, dataclasses_json.DataClassJsonMixin):
+class OpenCVPinholeCameraModelParameters(PinholeCameraModelParameters):
     """Represents Pinhole-specific (OpenCV-like) camera model parameters"""
 
     radial_coeffs: np.ndarray = util.numpy_array_field(
@@ -663,7 +679,7 @@ class OpenCVPinholeCameraModelParameters(PinholeCameraModelParameters, dataclass
 
 
 @dataclass
-class OpenCVFisheyeCameraModelParameters(CameraModelParameters, dataclasses_json.DataClassJsonMixin):
+class OpenCVFisheyeCameraModelParameters(CameraModelParameters):
     """Represents Fisheye-specific (OpenCV-like) camera model parameters"""
 
     principal_point: np.ndarray = util.numpy_array_field(

--- a/ncore/impl/sensors/camera.py
+++ b/ncore/impl/sensors/camera.py
@@ -19,7 +19,8 @@ import math
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union, cast
+from functools import singledispatch
+from typing import Generic, Optional, Tuple, TypeVar, Union, cast, overload
 
 import numpy as np
 import torch
@@ -245,8 +246,27 @@ class _CameraRollingShutterProjector(RollingShutterSolver.Projector):
         return self._model.image_points_relative_frame_times(projected)
 
 
-class CameraModel(BaseModel, ABC):
-    """Base class for all camera models"""
+#: Type of the camera model parameters a concrete camera model returns from get_parameters().
+#:
+#: Covariant: the parameter appears only in a return position, and invariance would leave
+#: `CameraModel[FThetaCameraModelParameters]` and `CameraModel[OpenCVPinholeCameraModelParameters]`
+#: with no common `CameraModel[...]` supertype, so a type checker joining a heterogeneous
+#: collection of concrete camera models would fall back past `CameraModel` entirely.
+CameraModelParametersT_co = TypeVar("CameraModelParametersT_co", bound=types.CameraModelParameters, covariant=True)
+
+#: Invariant counterpart used for the free factory's generic overload; a covariant type variable
+#: cannot appear in a function parameter position.
+CameraModelParametersT = TypeVar("CameraModelParametersT", bound=types.CameraModelParameters)
+
+
+class CameraModel(BaseModel, ABC, Generic[CameraModelParametersT_co]):
+    """Base class for all camera models
+
+    Generic in the concrete camera model parameter type the model round-trips through
+    :meth:`get_parameters`, so that a ``CameraModel`` remains statically useful without having to
+    narrow it to a concrete model type. Plain (unparameterized) ``CameraModel`` annotations remain
+    valid and behave as before.
+    """
 
     resolution: torch.Tensor  #: Width and height of the image in pixels (int32, [2,])
     shutter_type: types.ShutterType  #: Shutter type of the camera's imaging sensor
@@ -284,6 +304,13 @@ class CameraModel(BaseModel, ABC):
         assert self.resolution.dtype == torch.int32
         assert self.shutter_type in types.ShutterType, f"Unsupported shutter type {self.shutter_type}"
         assert self.external_distortion is None or isinstance(self.external_distortion, ExternalDistortionModel)
+
+    @abstractmethod
+    def get_parameters(self) -> CameraModelParametersT_co:
+        """
+        Returns the camera model parameters specific to the current camera model instance
+        """
+        pass
 
     @abstractmethod
     def _image_points_to_camera_rays_impl(self, image_points: torch.Tensor) -> torch.Tensor:
@@ -360,25 +387,20 @@ class CameraModel(BaseModel, ABC):
 
     @staticmethod
     def from_parameters(
-        cam_model_parameters: types.ConcreteCameraModelParametersUnion,
+        cam_model_parameters: types.CameraModelParameters,
         device: Union[str, torch.device] = torch.device("cuda"),
         dtype: torch.dtype = torch.float32,
     ) -> CameraModel:
         """
         Initialize a generic camera model class from camera model parameters
+
+        .. deprecated::
+            Prefer the module-level :func:`camera_model_from_parameters`, which dispatches on the
+            parameter type (and can be extended for out-of-tree models via
+            :func:`register_camera_model`) instead of being a closed dispatch table inherited by
+            every camera model.
         """
-        if isinstance(cam_model_parameters, types.FThetaCameraModelParameters):
-            return FThetaCameraModel(cam_model_parameters, device, dtype)
-        elif isinstance(cam_model_parameters, types.IdealPinholeCameraModelParameters):
-            return IdealPinholeCameraModel(cam_model_parameters, device, dtype)
-        elif isinstance(cam_model_parameters, types.OpenCVPinholeCameraModelParameters):
-            return OpenCVPinholeCameraModel(cam_model_parameters, device, dtype)
-        elif isinstance(cam_model_parameters, types.OpenCVFisheyeCameraModelParameters):
-            return OpenCVFisheyeCameraModel(cam_model_parameters, device, dtype)
-        else:
-            raise TypeError(
-                f"unsupported camera model type {type(cam_model_parameters)}, currently supporting Ftheta/Ideal-Pinhole/OpenCV-Pinhole/OpenCV-Fisheye only"
-            )
+        return camera_model_from_parameters(cam_model_parameters, device, dtype)
 
     @dataclass
     class WorldPointsToPixelsReturn:
@@ -1155,7 +1177,7 @@ class CameraModel(BaseModel, ABC):
         return xy_norms
 
 
-class FThetaCameraModel(CameraModel):
+class FThetaCameraModel(CameraModel[types.FThetaCameraModelParameters]):
     """Camera model for F-Theta lenses"""
 
     reference_poly: types.FThetaCameraModelParameters.PolynomialType
@@ -1396,7 +1418,14 @@ class FThetaCameraModel(CameraModel):
         return CameraModel.ImagePointsReturn(image_points=image_points, valid_flag=valid, jacobians=jacobians)
 
 
-class PinholeCameraModel(CameraModel, ABC):
+#: Type of the pinhole-family camera model parameters a concrete pinhole model returns
+#: (covariant, see CameraModelParametersT_co)
+PinholeCameraModelParametersT_co = TypeVar(
+    "PinholeCameraModelParametersT_co", bound=types.PinholeCameraModelParameters, covariant=True
+)
+
+
+class PinholeCameraModel(CameraModel[PinholeCameraModelParametersT_co], ABC):
     """Abstract base for pinhole-family camera models
 
     Holds the shared principal point and focal length and implements the closed-form
@@ -1481,7 +1510,7 @@ class PinholeCameraModel(CameraModel, ABC):
         return CameraModel.ImagePointsReturn(image_points=image_points, valid_flag=valid, jacobians=jacobians)
 
 
-class IdealPinholeCameraModel(PinholeCameraModel):
+class IdealPinholeCameraModel(PinholeCameraModel[types.IdealPinholeCameraModelParameters]):
     """Camera model for an ideal (distortion-free) pinhole camera"""
 
     def __init__(
@@ -1518,7 +1547,7 @@ class IdealPinholeCameraModel(PinholeCameraModel):
         return self._ideal_camera_rays_to_image_points(cam_rays, return_jacobians)
 
 
-class OpenCVPinholeCameraModel(PinholeCameraModel):
+class OpenCVPinholeCameraModel(PinholeCameraModel[types.OpenCVPinholeCameraModelParameters]):
     """Camera model for OpenCV pinhole cameras"""
 
     radial_coeffs: torch.Tensor
@@ -1730,7 +1759,7 @@ class OpenCVPinholeCameraModel(PinholeCameraModel):
         return cam_rays
 
 
-class OpenCVFisheyeCameraModel(CameraModel):
+class OpenCVFisheyeCameraModel(CameraModel[types.OpenCVFisheyeCameraModelParameters]):
     """Camera model for OpenCV fisheye cameras"""
 
     principal_point: torch.Tensor
@@ -1907,3 +1936,137 @@ class OpenCVFisheyeCameraModel(CameraModel):
             jacobians = None
 
         return CameraModel.ImagePointsReturn(image_points=image_points, valid_flag=valid, jacobians=jacobians)
+
+
+@singledispatch
+def _camera_model_from_parameters(
+    cam_model_parameters: types.CameraModelParameters,
+    device: Union[str, torch.device] = torch.device("cuda"),
+    dtype: torch.dtype = torch.float32,
+) -> CameraModel:
+    """Open dispatch registry backing :func:`camera_model_from_parameters`
+
+    Kept separate from the public entry point so that the latter can carry precise
+    :func:`typing.overload` signatures: a checker cannot see through the ``singledispatch``
+    decorator, and stacking overloads on top of it is rejected outright.
+    """
+    raise TypeError(
+        f"unsupported camera model type {type(cam_model_parameters)}, currently supporting "
+        "Ftheta/Ideal-Pinhole/OpenCV-Pinhole/OpenCV-Fisheye only; register out-of-tree camera "
+        "models with register_camera_model()"
+    )
+
+
+@_camera_model_from_parameters.register
+def _(
+    cam_model_parameters: types.FThetaCameraModelParameters,
+    device: Union[str, torch.device] = torch.device("cuda"),
+    dtype: torch.dtype = torch.float32,
+) -> FThetaCameraModel:
+    return FThetaCameraModel(cam_model_parameters, device, dtype)
+
+
+@_camera_model_from_parameters.register
+def _(
+    cam_model_parameters: types.IdealPinholeCameraModelParameters,
+    device: Union[str, torch.device] = torch.device("cuda"),
+    dtype: torch.dtype = torch.float32,
+) -> IdealPinholeCameraModel:
+    return IdealPinholeCameraModel(cam_model_parameters, device, dtype)
+
+
+@_camera_model_from_parameters.register
+def _(
+    cam_model_parameters: types.OpenCVPinholeCameraModelParameters,
+    device: Union[str, torch.device] = torch.device("cuda"),
+    dtype: torch.dtype = torch.float32,
+) -> OpenCVPinholeCameraModel:
+    return OpenCVPinholeCameraModel(cam_model_parameters, device, dtype)
+
+
+@_camera_model_from_parameters.register
+def _(
+    cam_model_parameters: types.OpenCVFisheyeCameraModelParameters,
+    device: Union[str, torch.device] = torch.device("cuda"),
+    dtype: torch.dtype = torch.float32,
+) -> OpenCVFisheyeCameraModel:
+    return OpenCVFisheyeCameraModel(cam_model_parameters, device, dtype)
+
+
+#: Registers a camera model factory for a camera model parameter type
+#:
+#: Accepts the same forms as :meth:`functools.singledispatch.register`, i.e. it can be used as a
+#: bare decorator on a factory whose first parameter is annotated with the parameter type it
+#: builds from::
+#:
+#:     @register_camera_model
+#:     def _(cam_model_parameters: MyCameraModelParameters, device=..., dtype=...) -> MyCameraModel:
+#:         return MyCameraModel(cam_model_parameters, device, dtype)
+#:
+#: Dispatch follows the parameter type's MRO, so a model parameter type derived from a registered
+#: one resolves to the base's factory unless it registers its own.
+register_camera_model = _camera_model_from_parameters.register
+
+
+@overload
+def camera_model_from_parameters(
+    cam_model_parameters: types.FThetaCameraModelParameters,
+    device: Union[str, torch.device] = ...,
+    dtype: torch.dtype = ...,
+) -> FThetaCameraModel: ...
+
+
+@overload
+def camera_model_from_parameters(
+    cam_model_parameters: types.IdealPinholeCameraModelParameters,
+    device: Union[str, torch.device] = ...,
+    dtype: torch.dtype = ...,
+) -> IdealPinholeCameraModel: ...
+
+
+@overload
+def camera_model_from_parameters(
+    cam_model_parameters: types.OpenCVPinholeCameraModelParameters,
+    device: Union[str, torch.device] = ...,
+    dtype: torch.dtype = ...,
+) -> OpenCVPinholeCameraModel: ...
+
+
+@overload
+def camera_model_from_parameters(
+    cam_model_parameters: types.OpenCVFisheyeCameraModelParameters,
+    device: Union[str, torch.device] = ...,
+    dtype: torch.dtype = ...,
+) -> OpenCVFisheyeCameraModel: ...
+
+
+@overload
+def camera_model_from_parameters(
+    cam_model_parameters: CameraModelParametersT,
+    device: Union[str, torch.device] = ...,
+    dtype: torch.dtype = ...,
+) -> CameraModel[CameraModelParametersT]: ...
+
+
+def camera_model_from_parameters(
+    cam_model_parameters: types.CameraModelParameters,
+    device: Union[str, torch.device] = torch.device("cuda"),
+    dtype: torch.dtype = torch.float32,
+) -> CameraModel:
+    """Initializes the camera model corresponding to the given camera model parameters
+
+    Dispatches on the runtime type of ``cam_model_parameters``. Out-of-tree camera models can
+    participate by registering their factory via :func:`register_camera_model`.
+
+    Args:
+        cam_model_parameters: the camera model parameters to build the camera model from.
+        device: the device to instantiate the camera model on.
+        dtype: the floating point type to instantiate the camera model with.
+
+    Returns:
+        the camera model corresponding to ``cam_model_parameters``.
+
+    Raises:
+        TypeError: if no camera model is registered for the given parameter type.
+    """
+    return _camera_model_from_parameters(cam_model_parameters, device, dtype)

--- a/ncore/impl/sensors/camera_test.py
+++ b/ncore/impl/sensors/camera_test.py
@@ -32,6 +32,7 @@ from numpy.polynomial.polynomial import Polynomial
 from ncore.impl.common.util import unpack_optional
 from ncore.impl.data.types import (
     BivariateWindshieldModelParameters,
+    CameraModelParameters,
     ConcreteCameraModelParametersUnion,
     FThetaCameraModelParameters,
     IdealPinholeCameraModelParameters,
@@ -50,6 +51,8 @@ from ncore.impl.sensors.camera import (
     IdealPinholeCameraModel,
     OpenCVFisheyeCameraModel,
     OpenCVPinholeCameraModel,
+    camera_model_from_parameters,
+    register_camera_model,
     to_torch,
 )
 
@@ -2313,6 +2316,99 @@ class TestIdealPinholeParameterIO(unittest.TestCase):
         np.testing.assert_array_equal(transformed.resolution, np.array([320, 240], dtype=np.uint64))
         np.testing.assert_array_equal(transformed.focal_length, np.array([250.0, 250.0], dtype=np.float32))
         np.testing.assert_array_equal(transformed.principal_point, np.array([160.0, 120.0], dtype=np.float32))
+
+
+class TestCameraModelFactory(unittest.TestCase):
+    """Tests for the free camera_model_from_parameters() factory and its open registry"""
+
+    # Reuse the parameter builders of the from_source test case
+    _ideal = staticmethod(TestIdealPinholeFromSource._ideal)
+    _opencv = staticmethod(TestIdealPinholeFromSource._opencv)
+    _fisheye = staticmethod(TestIdealPinholeFromSource._fisheye)
+    _ftheta = staticmethod(TestIdealPinholeFromSource._ftheta)
+
+    def test_dispatches_to_concrete_model(self):
+        for params, expected in (
+            (self._ftheta(), FThetaCameraModel),
+            (self._ideal(), IdealPinholeCameraModel),
+            (self._opencv(), OpenCVPinholeCameraModel),
+            (self._fisheye(), OpenCVFisheyeCameraModel),
+        ):
+            with self.subTest(model=expected.__name__):
+                model = camera_model_from_parameters(params, device="cpu")
+                self.assertIsInstance(model, expected)
+                # The parameters round-trip back out through the abstract interface
+                self.assertEqual(model.get_parameters().type(), params.type())
+
+    def test_deprecated_static_factory_forwards(self):
+        params = self._ideal()
+        self.assertIsInstance(
+            CameraModel.from_parameters(params, device="cpu", dtype=torch.float32), IdealPinholeCameraModel
+        )
+
+    def test_unregistered_parameters_raise(self):
+        not_a_camera = cast(ConcreteCameraModelParametersUnion, object())
+        with self.assertRaises(TypeError):
+            camera_model_from_parameters(not_a_camera, device="cpu")
+
+    def test_out_of_tree_registration(self):
+        @dataclasses.dataclass
+        class CustomCameraModelParameters(IdealPinholeCameraModelParameters):
+            @staticmethod
+            def type() -> str:
+                return "custom"
+
+        class CustomCameraModel(IdealPinholeCameraModel):
+            pass
+
+        # Without a registration, dispatch falls back to the base's factory along the MRO
+        params = CustomCameraModelParameters(
+            resolution=np.array([640, 480], dtype=np.uint64),
+            shutter_type=ShutterType.GLOBAL,
+            principal_point=np.array([320.0, 240.0], dtype=np.float32),
+            focal_length=np.array([500.0, 500.0], dtype=np.float32),
+        )
+        self.assertIsInstance(camera_model_from_parameters(params, device="cpu"), IdealPinholeCameraModel)
+
+        @register_camera_model
+        def _(
+            cam_model_parameters: CustomCameraModelParameters,
+            device: Union[str, torch.device] = torch.device("cuda"),
+            dtype: torch.dtype = torch.float32,
+        ) -> CustomCameraModel:
+            return CustomCameraModel(cam_model_parameters, device, dtype)
+
+        # The registry is process-global and singledispatch offers no unregister; keying it on a
+        # method-local parameter type keeps the registration unreachable from other tests
+        self.assertIsInstance(camera_model_from_parameters(params, device="cpu"), CustomCameraModel)
+
+    def test_camera_model_parameters_type_is_covariant(self):
+        # A heterogeneous collection of concrete camera models must still have `CameraModel` as a
+        # common static supertype. With an invariant parameter type it would not: a type checker
+        # joining the element types would fall back past `CameraModel` to its own bases, and every
+        # call to a `CameraModel` method on the joined type would be an error. This assignment only
+        # type-checks while `CameraModelParametersT_co` stays covariant, and the calls below keep
+        # the check honest at runtime too.
+        models: List[CameraModel[CameraModelParameters]] = [
+            camera_model_from_parameters(self._ftheta(), device="cpu"),
+            camera_model_from_parameters(self._ideal(), device="cpu"),
+            camera_model_from_parameters(self._opencv(), device="cpu"),
+            camera_model_from_parameters(self._fisheye(), device="cpu"),
+        ]
+        for model in models:
+            self.assertEqual(tuple(model.resolution.shape), (2,))
+            self.assertIsInstance(model.get_parameters(), CameraModelParameters)
+
+    def test_abstract_base_declares_serialization(self):
+        # Parameters can be serialized through the abstract type without narrowing
+        def encode(parameters: CameraModelParameters) -> dict:
+            return {"camera_model_type": parameters.type(), "camera_model_parameters": parameters.to_dict()}
+
+        self.assertEqual(encode(self._ideal())["camera_model_type"], "ideal-pinhole")
+
+        # ... but the base itself has no identifier of its own
+        with self.assertRaises(NotImplementedError):
+            CameraModelParameters.type()
 
 
 if __name__ == "__main__":

--- a/ncore/sensors/__init__.py
+++ b/ncore/sensors/__init__.py
@@ -24,6 +24,8 @@ from ncore.impl.sensors.camera import (
     OpenCVFisheyeCameraModel,
     OpenCVPinholeCameraModel,
     PinholeCameraModel,
+    camera_model_from_parameters,
+    register_camera_model,
 )
 from ncore.impl.sensors.lidar import LidarModel, RowOffsetStructuredSpinningLidarModel, StructuredLidarModel
 from ncore.impl.sensors.rectification import Rectificator
@@ -31,6 +33,8 @@ from ncore.impl.sensors.rectification import Rectificator
 
 __all__ = [
     "CameraModel",
+    "camera_model_from_parameters",
+    "register_camera_model",
     "FThetaCameraModel",
     "PinholeCameraModel",
     "IdealPinholeCameraModel",


### PR DESCRIPTION
Follows up on a project integration, where functions polymorphic in `CameraModel` / `CameraModelParameters` kept having their signatures replaced with unions of concrete types.

Two things forced that, both fixed here:

1. `CameraModelParameters` had no JSON (de)serialization interface. `type()`, `to_dict()` and `from_dict()` came from mixing `DataClassJsonMixin` into each concrete class individually, so code holding the abstract type could not serialize parameters. The mixin moves onto the base and comes off the concretes (the MRO linearizes unchanged); `type()` is added as a non-abstract method, deliberately, so that pre-existing out-of-tree subclasses stay instantiable.
2. `CameraModel` declared no `get_parameters()`. All four concrete models have one, but the base did not, making a `CameraModel`-typed value a dead end. `CameraModel` is now generic in its parameter type and declares it. Plain unparameterized `CameraModel` annotations and isinstance checks are unaffected.

`CameraModel.from_parameters` was a static method on the abstract base holding a closed if/elif table over every concrete subclass: it needed editing to add a model, could not build a camera model defined outside NCore, and, being inherited, made `FThetaCameraModel.from_parameters(<opencv params>) -> OpenCVPinholeCameraModel` well-typed. It is replaced by a module-level `camera_model_from_parameters()` dispatching on the parameter type via `functools.singledispatch`, with `register_camera_model` for out-of-tree models, and kept as a deprecated forwarder.

The registry sits behind a private symbol so the public entry point can carry `typing.overload` signatures: a checker cannot see through the `singledispatch` decorator, and stacking overloads directly on it is rejected outright. Concrete parameters resolve to their concrete model type; an abstract argument yields `CameraModel[CameraModelParameters]`.

Verified: full suite green (33/33, py3.8 + py3.11), ty aspect clean, `//:format.check` clean.



The camera model parameter type is **covariant**. It appears only in the return position of `get_parameters()`, so covariance is sound, and invariance would be actively harmful: `CameraModel[FThetaCameraModelParameters]` and `CameraModel[OpenCVPinholeCameraModelParameters]` would share no common `CameraModel[...]` supertype, so a type checker joining a heterogeneous collection of concrete camera models would fall back past `CameraModel` to its own bases and reject every subsequent method call on the joined type. A regression test pins this. The free factory's generic overload uses a separate invariant type variable, since a covariant one cannot appear in a function parameter position.