### PR TITLE
refactor(data): return Self from every CameraModelParameters.transform override

### DIFF
--- a/ncore/impl/data/types.py
+++ b/ncore/impl/data/types.py
@@ -34,7 +34,6 @@ from typing import (
     Optional,
     Protocol,
     Tuple,
-    TypeVar,
     Union,
 )
 
@@ -142,9 +141,6 @@ class BivariateWindshieldModelParameters(dataclasses_json.DataClassJsonMixin):
 # Represents the collection of all concrete external distortion types
 ConcreteExternalDistortionParametersUnion = Union[BivariateWindshieldModelParameters]
 
-# Self type-var for camera model parameters consistent with PEP 673 but compatible with Python < 3.11
-CameraModelParametersSelf = TypeVar("CameraModelParametersSelf", bound="CameraModelParameters")
-
 
 @dataclass
 class CameraModelParameters(dataclasses_json.DataClassJsonMixin, ABC):
@@ -166,11 +162,11 @@ class CameraModelParameters(dataclasses_json.DataClassJsonMixin, ABC):
 
     @abstractmethod
     def transform(
-        self: CameraModelParametersSelf,
+        self,
         image_domain_scale: Union[float, Tuple[float, float]],
         image_domain_offset: Tuple[float, float] = (0.0, 0.0),
         new_resolution: Optional[Tuple[int, int]] = None,
-    ) -> CameraModelParametersSelf:
+    ) -> Self:
         """
         Applies a transformation to camera model parameter
 
@@ -302,7 +298,7 @@ class FThetaCameraModelParameters(CameraModelParameters):
         image_domain_scale: Union[float, Tuple[float, float]],
         image_domain_offset: Tuple[float, float] = (0.0, 0.0),
         new_resolution: Optional[Tuple[int, int]] = None,
-    ) -> FThetaCameraModelParameters:
+    ) -> Self:
         """
         Applies a transformation to FTheta camera model parameter
 
@@ -720,7 +716,7 @@ class OpenCVFisheyeCameraModelParameters(CameraModelParameters):
         image_domain_scale: Union[float, Tuple[float, float]],
         image_domain_offset: Tuple[float, float] = (0.0, 0.0),
         new_resolution: Optional[Tuple[int, int]] = None,
