### PR TITLE
refactor(data): type the reader and writer APIs against the abstract parameter bases

### DIFF
--- a/ncore/impl/data/compat.py
+++ b/ncore/impl/data/compat.py
@@ -63,14 +63,14 @@ from upath import UPath
 from ncore.impl.common.transformations import HalfClosedInterval, PoseGraphInterpolator
 from ncore.impl.data.types import (
     CameraLabelDescriptor,
-    ConcreteCameraModelParametersUnion,
-    ConcreteLidarModelParametersUnion,
+    CameraModelParameters,
     CuboidTrackObservation,
     EncodedImageData,
     FrameTimepoint,
     JsonLike,
     LabelCategory,
     LabelType,
+    LidarModelParameters,
     PointCloud,
 )
 from ncore.impl.data.util import closest_index_sorted
@@ -412,7 +412,7 @@ class CameraSensorProtocol(SensorProtocol, Protocol):
     """CameraSensorProtocol provides unified access to a relevant subset of common NCore camera sensor APIs"""
 
     @property
-    def model_parameters(self) -> ConcreteCameraModelParametersUnion:
+    def model_parameters(self) -> CameraModelParameters:
         """Returns parameters specific to the camera's intrinsic model"""
         ...
 
@@ -560,7 +560,7 @@ class LidarSensorProtocol(RayBundleSensorProtocol, Protocol):
     """LidarSensorProtocol provides unified access to a relevant subset of common NCore lidar sensor APIs"""
 
     @property
-    def model_parameters(self) -> Optional[ConcreteLidarModelParametersUnion]:
+    def model_parameters(self) -> Optional[LidarModelParameters]:
         """Returns parameters specific to the lidar's intrinsic model (optional as not mandatory)"""
         ...
 

--- a/ncore/impl/data/types.py
+++ b/ncore/impl/data/types.py
@@ -576,7 +576,7 @@ class IdealPinholeCameraModelParameters(PinholeCameraModelParameters):
         return IdealPinholeCameraModelParameters._fov_for_focal(half_extent, self.focal_length)
 
     @staticmethod
-    def natural_fov(source: ConcreteCameraModelParametersUnion) -> np.ndarray:
+    def natural_fov(source: CameraModelParameters) -> np.ndarray:
         """Per-axis full field-of-view angles ``[fov_x, fov_y]`` [rad] of ``source``'s ideal pinhole
 
         This is the field of view of the (paraxial) ideal pinhole that
@@ -598,7 +598,7 @@ class IdealPinholeCameraModelParameters(PinholeCameraModelParameters):
 
     @staticmethod
     def from_source(
-        source: ConcreteCameraModelParametersUnion,
+        source: CameraModelParameters,
         target_fov: Union[float, np.ndarray, None] = None,
     ) -> IdealPinholeCameraModelParameters:
         """Construct an ideal (distortion-free) pinhole approximating ``source``
