### PR TITLE
feat(sensors): open lidar model factory and make LidarModel generic in its parameters

### DIFF
--- a/ncore/impl/data/types.py
+++ b/ncore/impl/data/types.py
@@ -873,10 +873,33 @@ def decode_camera_model_parameters(encoded_parameters: Mapping) -> ConcreteCamer
 
 
 @dataclass()
-class BaseLidarModelParameters:
-    """Represents parameters common to all lidar models"""
+class BaseLidarModelParameters(dataclasses_json.DataClassJsonMixin, ABC):
+    """Represents parameters common to all lidar models
 
-    pass
+    The JSON (de)serialization interface (:meth:`to_dict` / :meth:`from_dict`) is provided by
+    :class:`dataclasses_json.DataClassJsonMixin` on this base, so that code operating on the
+    abstract type can serialize parameters without narrowing to a concrete model first.
+    """
+
+    @staticmethod
+    def type() -> str:
+        """Returns a string-identifier of the lidar model
+
+        Concrete lidar model parameters must override this with their own stable identifier; it
+        keys the serialized representation (see :func:`encode_lidar_model_parameters`). This is
+        deliberately not an :func:`abstractmethod` so that adding it to this base does not render
+        pre-existing out-of-tree subclasses non-instantiable.
+        """
+        raise NotImplementedError("Concrete lidar model parameters must implement type()")
+
+    def __post_init__(self) -> None:
+        # `ABC` alone does not prevent instantiation when a class declares no abstract method, and
+        # `type()` is deliberately non-abstract here so that out-of-tree subclasses stay
+        # instantiable. Guard the base explicitly: `dataclasses_json` constructs whatever type a
+        # field is annotated with, so an abstract annotation would otherwise yield a silently
+        # useless base instance instead of a concrete model's parameters.
+        if type(self) is BaseLidarModelParameters:
+            raise TypeError("BaseLidarModelParameters is abstract; instantiate a concrete lidar model's parameters")
 
 
 @dataclass()
