### PR TITLE
docs(conversions): correct stale converter test targets, defaults and revision

### DIFF
--- a/docs/conversions/argoverse2/argoverse2.rst
+++ b/docs/conversions/argoverse2/argoverse2.rst
@@ -132,4 +132,4 @@ Testing
 .. code-block:: bash
 
     AV2_DIR=/path/to/argoverse2/sensor AV2_SPLIT=val \
-        bazel test //tools/data_converter/argoverse2:pytest_converter
+        bazel test //tools/data_converter/argoverse2:pytest_converter_3_11

--- a/docs/conversions/waymo/waymo.rst
+++ b/docs/conversions/waymo/waymo.rst
@@ -131,7 +131,7 @@ To convert only a time slice of each sequence, use ``--seek-sec`` and/or
      - Output store format. ``itar`` produces an indexed tar archive;
        ``directory`` writes plain zarr directories
    * - ``--profile {default,separate-sensors,separate-all}``
-     - ``default``
+     - ``separate-sensors``
      - Component group layout. ``default`` groups all sensors together;
        ``separate-sensors`` gives each sensor its own group; ``separate-all``
        splits every component type into its own group

--- a/tools/data_converter/argoverse2/README.md
+++ b/tools/data_converter/argoverse2/README.md
@@ -113,5 +113,5 @@ the converter does not export).
 
 ```bash
 AV2_DIR=/path/to/argoverse2/sensor AV2_SPLIT=val \
-    bazel test //tools/data_converter/argoverse2:pytest_converter
+    bazel test //tools/data_converter/argoverse2:pytest_converter_3_11
 ```

--- a/tools/data_converter/nuscenes/README.md
+++ b/tools/data_converter/nuscenes/README.md
@@ -89,5 +89,5 @@ far-range (> 20 m) angular error, measured with `//tools:ncore_evaluate_lidar_mo
 
 ```bash
 NUSCENES_DIR=/path/to/nuscenes NUSCENES_VERSION=v1.0-mini \
-    bazel test //tools/data_converter/nuscenes:pytest_converter
+    bazel test //tools/data_converter/nuscenes:pytest_converter_3_11
 ```

--- a/tools/data_converter/pai/README.md
+++ b/tools/data_converter/pai/README.md
@@ -154,7 +154,7 @@ bazel run //tools/data_converter/pai:convert -- \
     --hf-token <your-hf-token>
 ```
 
-`--revision` selects the HuggingFace dataset branch/tag (current default: `ncore`). Video data is
+`--revision` selects the HuggingFace dataset branch/tag (default: `main`). Video data is
 temporarily written to disk and cleaned up after each clip.
 
 ### Shared conversion options


### PR DESCRIPTION
## Description

Four independent staleness fixes found while cross-checking the converter docs
against the code for the ncore skill in #181. Docs only, no code change.

1. **Test targets that do not exist.** `pytest_test` suffixes the Python
   version (`bazel/pytest/defs.bzl:30`), so `:pytest_converter` is not a real
   label and the documented command errors out with
   `no such target ... did you mean pylib_utils?`. Fixed in
   `argoverse2/README.md`, `docs/conversions/argoverse2/argoverse2.rst` and
   `nuscenes/README.md`. (`tools/data_converter/README.md` already had the
   suffixed form.)

2. **Waymo `--profile` default.** `waymo.rst` documented `default`, but both
   `waymo/converter.py:1045` and `waymo/README.md:43` say `separate-sensors`.
   All six converters default to `separate-sensors`.

3. **PAI `--revision` default.** `pai/README.md:157` said `ncore`;
   `DEFAULT_REVISION` in `pai_remote/config.py:28` is `main`, which
   `pai.rst:269` already stated correctly.

## Testing

```
bazel run //:format.check   # clean
```

Verified each corrected target resolves under `bazel query`, and each corrected
default against the source.

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits are GPG-signed
- [ ] I have added tests that prove my fix is effective or my feature works — n/a, documentation only
- [x] New and existing tests pass locally (`bazel test //...`)
- [x] Code is formatted (`bazel run //:format`)
- [x] I have updated documentation as needed
- [x] My changes include SPDX license headers on all new files