@@ -666,7 +666,7 @@ class IdealPinholeCameraModelParameters(PinholeCameraModelParameters):
 
     @staticmethod
     def _paraxial_geometry(
-        source: ConcreteCameraModelParametersUnion,
+        source: CameraModelParameters,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Extract the (paraxial focal, principal point, resolution) of ``source``'s ideal pinhole
 
@@ -919,7 +919,7 @@ ConcreteCameraModelParametersUnion = Union[
 ]
 
 
-def encode_camera_model_parameters(camera_model_parameters: ConcreteCameraModelParametersUnion) -> Dict:
+def encode_camera_model_parameters(camera_model_parameters: CameraModelParameters) -> Dict:
     """Encodes camera intrinsic model parameters to serializable model-typed dictionary"""
 
     encoded = {
@@ -936,7 +936,7 @@ def encode_camera_model_parameters(camera_model_parameters: ConcreteCameraModelP
     return encoded
 
 
-def decode_camera_model_parameters(encoded_parameters: Mapping) -> ConcreteCameraModelParametersUnion:
+def decode_camera_model_parameters(encoded_parameters: Mapping) -> CameraModelParameters:
     """Decodes model-typed dictionary parameters specific to the camera's intrinsic model"""
 
     camera_model_type = encoded_parameters["camera_model_type"]
@@ -1138,7 +1138,7 @@ def encode_lidar_model_parameters(lidar_model_parameters: LidarModelParameters) 
     return encoded
 
 
-def decode_lidar_model_parameters(encoded_parameters: Mapping) -> ConcreteLidarModelParametersUnion:
+def decode_lidar_model_parameters(encoded_parameters: Mapping) -> LidarModelParameters:
     """Decodes model-typed dictionary parameters specific to the lidars's intrinsic model"""
 
     lidar_model_type = encoded_parameters["lidar_model_type"]

--- a/ncore/impl/data/v4/compat.py
+++ b/ncore/impl/data/v4/compat.py
@@ -38,13 +38,13 @@ from ncore.impl.data.compat import (
 )
 from ncore.impl.data.types import (
     CameraLabelDescriptor,
-    ConcreteCameraModelParametersUnion,
-    ConcreteLidarModelParametersUnion,
+    CameraModelParameters,
     CuboidTrackObservation,
     FrameTimepoint,
     JsonLike,
     LabelCategory,
     LabelType,
+    LidarModelParameters,
     PointCloud,
 )
 from ncore.impl.data.v4.components import (
@@ -292,13 +292,13 @@ class SequenceLoaderV4(SequenceLoaderProtocol):
             self,
             reader: CameraSensorComponent.Reader,
             mask_reader: Optional[MasksComponent.Reader],
-            model_parameters: ConcreteCameraModelParametersUnion,
+            model_parameters: CameraModelParameters,
             pose_graph: PoseGraphInterpolator,
         ):
             super().__init__(reader, pose_graph)
 
             self._mask_reader: Optional[MasksComponent.Reader] = mask_reader
-            self._model_parameters: ConcreteCameraModelParametersUnion = model_parameters
+            self._model_parameters: CameraModelParameters = model_parameters
 
         @property
         def camera_reader(self) -> CameraSensorComponent.Reader:
@@ -306,7 +306,7 @@ class SequenceLoaderV4(SequenceLoaderProtocol):
 
         @property
         @override
-        def model_parameters(self) -> ConcreteCameraModelParametersUnion:
+        def model_parameters(self) -> CameraModelParameters:
             """Returns parameters specific to the camera's intrinsic model"""
             return self._model_parameters
 
@@ -465,11 +465,11 @@ class SequenceLoaderV4(SequenceLoaderProtocol):
             self,
             reader: LidarSensorComponent.Reader,
             pose_graph: PoseGraphInterpolator,
-            model_parameters: Optional[ConcreteLidarModelParametersUnion],
+            model_parameters: Optional[LidarModelParameters],
         ):
             super().__init__(reader, pose_graph)
 
-            self._model_parameters: Optional[ConcreteLidarModelParametersUnion] = model_parameters
+            self._model_parameters: Optional[LidarModelParameters] = model_parameters
 
         @property
         def lidar_reader(self) -> LidarSensorComponent.Reader:
@@ -477,7 +477,7 @@ class SequenceLoaderV4(SequenceLoaderProtocol):
 
         @property
         @override
-        def model_parameters(self) -> Optional[ConcreteLidarModelParametersUnion]:
+        def model_parameters(self) -> Optional[LidarModelParameters]:
             """Returns parameters specific to the lidar's intrinsic model, if available"""
             return self._model_parameters
 

--- a/ncore/impl/data/v4/components.py
+++ b/ncore/impl/data/v4/components.py
@@ -937,7 +937,7 @@ class IntrinsicsComponent:
             self,
             camera_id: str,
             # intrinsics
-            camera_model_parameters: types.ConcreteCameraModelParametersUnion,
+            camera_model_parameters: types.CameraModelParameters,
         ) -> "Self":
             """Store camera-associated intrinsics"""
 
@@ -953,7 +953,7 @@ class IntrinsicsComponent:
             self,
             lidar_id: str,
             # intrinsics
-            lidar_model_parameters: types.ConcreteLidarModelParametersUnion,
+            lidar_model_parameters: types.LidarModelParameters,
         ) -> "Self":
             """Store lidar-associated intrinsics"""
 
@@ -977,11 +977,11 @@ class IntrinsicsComponent:
             """Returns true if the component version is supported by the reader"""
             return version == "v1"
 
-        def get_camera_model_parameters(self, camera_id: str) -> types.ConcreteCameraModelParametersUnion:
+        def get_camera_model_parameters(self, camera_id: str) -> types.CameraModelParameters:
             """Returns the camera model associated with the requested camera sensor"""
             return types.decode_camera_model_parameters(cast(zarr.Group, self._group["cameras"][camera_id]).attrs)
 
-        def get_lidar_model_parameters(self, lidar_id: str) -> Optional[types.ConcreteLidarModelParametersUnion]:
+        def get_lidar_model_parameters(self, lidar_id: str) -> Optional[types.LidarModelParameters]:
             """Returns the lidar model associated with the requested lidar sensor"""
             lidars_group = self._group["lidars"]
 

--- a/ncore/impl/sensors/camera_test.py
+++ b/ncore/impl/sensors/camera_test.py
@@ -18,7 +18,8 @@ import itertools
 import os
 import unittest
 
-from typing import Dict, List, Tuple, Union, cast
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple, Union, cast
 
 import cv2
 import numpy as np