@@ -912,9 +935,7 @@ class BaseStructuredSpinningLidarModelParameters(BaseSpinningLidarModelParameter
 
 
 @dataclass()
-class RowOffsetStructuredSpinningLidarModelParameters(
-    BaseStructuredSpinningLidarModelParameters, dataclasses_json.DataClassJsonMixin
-):
+class RowOffsetStructuredSpinningLidarModelParameters(BaseStructuredSpinningLidarModelParameters):
     """Represents parameters for a structured spinning lidar model that is using a per-row azimuth-offset (compatible with, e.g., Hesai P128 sensors)"""
 
     # elevation angles
@@ -1004,7 +1025,7 @@ class RowOffsetStructuredSpinningLidarModelParameters(
 ConcreteLidarModelParametersUnion = Union[RowOffsetStructuredSpinningLidarModelParameters]
 
 
-def encode_lidar_model_parameters(lidar_model_parameters: ConcreteLidarModelParametersUnion) -> Dict:
+def encode_lidar_model_parameters(lidar_model_parameters: BaseLidarModelParameters) -> Dict:
     """Encodes lidar intrinsic model parameters to serializable model-typed dictionary"""
 
     encoded = {

--- a/ncore/impl/sensors/lidar.py
+++ b/ncore/impl/sensors/lidar.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Literal, Optional, Union, cast
+from functools import singledispatch
+from typing import Generic, Literal, Optional, TypeVar, Union, cast, overload
 
 import numpy as np
 import torch
@@ -52,8 +53,34 @@ class _LidarRollingShutterProjector(RollingShutterSolver.Projector):
         return self._model.sensor_angles_relative_frame_times(projected)
 
 
-class LidarModel(BaseModel, ABC):
-    """Base class for all lidar models"""
+#: Type of the lidar model parameters a concrete lidar model returns from get_parameters().
+#:
+#: Covariant: the parameter appears only in a return position, and invariance would leave two
+#: concrete `LidarModel[...]` instantiations with no common `LidarModel[...]` supertype, so a type
+#: checker joining a heterogeneous collection of lidar models would fall back past `LidarModel`.
+LidarModelParametersT_co = TypeVar("LidarModelParametersT_co", bound=types.BaseLidarModelParameters, covariant=True)
+
+#: Invariant counterpart used for the free factory's generic overload; a covariant type variable
+#: cannot appear in a function parameter position.
+LidarModelParametersT = TypeVar("LidarModelParametersT", bound=types.BaseLidarModelParameters)
+
+#: Type of the structured lidar model parameters a concrete structured model returns
+#: (covariant, see LidarModelParametersT_co)
+StructuredLidarModelParametersT_co = TypeVar(
+    "StructuredLidarModelParametersT_co",
+    bound=types.BaseStructuredSpinningLidarModelParameters,
+    covariant=True,
+)
+
+
+class LidarModel(BaseModel, ABC, Generic[LidarModelParametersT_co]):
+    """Base class for all lidar models
+
+    Generic in the concrete lidar model parameter type the model round-trips through
+    :meth:`get_parameters`, so that a ``LidarModel`` remains statically useful without having to
+    narrow it to a concrete model type. Plain (unparameterized) ``LidarModel`` annotations remain
+    valid and behave as before.
+    """
 
     @dataclass
     class SensorAnglesReturn:
@@ -115,20 +142,27 @@ class LidarModel(BaseModel, ABC):
 
     @staticmethod
     def maybe_from_parameters(
-        lidar_model_parameters: Optional[types.ConcreteLidarModelParametersUnion],
+        lidar_model_parameters: Optional[types.BaseLidarModelParameters],
         device: Union[str, torch.device] = torch.device("cuda"),
         dtype: torch.dtype = torch.float32,
     ) -> Optional[LidarModel]:
         """
         Initialize a generic lidar model from parameters, if available
+
+        .. deprecated::
+            Prefer the module-level :func:`maybe_lidar_model_from_parameters`, which dispatches on
+            the parameter type (and can be extended for out-of-tree models via
+            :func:`register_lidar_model`) instead of being a closed dispatch table inherited by
+            every lidar model.
         """
-        if lidar_model_parameters is None:
-            return None
-        if isinstance(lidar_model_parameters, types.RowOffsetStructuredSpinningLidarModelParameters):
-            return RowOffsetStructuredSpinningLidarModel(lidar_model_parameters, device=device, dtype=dtype)
-        raise TypeError(
-            f"Unsupported lidar model type {type(lidar_model_parameters)}, currently only supporting 'RowOffsetStructuredSpinningLidarModel'."
-        )
+        return maybe_lidar_model_from_parameters(lidar_model_parameters, device, dtype)
+
+    @abstractmethod
+    def get_parameters(self) -> LidarModelParametersT_co:
+        """
+        Returns the lidar model parameters specific to the current lidar model instance
+        """
+        ...
 
     @abstractmethod
     def sensor_rays_to_sensor_angles(
@@ -145,23 +179,27 @@ class LidarModel(BaseModel, ABC):
         ...
 
 
-class StructuredLidarModel(LidarModel, ABC):
+class StructuredLidarModel(LidarModel[StructuredLidarModelParametersT_co], ABC):
     @staticmethod
     def maybe_from_parameters(
-        lidar_model_parameters: Optional[types.ConcreteLidarModelParametersUnion],
+        lidar_model_parameters: Optional[types.BaseLidarModelParameters],
         device: Union[str, torch.device] = torch.device("cuda"),
         dtype: torch.dtype = torch.float32,
     ) -> Optional[StructuredLidarModel]:
         """
-        Initialize a generic lidar model from parameters, if available
+        Initialize a structured lidar model from parameters, if available
+
+        .. deprecated::
+            Prefer the module-level :func:`maybe_lidar_model_from_parameters`. This shadowed the
+            base's static method with a narrowed return type, so which closed dispatch table ran
+            depended only on the class name the caller happened to spell. The parameter type stays
+            as wide as the base's: narrowing it here would be a contravariance violation, so the
+            structured-ness of the result is enforced at runtime instead.
         """
-        if lidar_model_parameters is None:
-            return None
-        if isinstance(lidar_model_parameters, types.RowOffsetStructuredSpinningLidarModelParameters):
-            return RowOffsetStructuredSpinningLidarModel(lidar_model_parameters, device=device, dtype=dtype)
-        raise TypeError(
-            f"Unsupported structured lidar model type {type(lidar_model_parameters)}, currently only supporting 'RowOffsetStructuredSpinningLidarModel'."
-        )
+        model = maybe_lidar_model_from_parameters(lidar_model_parameters, device, dtype)
+        if model is not None and not isinstance(model, StructuredLidarModel):
+            raise TypeError(f"{type(lidar_model_parameters)} does not build a structured lidar model")
+        return model
 
     def elements_to_sensor_points(
         self, elements: Union[torch.Tensor, np.ndarray], element_distances: Union[torch.Tensor, np.ndarray]
@@ -195,7 +233,9 @@ class StructuredLidarModel(LidarModel, ABC):
         ...
 
 
-class RowOffsetStructuredSpinningLidarModel(StructuredLidarModel):
+class RowOffsetStructuredSpinningLidarModel(
+    StructuredLidarModel[types.RowOffsetStructuredSpinningLidarModelParameters]
+):
     """Represents a structured spinning lidar model that is using a per-row azimuth-offset (compatible with, e.g., Hesai P128 sensors)"""
 
     row_elevations_rad: torch.Tensor
@@ -691,3 +731,112 @@ class RowOffsetStructuredSpinningLidarModel(StructuredLidarModel):
 
         # Check if relative sensor angles are within the FOV of the sensor
         return self._valid_relative_sensor_angles(relative_sensor_angles)
+
+
+@singledispatch
+def _lidar_model_from_parameters(
+    lidar_model_parameters: types.BaseLidarModelParameters,
+    device: Union[str, torch.device] = torch.device("cuda"),
+    dtype: torch.dtype = torch.float32,
+) -> LidarModel:
+    """Open dispatch registry backing :func:`lidar_model_from_parameters`
+
+    Kept separate from the public entry point so that the latter can carry precise
+    :func:`typing.overload` signatures: a checker cannot see through the ``singledispatch``
+    decorator, and stacking overloads on top of it is rejected outright.
+    """
+    raise TypeError(
+        f"Unsupported lidar model type {type(lidar_model_parameters)}, currently only supporting "
+        "'RowOffsetStructuredSpinningLidarModel'; register out-of-tree lidar models with "
+        "register_lidar_model()"
+    )
+
+
+@_lidar_model_from_parameters.register
+def _(
+    lidar_model_parameters: types.RowOffsetStructuredSpinningLidarModelParameters,
+    device: Union[str, torch.device] = torch.device("cuda"),
+    dtype: torch.dtype = torch.float32,
+) -> RowOffsetStructuredSpinningLidarModel:
+    return RowOffsetStructuredSpinningLidarModel(lidar_model_parameters, device=device, dtype=dtype)
+
+
+#: Registers a lidar model factory for a lidar model parameter type
+#:
+#: Accepts the same forms as :meth:`functools.singledispatch.register`, i.e. it can be used as a
+#: bare decorator on a factory whose first parameter is annotated with the parameter type it
+#: builds from. Dispatch follows the parameter type's MRO, so a model parameter type derived from
+#: a registered one resolves to the base's factory unless it registers its own.
+#:
+#: Registration is a runtime mechanism; it cannot extend the overloads of
+#: :func:`lidar_model_from_parameters`. Out-of-tree parameters deriving from
+#: :class:`~ncore.impl.data.types.BaseLidarModelParameters` therefore resolve statically through
+#: the generic overload to ``LidarModel[TheirParameters]``, which is precise enough for most uses.
+#: Parameters deriving from a *concrete* NCore parameters class instead match that class's
+#: overload, so the call statically yields the NCore model type even though the registered factory
+#: runs. Register a distinct parameters type, or wrap the call in an own typed helper, where the
+#: precise model type matters.
+register_lidar_model = _lidar_model_from_parameters.register
+
+
+@overload
+def lidar_model_from_parameters(
+    lidar_model_parameters: types.RowOffsetStructuredSpinningLidarModelParameters,
+    device: Union[str, torch.device] = ...,
+    dtype: torch.dtype = ...,
+) -> RowOffsetStructuredSpinningLidarModel: ...
+
+
+@overload
+def lidar_model_from_parameters(
+    lidar_model_parameters: LidarModelParametersT,
+    device: Union[str, torch.device] = ...,
+    dtype: torch.dtype = ...,
+) -> LidarModel[LidarModelParametersT]: ...
+
+
+def lidar_model_from_parameters(
+    lidar_model_parameters: types.BaseLidarModelParameters,
+    device: Union[str, torch.device] = torch.device("cuda"),
+    dtype: torch.dtype = torch.float32,
+) -> LidarModel:
+    """Initializes the lidar model corresponding to the given lidar model parameters
+
+    Dispatches on the runtime type of ``lidar_model_parameters``. Out-of-tree lidar models can
+    participate by registering their factory via :func:`register_lidar_model`.
+
+    Args:
+        lidar_model_parameters: the lidar model parameters to build the lidar model from.
+        device: the device to instantiate the lidar model on.
+        dtype: the floating point type to instantiate the lidar model with.
+
+    Returns:
+        the lidar model corresponding to ``lidar_model_parameters``.
+
+    Raises:
+        TypeError: if no lidar model is registered for the given parameter type.
+    """
+    return _lidar_model_from_parameters(lidar_model_parameters, device, dtype)
+
+
+def maybe_lidar_model_from_parameters(
+    lidar_model_parameters: Optional[types.BaseLidarModelParameters],
+    device: Union[str, torch.device] = torch.device("cuda"),
+    dtype: torch.dtype = torch.float32,
+) -> Optional[LidarModel]:
+    """Initializes the lidar model corresponding to the given parameters, if any
+
+    Convenience wrapper around :func:`lidar_model_from_parameters` for the common case of an
+    optional lidar model.
+
+    Args:
+        lidar_model_parameters: the lidar model parameters to build from, or None.
+        device: the device to instantiate the lidar model on.
+        dtype: the floating point type to instantiate the lidar model with.
+
+    Returns:
+        the corresponding lidar model, or None if no parameters were given.
+    """
+    if lidar_model_parameters is None:
+        return None
+    return lidar_model_from_parameters(lidar_model_parameters, device, dtype)

--- a/ncore/impl/sensors/lidar_test.py
+++ b/ncore/impl/sensors/lidar_test.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import itertools
 import json
 import os
 import unittest
 import unittest.mock
 
-from typing import Tuple
+from typing import List, Tuple, Union, cast
 
 import numpy as np
 import parameterized
@@ -27,10 +28,17 @@ import torch
 
 from ncore.impl.common.transformations import se3_inverse
 from ncore.impl.common.util import unpack_optional
-from ncore.impl.data.types import RowOffsetStructuredSpinningLidarModelParameters
+from ncore.impl.data.types import BaseLidarModelParameters, RowOffsetStructuredSpinningLidarModelParameters
 from ncore.impl.sensors import lidar as lidar_module
 from ncore.impl.sensors.common import to_torch
-from ncore.impl.sensors.lidar import RowOffsetStructuredSpinningLidarModel
+from ncore.impl.sensors.lidar import (
+    LidarModel,
+    RowOffsetStructuredSpinningLidarModel,
+    StructuredLidarModel,
+    lidar_model_from_parameters,
+    maybe_lidar_model_from_parameters,
+    register_lidar_model,
+)
 
 
 # =============================================================================
@@ -71,6 +79,104 @@ class TestRowOffsetStructuredSpinningLidarModelParameters(unittest.TestCase):
 
         # re-enconde and make sure data is equal
         self.assertEqual(model_parameters.to_dict(), self.model_parameters_ref)
+
+
+class TestLidarModelFactory(unittest.TestCase):
+    """Tests for the free lidar_model_from_parameters() factory and its open registry"""
+
+    @staticmethod
+    def _parameters() -> RowOffsetStructuredSpinningLidarModelParameters:
+        with open("ncore/impl/sensors/test_data/row-offset-spinning-lidar-model-parameters.json", "r") as fp:
+            return RowOffsetStructuredSpinningLidarModelParameters.from_dict(json.load(fp))
+
+    def test_dispatches_to_concrete_model(self):
+        model = lidar_model_from_parameters(self._parameters(), device="cpu")
+        self.assertIsInstance(model, RowOffsetStructuredSpinningLidarModel)
+        # The parameters round-trip back out through the abstract interface
+        self.assertEqual(model.get_parameters().type(), self._parameters().type())
+
+    def test_maybe_variant_passes_none_through(self):
+        self.assertIsNone(maybe_lidar_model_from_parameters(None, device="cpu"))
+        self.assertIsInstance(
+            maybe_lidar_model_from_parameters(self._parameters(), device="cpu"),
+            RowOffsetStructuredSpinningLidarModel,
+        )
+
+    def test_deprecated_static_factories_forward(self):
+        parameters = self._parameters()
+        for owner in (LidarModel, StructuredLidarModel):
+            with self.subTest(owner=owner.__name__):
+                self.assertIsInstance(
+                    owner.maybe_from_parameters(parameters, device="cpu"),
+                    RowOffsetStructuredSpinningLidarModel,
+                )
+                self.assertIsNone(owner.maybe_from_parameters(None, device="cpu"))
+
+    def test_unregistered_parameters_raise(self):
+        with self.assertRaises(TypeError):
+            lidar_model_from_parameters(cast(BaseLidarModelParameters, object()), device="cpu")
+
+    def test_out_of_tree_registration(self):
+        @dataclasses.dataclass
+        class CustomLidarModelParameters(RowOffsetStructuredSpinningLidarModelParameters):
+            @staticmethod
+            def type() -> str:
+                return "custom"
+
+        class CustomLidarModel(RowOffsetStructuredSpinningLidarModel):
+            pass
+
+        reference = self._parameters()
+        parameters = CustomLidarModelParameters(**dataclasses.asdict(reference))
+
+        # Without a registration, dispatch falls back to the base's factory along the MRO
+        self.assertIsInstance(
+            lidar_model_from_parameters(parameters, device="cpu"), RowOffsetStructuredSpinningLidarModel
+        )
+
+        @register_lidar_model
+        def _(
+            lidar_model_parameters: CustomLidarModelParameters,
+            device: Union[str, torch.device] = torch.device("cuda"),
+            dtype: torch.dtype = torch.float32,
+        ) -> CustomLidarModel:
+            return CustomLidarModel(lidar_model_parameters, device=device, dtype=dtype)
+
+        # The registry is process-global and singledispatch offers no unregister; keying it on a
+        # method-local parameter type keeps the registration unreachable from other tests.
+        #
+        # Registration is a runtime mechanism and cannot add an overload, so this call statically
+        # resolves through the overload of the concrete base these parameters derive from, i.e. to
+        # `RowOffsetStructuredSpinningLidarModel`. That stays sound here because `CustomLidarModel`
+        # is one; see `register_lidar_model` for when it is not.
+        self.assertIsInstance(lidar_model_from_parameters(parameters, device="cpu"), CustomLidarModel)
+
+    def test_lidar_model_parameters_type_is_covariant(self):
+        # A collection of lidar models must still have `LidarModel` as a common static supertype;
+        # with an invariant parameter type a type checker joining the element types would fall back
+        # past `LidarModel` and reject every method call on the joined type.
+        models: List[LidarModel[BaseLidarModelParameters]] = [
+            lidar_model_from_parameters(self._parameters(), device="cpu"),
+        ]
+        for model in models:
+            self.assertIsInstance(model.get_parameters(), BaseLidarModelParameters)
+
+    def test_abstract_base_is_not_instantiable(self):
+        # `ABC` does not prevent instantiation without an abstract method, and `type()` is
+        # deliberately non-abstract, so the base guards itself explicitly.
+        with self.assertRaises(TypeError):
+            BaseLidarModelParameters()
+
+    def test_abstract_base_declares_serialization(self):
+        # Parameters can be serialized through the abstract type without narrowing
+        def encode(parameters: BaseLidarModelParameters) -> dict:
+            return {"lidar_model_type": parameters.type(), "lidar_model_parameters": parameters.to_dict()}
+
+        self.assertEqual(encode(self._parameters())["lidar_model_type"], "row-offset-spinning")
+
+        # ... but the base itself has no identifier of its own
+        with self.assertRaises(NotImplementedError):
+            BaseLidarModelParameters.type()
 
 
 # NOTE: Uses _get_test_devices() to skip GPU tests when NCORE_NO_GPU_TESTS is set

--- a/ncore/sensors/__init__.py
+++ b/ncore/sensors/__init__.py
@@ -27,7 +27,14 @@ from ncore.impl.sensors.camera import (
     camera_model_from_parameters,
     register_camera_model,
 )
-from ncore.impl.sensors.lidar import LidarModel, RowOffsetStructuredSpinningLidarModel, StructuredLidarModel
+from ncore.impl.sensors.lidar import (
+    LidarModel,
+    RowOffsetStructuredSpinningLidarModel,
+    StructuredLidarModel,
+    lidar_model_from_parameters,
+    maybe_lidar_model_from_parameters,
+    register_lidar_model,
+)
 from ncore.impl.sensors.rectification import Rectificator
 
 
@@ -43,6 +50,9 @@ __all__ = [
     "ExternalDistortionModel",
     "BivariateWindshieldModel",
     "LidarModel",
+    "lidar_model_from_parameters",
+    "maybe_lidar_model_from_parameters",
+    "register_lidar_model",
     "StructuredLidarModel",
     "RowOffsetStructuredSpinningLidarModel",
     "Rectificator",


### PR DESCRIPTION
Applies the treatment the camera model hierarchy received in #175 / #177 to the lidar hierarchy. Same shape, so the review should feel familiar.

### The closed dispatch table, twice

`LidarModel.maybe_from_parameters` was a static method on the abstract base holding a closed `if`/`elif` table over every concrete subclass — and `StructuredLidarModel` **shadowed it with a second copy** that had to be kept in sync by hand. Since static methods do not dispatch, which of the two tables ran depended only on the class name the caller happened to spell, and neither could construct a lidar model defined outside NCore.

Both are replaced by a module-level `lidar_model_from_parameters()` dispatching on the parameter type via `functools.singledispatch`, with `maybe_lidar_model_from_parameters()` for the optional case and `register_lidar_model` for out-of-tree models. Both static methods are kept as deprecated forwarders.

### Generic model

`LidarModel` declared no `get_parameters` — only the concrete leaf did, so a `LidarModel`-typed value was a dead end. It is now generic in its parameter type and declares it. The parameter is **covariant**: it appears only in a return position, and invariance would leave concrete instantiations with no common `LidarModel[...]` supertype. Plain unparameterized `LidarModel` annotations and isinstance checks are unaffected.

### Serialization on the abstract base

`BaseLidarModelParameters` was not even an ABC (`@dataclass class BaseLidarModelParameters: pass`); the JSON mixin and `type()` sat only on the concrete leaf, so code holding the abstract type could not serialize. It now carries both, `type()` non-abstract so pre-existing out-of-tree subclasses stay instantiable, and the leaf drops its own mixin.

### One thing worth a look

The deprecated `StructuredLidarModel.maybe_from_parameters` keeps the **base's** parameter type rather than narrowing it to the structured parameters. Narrowing it is a contravariance violation that `ty` rejects once the base is widened — it was invisible before only because both copies happened to name the same concrete union. The structured-ness of the result is enforced at runtime instead.

Verified: 33/33 tests on 3.8 and 3.11, `ty` aspect clean, `//:format.check` clean.