-    ) -> OpenCVFisheyeCameraModelParameters:
+    ) -> Self:
         """
         Applies a transformation to OpenCV fisheye camera model parameter
 

--- a/ncore/impl/data/types_test.py
+++ b/ncore/impl/data/types_test.py
@@ -16,14 +16,36 @@
 import io
 import unittest
 
-from typing import Optional
+from typing import List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 import numpy.testing as npt
 import PIL.Image as PILImage
 
 from ncore.impl.common.transformations import PoseGraphInterpolator
-from ncore.impl.data.types import EncodedImageData, PointCloud
+from ncore.impl.data.types import (
+    CameraModelParameters,
+    EncodedImageData,
+    FThetaCameraModelParameters,
+    IdealPinholeCameraModelParameters,
+    OpenCVFisheyeCameraModelParameters,
+    OpenCVPinholeCameraModelParameters,
+    PointCloud,
+    ShutterType,
+)
+
+
+#: A caller-side generic helper over camera model parameters. Bound to the abstract base, this is
+#: the shape downstream code needs in order to transform parameters while keeping the caller's
+#: concrete type; it only type-checks because every `transform` override returns `Self`.
+_CameraModelParametersT = TypeVar("_CameraModelParametersT", bound=CameraModelParameters)
+
+
+def _downscale(
+    parameters: _CameraModelParametersT,
+    image_domain_scale: Union[float, Tuple[float, float]],
+) -> _CameraModelParametersT:
+    return parameters.transform(image_domain_scale)
 
 
 class TestPointCloud(unittest.TestCase):
@@ -353,6 +375,76 @@ class TestEncodedImageData(unittest.TestCase):
         other.get_decoded_image()  # would evict a method-level maxsize=1 cache
         a2 = first.get_decoded_image()
         self.assertIs(a1, a2)
+
+
+class TestCameraModelParametersTransformSelf(unittest.TestCase):
+    """`transform` must preserve the concrete parameter type, statically and at runtime"""
+
+    _RESOLUTION = np.array([640, 480], dtype=np.uint64)
+    _PRINCIPAL_POINT = np.array([320.0, 240.0], dtype=np.float32)
+    _FOCAL_LENGTH = np.array([500.0, 500.0], dtype=np.float32)
+
+    @classmethod
+    def _ftheta(cls) -> FThetaCameraModelParameters:
+        return FThetaCameraModelParameters(
+            resolution=cls._RESOLUTION,
+            shutter_type=ShutterType.GLOBAL,
+            principal_point=cls._PRINCIPAL_POINT,
+            reference_poly=FThetaCameraModelParameters.PolynomialType.ANGLE_TO_PIXELDIST,
+            pixeldist_to_angle_poly=np.array([0.0, 0.0008, 0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            angle_to_pixeldist_poly=np.array([0.0, 1250.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            max_angle=float(np.radians(45.0)),
+            linear_cde=np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        )
+
+    @classmethod
+    def _all_parameters(cls) -> List[CameraModelParameters]:
+        resolution = cls._RESOLUTION
+        principal_point = cls._PRINCIPAL_POINT
+        focal_length = cls._FOCAL_LENGTH
+        return [
+            cls._ftheta(),
+            IdealPinholeCameraModelParameters(
+                resolution=resolution,
+                shutter_type=ShutterType.GLOBAL,
+                principal_point=principal_point,
+                focal_length=focal_length,
+            ),
+            OpenCVPinholeCameraModelParameters(
+                resolution=resolution,
+                shutter_type=ShutterType.GLOBAL,
+                principal_point=principal_point,
+                focal_length=focal_length,
+                radial_coeffs=np.zeros(6, dtype=np.float32),
+                tangential_coeffs=np.zeros(2, dtype=np.float32),
+                thin_prism_coeffs=np.zeros(4, dtype=np.float32),
+            ),
+            OpenCVFisheyeCameraModelParameters(
+                resolution=resolution,
+                shutter_type=ShutterType.GLOBAL,
+                principal_point=principal_point,
+                focal_length=focal_length,
+                radial_coeffs=np.zeros(4, dtype=np.float32),
+                max_angle=float(np.radians(70.0)),
+            ),
+        ]
+
+    def test_transform_preserves_concrete_type(self):
+        # Statically, `_downscale` is generic over the abstract base and returns the caller's own
+        # type; that only holds while every override returns `Self` rather than its own class.
+        for parameters in self._all_parameters():
+            with self.subTest(model=parameters.type()):
+                transformed = _downscale(parameters, 0.5)
+                self.assertIs(type(transformed), type(parameters))
+                npt.assert_array_equal(transformed.resolution, np.array([320, 240], dtype=np.uint64))
+
+    def test_generic_helper_keeps_the_concrete_static_type(self):
+        # Assigning to the concrete type is what pins the `Self` behaviour for the type checker;
+        # with a non-`Self` override this narrows to the declaring class and fails to check. This
+        # needs a statically concrete input, so it takes `_ftheta()` rather than an element of
+        # `_all_parameters()`, which is typed as the abstract base.
+        ftheta: FThetaCameraModelParameters = _downscale(self._ftheta(), 0.5)
+        self.assertIsInstance(ftheta.angle_to_pixeldist_poly, np.ndarray)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`CameraModelParameters.transform` was declared four different ways across the hierarchy:

| class | declaration |
|---|---|
| `CameraModelParameters` (abstract) | `self: CameraModelParametersSelf` -> `CameraModelParametersSelf` (ad-hoc type-var) |
| `PinholeCameraModelParameters` | `self` -> `Self` |
| `FThetaCameraModelParameters` | `self` -> `FThetaCameraModelParameters` |
| `OpenCVFisheyeCameraModelParameters` | `self` -> `OpenCVFisheyeCameraModelParameters` |

The last two narrow `self` relative to the base, so those overrides are not substitutable for it. Two consequences: a helper generic over camera model parameters cannot call `transform` on them at all, and the return type collapses to the declaring class instead of preserving the caller's own type.

This unifies all four on PEP 673 `Self` and drops the now-unused `CameraModelParametersSelf` type-var. `Self` was already used in this module, and the module's `from __future__ import annotations` keeps it safe on the Python versions that do not provide it.

The regression test pins the property that motivates the change: a helper generic over the abstract base

```python
_T = TypeVar("_T", bound=CameraModelParameters)

def _downscale(parameters: _T, image_domain_scale: float) -> _T:
    return parameters.transform(image_domain_scale)
```

now type-checks and returns the caller's concrete type, verified for all four concrete parameter classes.

### Scope, explicitly

This does **not** make the same helper work when its type variable is bound to `ConcreteCameraModelParametersUnion` rather than the abstract base. I verified that separately: with a union bound the receiver is the whole union and is not assignable to any single member's `self`, so the call fails no matter how the overrides are annotated. `PinholeCameraModelParameters` demonstrates this independently of this change, since it already returned `Self` and still produced a diagnostic under a union bound.

Measured against a reproduction of that pattern, this change takes it from 4 diagnostics to 3: only the `invalid-return-type` one is fixed. The three remaining `invalid-argument-type` diagnostics are inherent to the union bound. Binding the type variable to `CameraModelParameters` instead resolves all of them, and does so on `main` today.