@@ -28,6 +29,7 @@ import scipy.linalg
 import torch
 
 from numpy.polynomial.polynomial import Polynomial
+from typing_extensions import Self
 
 from ncore.impl.common.util import unpack_optional
 from ncore.impl.data.types import (
@@ -2281,6 +2283,67 @@ class TestIdealPinholeFromSource(unittest.TestCase):
                 IdealPinholeCameraModelParameters.from_source(params, target_fov=bad)
         with self.assertRaises(ValueError):
             IdealPinholeCameraModelParameters.from_source(params, target_fov=np.array([1.0, 1.0, 1.0]))
+
+    def test_abstract_typed_source_is_accepted(self):
+        """A source held under the abstract base is usable, without narrowing at the call site.
+
+        This is the contract the signatures promise: callers holding a `CameraModelParameters`,
+        which is what the decoders and the `model_parameters` accessors hand out, can reach these
+        helpers directly. Annotating the local is the point of the test, so keep it.
+        """
+        for concrete in (
+            self._ideal(),
+            self._opencv(),
+            self._fisheye(),
+            self._ftheta(),
+        ):
+            with self.subTest(model=type(concrete).__name__):
+                source: CameraModelParameters = concrete
+
+                fov = IdealPinholeCameraModelParameters.natural_fov(source)
+                self.assertEqual(fov.shape, (2,))
+                self.assertTrue(np.all(fov > 0.0))
+
+                ideal = IdealPinholeCameraModelParameters.from_source(source)
+                self.assertIsInstance(ideal, IdealPinholeCameraModelParameters)
+                np.testing.assert_array_equal(ideal.resolution, concrete.resolution)
+
+    def test_out_of_tree_camera_parameters_raise(self):
+        """A concrete subclass the dispatch does not know is rejected, naming the offending type.
+
+        Reachable as a plain call only because the parameter is the abstract base: an out-of-tree
+        model registered through `register_camera_model` satisfies the signature but has no branch
+        in `_paraxial_geometry`, so the failure has to be a clean `TypeError` rather than an
+        `AttributeError` from a missing field.
+        """
+
+        @dataclass
+        class _OutOfTreeCameraModelParameters(CameraModelParameters):
+            """A minimal out-of-tree model, declaring only what the abstract base requires"""
+
+            @staticmethod
+            def type() -> str:
+                return "out-of-tree-test-model"
+
+            def transform(
+                self,
+                image_domain_scale: Union[float, Tuple[float, float]],
+                image_domain_offset: Tuple[float, float] = (0.0, 0.0),
+                new_resolution: Optional[Tuple[int, int]] = None,
+            ) -> Self:
+                return self
+
+        source = _OutOfTreeCameraModelParameters(
+            resolution=np.array((640, 480), dtype=np.uint64),
+            shutter_type=ShutterType.GLOBAL,
+        )
+
+        with self.assertRaises(TypeError) as ctx:
+            IdealPinholeCameraModelParameters.from_source(source)
+        self.assertIn("_OutOfTreeCameraModelParameters", str(ctx.exception))
+
+        with self.assertRaises(TypeError):
+            IdealPinholeCameraModelParameters.natural_fov(source)
 
     def test_unsupported_source_raises(self):
         # Pass an object that is not a supported camera model (cast so the static type

--- a/tools/data_converter/pai/converter.py
+++ b/tools/data_converter/pai/converter.py
@@ -70,7 +70,6 @@ from ncore.data_converter import (
 from ncore.impl.common.transformations import HalfClosedInterval, se3_inverse, time_bounds
 from ncore.impl.data.types import (
     BBox3,
-    ConcreteLidarModelParametersUnion,
     CuboidTrackObservation,
     FThetaCameraModelParameters,
     JsonLike,
@@ -351,7 +350,7 @@ class _PaiConversionMixin:
         # Close data streaming provider
         self.provider.close()
 
-    def _load_lidar_model_parameters(self) -> ConcreteLidarModelParametersUnion | None:
+    def _load_lidar_model_parameters(self) -> RowOffsetStructuredSpinningLidarModelParameters | None:
         """Load lidar model parameters from lidar_intrinsics parquet."""
 
         if self.provider.has_file("lidar_intrinsics"):

--- a/tools/ncore_export_camera.py
+++ b/tools/ncore_export_camera.py
@@ -26,7 +26,7 @@ import numpy as np
 import tqdm
 
 from ncore.impl.data.types import (
-    ConcreteCameraModelParametersUnion,
+    CameraModelParameters,
     IdealPinholeCameraModelParameters,
     encode_camera_model_parameters,
 )
@@ -189,7 +189,7 @@ def v4(
 
 
 def _build_rectificator(
-    params: CLIBaseParams, source_parameters: ConcreteCameraModelParametersUnion
+    params: CLIBaseParams, source_parameters: CameraModelParameters
 ) -> Tuple[Rectificator, IdealPinholeCameraModelParameters]:
     """Builds a Rectificator mapping the source camera to an ideal pinhole target
 


### PR DESCRIPTION
Types the public camera and lidar parameter APIs against the abstract bases instead of
`ConcreteCameraModelParametersUnion` / `ConcreteLidarModelParametersUnion`, in the positions where
only the shared surface is used.

20 annotations across 6 files: 19 widened to an abstract base, plus one de-aliased to a concrete
class (see below). The input and output halves have to land together, for the reason under
"Output positions".

## Input positions: safe

Widening an input is backwards compatible for callers, since a concrete argument still satisfies an
abstract parameter. It is only safe for the *body* if the body does not reach for model-specific
fields, so each was checked:

| function | what the body needs |
|---|---|
| `encode_camera_model_parameters` | `type()`, `to_dict()`, `external_distortion_parameters`, all on the base |
| `IdealPinholeCameraModelParameters._paraxial_geometry` | `isinstance` dispatch, raising `TypeError` on anything unrecognised |
| `natural_fov`, `from_source` | delegate to `_paraxial_geometry` |
| `store_camera_intrinsics`, `store_lidar_intrinsics` | delegate to the encoders |
| `_build_rectificator` (export tool) | delegates to `natural_fov` / `from_source` |

`encode_lidar_model_parameters` already took the abstract `LidarModelParameters`, so this brings the
rest in line with existing practice rather than introducing a new convention.

## Output positions: breaking

Callers of `decode_camera_model_parameters`, `decode_lidar_model_parameters` and the
`model_parameters` accessors now receive the abstract base, and must narrow with `isinstance` before
reading a model-specific field.

These cannot land separately from the inputs, because the widened outputs feed the widened inputs.
With only the outputs widened, `_build_rectificator`, `natural_fov` and `from_source` stop accepting
what the decoders hand them, and the two `pylib_compat` targets fail the ty aspect. Applied
together, the tree is clean. Both halves were applied separately to confirm this rather than
assumed.

## What this does not claim

`decode_camera_model_parameters` is a closed `if/elif` over the four in-tree models, so the unions it
returned were **accurate**, not unsound. The registries added in 19.6.0 cover the model factories,
not the parameter decode path, so this is not a correctness fix.

The argument is narrower: the closed set should not be baked into every signature that only reads
the shared surface, and the decode path is then free to become registry-driven, matching the
factories, without a second signature change.

## Tests

`natural_fov` and `from_source` were exercised only through concrete parameter classes, so nothing
pinned the contract these signatures promise.

- `test_abstract_typed_source_is_accepted` annotates the local as the abstract base deliberately and
  runs all four in-tree models through it. Reverting either signature to the concrete union makes it
  fail with `invalid-argument-type`, so it tracks the contract rather than restating the existing
  concrete-source tests. This was verified by actually reverting them.
- `test_out_of_tree_camera_parameters_raise` covers the case the widening newly admits: a subclass
  satisfying the abstract base with no branch in `_paraxial_geometry`. It must fail as a `TypeError`
  naming the offending class, not as an `AttributeError` from an absent field. The existing
  `test_unsupported_source_raises` passes a bare `object()` through a cast and never reaches this
  path.

## Left alone deliberately

- The union aliases remain exported from `ncore.data`. Removing a public name is a separate call.
- `ConcreteExternalDistortionParametersUnion` has had no in-tree use since the discriminator change,
  but is likewise still exported.
- The PAI converter's `_load_lidar_model_parameters` is private and genuinely produces one concrete
  class, so widening it would lose information. It now names that class directly instead of the
  single-member `ConcreteLidarModelParametersUnion`, which collapses to exactly that class anyway.
  This is the one de-aliasing rather than a widening.

## Verification

- `bazel test //ncore/... //tools/...` with `--nocache_test_results`: **34/34 pass**
- ty lint aspect passes on every target; `bazel run //:format.check` clean
- CI green on 3.8 and 3.11 from a clean checkout

Downstream impact was measured, not assumed, by building a wheel from this branch and running it
against the two largest consumers:

- one consumer's ty gate: **45 diagnostics before, 45 after, and the diff of the diagnostic sets is
  empty**. No new type errors.
- the other has no ty gate; its ten accessor-using modules were audited by hand. Every
  model-specific field read is already behind an `isinstance` guard or an explicit cast.

So consumers *may* need an `isinstance` narrow, but neither of the two known ones does. Runtime
behaviour is unchanged throughout: every line in the diff is a type annotation, with no expression,
branch or value touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
